### PR TITLE
Added neq and nrefEq

### DIFF
--- a/README.md
+++ b/README.md
@@ -796,7 +796,11 @@ By default simple arguments are matched using `eq()`
 |`matchNullable { it?.startsWith("string") }`|matches nullable value via passe predicate|
 |`coMatchNullable { it?.startsWith("string") }`|matches nullable value via passed coroutine predicate|
 |`eq(value)`|matches if value is equal to the provided via deepEquals function|
+|`eq(value, inverse=true)`|matches if value is not equal to the provided via deepEquals function|
+|`neq(value)`|matches if value is not equal to the provided via deepEquals function|
 |`refEq(value)`|matches if value is equal to the provided via reference comparation|
+|`refEq(value, inverse=true)`|matches if value is not equal to the provided via reference comparation||
+|`nrefEq(value)`|matches if value is not equal to the provided via reference comparation||
 |`cmpEq(value)`|matches if value is equal to the provided via compareTo function|
 |`less(value)`|matches if value is less to the provided via compareTo function|
 |`more(value)`|matches if value is more to the provided via compareTo function|

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -1,5 +1,10 @@
 apply plugin: 'kotlin-platform-common'
 
+configurations {
+    sampleTestCompile.extendsFrom testCompile
+    sampleTestRuntime.extendsFrom testRuntime
+}
+
 dependencies {
     compile project(":mockk-dsl")
     compileOnly "org.jetbrains.kotlin:kotlin-stdlib-common:$kotlin_version"
@@ -11,6 +16,23 @@ kotlin {
     experimental {
         coroutines "enable"
     }
+}
+
+sourceSets {
+    sample {
+        kotlin {
+            compileClasspath += main.output + test.output
+            runtimeClasspath += main.output + test.output
+            srcDir file('src/sample/kotlin')
+        }
+        resources.srcDir file('src/sample/resources')
+    }
+}
+
+
+task samples(type: Test) {
+    setTestClassesDirs(sourceSets.sample.output.classesDirs)
+    classpath = sourceSets.sample.runtimeClasspath
 }
 
 task sourcesJar(type: Jar) {

--- a/common/src/sample/kotlin/io/mockk/MockKSamples.kt
+++ b/common/src/sample/kotlin/io/mockk/MockKSamples.kt
@@ -1,0 +1,281 @@
+package io.mockk
+
+import kotlin.test.assertEquals
+
+
+class MockKSamples {
+    
+    fun basicMockkCreation() {
+        class Foo(val bar: String)
+    
+    
+        val foo: Foo = mockk()
+        
+    }
+    
+    fun mockkWithCreationBlock() {
+        class Foo(val bar: String)
+        
+        val foo: Foo = mockk {
+            //Code that creates behaviour for this Mockk
+            every { bar } returns "baz"
+        }
+    }
+}
+
+class SpykSamples {
+    
+    
+    fun spyOriginalBehaviourCopyingFields() {
+        class Foo(val bar: String = "bar", val baz: String = "baz")
+        
+        val foo = Foo(bar = "bar", baz = "baz")
+        
+        val spiedFoo = spyk(foo) {
+            every { baz } returns "boz"
+        }
+        
+        assertEquals("bar", spiedFoo.bar) //Will call the real behaviour
+        
+        assertEquals("boz", spiedFoo.baz)  //Will call the mocked behaviour
+        
+    }
+    
+    fun spyOriginalBehaviourDefaultConstructor() {
+        
+        class Foo(val bar: String = "bar", val baz: String = "baz")
+        
+        val spiedFoo = spyk<Foo> {
+            every { baz } returns "boz"
+        }
+        
+        assertEquals("bar", spiedFoo.bar) //Will call the real behaviour
+        
+        assertEquals("boz", spiedFoo.baz)  //Will call the mocked behaviour
+        
+    }
+    
+    fun spyOriginalBehaviourWithPrivateCalls() {
+        
+        class Foo(val bar: String, val baz: String) {
+        
+            fun callPrivateBarBaz(): String {
+                return barBaz()
+            }
+            private fun barBaz() = "$bar.$baz"
+        }
+        
+        val foo = Foo(bar = "bar", baz = "baz")
+        
+        val spiedFoo = spyk(foo, recordPrivateCalls = true)
+        
+        val barBaz = spiedFoo.callPrivateBarBaz()
+        
+        verify {
+            spiedFoo invoke "barBaz" withArguments emptyList()  //Private method barBaz
+        }
+    }
+    
+}
+
+class SlotSample {
+    
+    fun captureSlot() {
+        class Foo {
+            fun foo(string: String): String {
+                return "$string.foo"
+            }
+        }
+        
+        val slot = slot<String>()
+        
+        val foo = mockk<Foo> {
+            every { foo(capture(slot)) } answers { slot.captured + ".bar" }
+        }
+        
+        val returnedValue = foo.foo("foo")
+        assertEquals("foo.bar", returnedValue)
+    }
+    
+}
+
+class EverySample {
+    
+    fun simpleEvery() {
+        class Foo {
+            fun foo(): String {
+                return "foo"
+            }
+        }
+        
+        val foo: Foo = mockk {
+            every { foo() } returns "bar"
+        }
+        
+        assertEquals("bar", foo.foo())
+        
+    }
+    
+}
+
+class StaticMockkSample {
+    
+    fun mockJavaStatic() {
+        public class JavaStatic {
+            public static Foo staticMethod() {
+                //...
+            }
+        }
+        
+        mockkStatic(JavaStatic::class)
+        
+        every { JavaStatic.staticMethod() } returns mockk<Foo>()
+    }
+    
+    fun mockJavaStaticString() {
+        package foo.bar
+        public class JavaStatic {
+            public static Foo staticMethod() {
+                //...
+            }
+        }
+        
+        mockkStatic("foo.bar.JavaStatic")
+        
+        every { JavaStatic.staticMethod() } returns mockk<Foo>()
+    }
+}
+
+class ObjectMockkSample {
+
+    fun mockSimpleObject() {
+        object Foo {
+            val bar = "bar"
+        }
+        
+        mockkObject(Foo)
+        
+        every { Foo.bar } returns "baz"
+        
+        assertEquals("baz", Foo.bar)
+    }
+    
+    fun mockEnumeration() {
+        enum class Enumeration(val goodInt: Int) {
+            CONSTANT(35),
+            OTHER_CONSTANT(45);
+        }
+    
+        mockkObject(Enumeration.CONSTANT)
+        every { Enumeration.CONSTANT.goodInt } returns 42
+        assertEquals(42, Enumeration.CONSTANT.goodInt)
+    }
+
+}
+
+class VerifySample {
+    
+    object random {
+        fun shouldExecute(): Boolean = true
+    }
+    
+    fun verifyAmount() {
+        class Foo(val bar: String)
+        
+        val foo: Foo = mockk {
+            every { bar } returns "bar"
+        }
+        val firstBar = foo.bar
+        val secondBar = foo.bar
+        
+        verify(exactly = 2) { foo.bar }
+        
+    }
+    
+    fun verifyOrder() {
+        class Foo {
+            fun bar() = "bar"
+            fun baz() = "baz"
+            fun boo() = "boo"
+        }
+        
+        val foo: Foo = mockk {
+            every { bar() } returns "bot"
+            every { baz() } returns "far"
+            every { boo() } returns "laz"
+        }
+        
+        foo.bar()
+        foo.boo()
+        foo.baz()
+        
+        verifyOrder {
+            foo.bar()
+            foo.baz()
+        }   //These calls happened in this order, and it doesn't matter that foo.boo() also happened
+    }
+    
+    fun verifySequence() {
+        class Foo {
+            fun bar() = "bar"
+            fun baz() = "baz"
+        }
+        
+        val foo: Foo = mockk {
+            every { bar() } returns "bot"
+            every { baz() } returns "far"
+        }
+        
+        foo.bar()
+        foo.baz()
+        
+        verifySequence {
+            foo.bar()
+            foo.baz()
+        }   //These calls happened in this exact order, and only those were made in the mock
+    }
+    
+    fun failingVerifySequence() {
+        class Foo {
+            fun bar() = "bar"
+            fun baz() = "baz"
+        }
+        
+        val foo: Foo = mockk {
+            every { bar() } returns "bot"
+            every { baz() } returns "far"
+        }
+        
+        foo.bar()
+        foo.baz()
+        
+        verifySequence {
+            foo.bar()
+        }   //This will fail, as no call to foo.baz() was expected in the call sequence, but it happened
+    }
+    
+    
+    fun verifyRange() {
+        class Foo {
+            fun foo() = println("foo")
+            fun bar() {
+                if (random.shouldExecute()) {
+                    foo()
+                }
+            }
+        }
+        
+        val spiedFoo = spyk<Foo>()
+        
+        spiedFoo.foo()
+        
+        for (i in 1..5) {
+            spiedFoo.bar()
+        }
+        
+        verify(atLeast = 1, atMost = 6) {
+            spiedFoo.foo()
+        }
+        
+    }
+}

--- a/common/src/test/kotlin/io/mockk/it/MatcherTest.kt
+++ b/common/src/test/kotlin/io/mockk/it/MatcherTest.kt
@@ -46,6 +46,23 @@ class MatcherTest {
             mock.op(IntWrapper(3), b)
         }
     }
+    
+    @Test
+    fun nEqNRefEq() {
+        val a = IntWrapper(3)
+        val b = IntWrapper(4)
+        
+        every { mock.op(neq(a), nrefEq(b)) } returns 1
+        
+        assertEquals(1, mock.op(b, a), "Answer should be one, as b != a and a != b, so both neq and nrefEq.")
+        assertFailsWith<MockKException>("Should fail because a is eq to a, so neq fails") { mock.op(a, IntWrapper(4)) }
+        assertFailsWith<MockKException>("Should fail because b is referencial equal tob, so nrefEq fails") { mock.op(b, b) }
+        assertEquals(1, mock.op(b, IntWrapper(3)))
+        
+        verify {
+            mock.op(b, IntWrapper(3))
+        }
+    }
 
     @Test
     fun less() {

--- a/dsl/common/src/main/kotlin/io/mockk/API.kt
+++ b/dsl/common/src/main/kotlin/io/mockk/API.kt
@@ -439,7 +439,7 @@ object MockKDsl {
 }
 
 /**
- * Verification orderding
+ * Verification ordering
  */
 enum class Ordering {
     /**

--- a/dsl/common/src/main/kotlin/io/mockk/API.kt
+++ b/dsl/common/src/main/kotlin/io/mockk/API.kt
@@ -497,10 +497,11 @@ open class MockKMatcherScope(
 
     inline fun <reified T : Any> matchNullable(noinline matcher: (T?) -> Boolean): T =
         match(FunctionMatcher(matcher, T::class))
-
     inline fun <reified T : Any> eq(value: T, inverse: Boolean = false): T = match(EqMatcher(value, inverse = inverse))
+    inline fun <reified T: Any> neq(value: T): T = eq(value, true)
     inline fun <reified T : Any> refEq(value: T, inverse: Boolean = false): T =
         match(EqMatcher(value, ref = true, inverse = inverse))
+    inline fun <reified T : Any> nrefEq(value: T) = refEq(value, true)
 
     inline fun <reified T : Any> any(): T = match(ConstantMatcher(true))
     inline fun <reified T : Any> capture(lst: MutableList<T>): T = match(CaptureMatcher(lst, T::class))


### PR DESCRIPTION
Having the code `eq(x, true)` and `refEq(x, true)` might sometimes be too verbose and boilerplate.

I propose the matcher neq and nrefEq as a shortcut to both.
I believe the ideal would be to type `!eq(x)` and `!refEq(x)` but I couldn't find an alternative overloading operators, maybe in a further release.