### PR TITLE
Adds Language specific syntax highlight to code blocks in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,12 +278,12 @@ You can use `relaxUnitFun = true` as an argument to `mockk` function,
 `@MockK`annotation or `MockKAnntations.init` function.
 
 Function:
-```
+```kotlin
 mockk<MockCls>(relaxUnitFun = true)
 ```
 
 Annotation:
-```
+```kotlin
 @MockK(relaxUnitFun = true)
 lateinit var mock1: RurfMockCls
 init {
@@ -292,7 +292,7 @@ init {
 ```
 
 MockKAnnotations.init:
-```
+```kotlin
 @MockK
 lateinit var mock2: RurfMockCls
 init {
@@ -304,7 +304,7 @@ init {
 
 Objects can be transformed to mocks following way:
 
-```
+```kotlin
 object MockObj {
   fun add(a: Int, b: Int) = a + b
 }
@@ -321,7 +321,7 @@ assertEquals(55, MockObj.add(1, 2))
 
 To revert back use `unmockkAll` or `unmockkObject`:
 
-```
+```kotlin
 @Before
 fun beforeTests() {
     mockkObject(MockObj)
@@ -343,7 +343,7 @@ fun afterTests() {
 ```
 
 Despite Kotlin language limits you can create new instances of objects if testing logic needs that:
-```
+```kotlin
 val newObjectMock = mockk<MockObj>()
 ```
 
@@ -365,7 +365,7 @@ verify { car.drive(Direction.NORTH) }
 
 Enums can be mocked using `mockkObject`:
 
-```
+```kotlin
 enum class Enumeration(val goodInt: Int) {
     CONSTANT(35),
     OTHER_CONSTANT(45);
@@ -381,7 +381,7 @@ assertEquals(42, Enumeration.CONSTANT.goodInt)
 Sometimes, especially in code you are not owning, you need to mock newly created objects.
 For this purpose following constructs are provided:
 
-```
+```kotlin
 class MockCls {
   fun add(a: Int, b: Int) = a + b
 }
@@ -557,7 +557,7 @@ verify {
 
 To verify concurrent operations you can use `timeout = xxx`:
 
-```
+```kotlin
 mockk<MockCls> {
     every { sum(1, 2) } returns 4
 
@@ -695,7 +695,7 @@ verify {
 
 Sometimes you need to know a little bit more to mock extension function. 
 For example `File.endsWith()` extension function has totally unpredictable `classname`:
-```
+```kotlin
    mockkStatic("kotlin.io.FilesKt__UtilsKt")
    every { File("abc").endsWith(any<String>()) } returns true
    println(File("abc").endsWith("abc"))
@@ -706,7 +706,7 @@ Use `Tools -> Kotlin -> Show Kotlin Bytecode` or check `.class` files in JAR arc
 ### Private functions mocking / dynamic calls
 
 In case you have a need to mock private function, you can do it via dynamic call.
-```
+```kotlin
 class Car {
     fun drive() = accelerate()
 
@@ -796,7 +796,7 @@ To adjust parameters globaly there is a posibility to specify few settings in a 
 How to use: 
  1. create `io/mockk/settings.properties` file in resources.
  2. Put one of following options:
-```
+```properties
 relaxed=true|false
 relaxUnitFun=true|false
 recordPrivateCalls=true|false


### PR DESCRIPTION
Adds Language specific syntax highlight to code blocks where language was missing in `README.md`.
This way the code snippets will be consistently highlighted instead of some being highlighted and other not.