### PR TITLE
Improve Issue99Test

### DIFF
--- a/mockk/jvm/src/test/kotlin/io/mockk/gh/Issue99Test.kt
+++ b/mockk/jvm/src/test/kotlin/io/mockk/gh/Issue99Test.kt
@@ -10,19 +10,14 @@ import kotlin.test.assertNotEquals
 
 class Issue99Test {
     @Test
-    fun someTest() {
-        val timestamp = Instant.now().toEpochMilli()
-        assertNotEquals(123L, timestamp)
-    }
-
-    @Test
-    fun someOtherTest() {
+    fun `unmockStatic() unmocks static mocks`() {
         mockkStatic(Instant::class)
-        every { Instant.now().toEpochMilli() } returns 123
+        every { Instant.now().toEpochMilli() } returns 123L
 
-        val timestamp = Instant.now().toEpochMilli()
-        assertEquals(123, timestamp)
+        assertEquals(123L, Instant.now().toEpochMilli())
 
         unmockkStatic(Instant::class)
+
+        assertNotEquals(123L, Instant.now().toEpochMilli())
     }
 }


### PR DESCRIPTION
The tested behaviour was incorrect in the sense that it tested if wasn't `123L` by chance. However, what this needs to test is that after unmocking the time doesn't equal the mocked time any longer.