### PR TITLE
Add extra article and better example of capturing a list

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ Table of contents:
  - [kotlin-fullstack-sample](https://github.com/Kotlin/kotlin-fullstack-sample/pull/28/files#diff-eade18fbfd0abfb6338dbfa647b3215dR17) project covered with tests
  - [DZone article](https://dzone.com/articles/new-mocking-tool-for-kotlin-an-alternative-to-java)
  - [Habrahabr article](https://habrahabr.ru/post/341202/) (RU)
+ - [Mocking in Kotlin with MockK - Yannick De Turck](https://ordina-jworks.github.io/testing/2018/02/05/Writing-tests-in-Kotlin-with-MockK.html)
  
 #### Kotlin Academy <img src="https://cdn-images-1.medium.com/letterbox/47/47/50/50/1*FUXqI88mttV_kV8aTrKjOg.png?source=logoAvatar-1f9f77b4b3d1---e57b304801ef" width="20px" />
 
@@ -477,8 +478,6 @@ every {
     direction = Direction.SOUTH
   )
 } answers {
-  println(list.captured())
-
   Outcome.RECORDED
 }
 
@@ -486,6 +485,7 @@ obj.recordTelemetry(speed = 15, direction = Direction.NORTH) // prints 15
 obj.recordTelemetry(speed = 16, direction = Direction.SOUTH) // prints 16
 
 verify(exactly = 2) { obj.recordTelemetry(speed = or(15, 16), direction = any()) }
+assertTrue(list.containsAll(15, 16))
 ```
 
 ### Verification atLeast, atMost or exactly times

--- a/README.md
+++ b/README.md
@@ -478,6 +478,8 @@ every {
     direction = Direction.SOUTH
   )
 } answers {
+  println(list.captured())
+
   Outcome.RECORDED
 }
 
@@ -485,7 +487,6 @@ obj.recordTelemetry(speed = 15, direction = Direction.NORTH) // prints 15
 obj.recordTelemetry(speed = 16, direction = Direction.SOUTH) // prints 16
 
 verify(exactly = 2) { obj.recordTelemetry(speed = or(15, 16), direction = any()) }
-assertTrue(list.containsAll(15, 16))
 ```
 
 ### Verification atLeast, atMost or exactly times


### PR DESCRIPTION
I've added an extra article that I've written a while ago on Mockito and Kotlin.
I've also updated the example on capturing a list of arguments as there was an error in the same and because nothing was done to show that the list contained the two captured arguments.

Error:
``` kotlin
every {
   obj.recordTelemetry(
     speed = capture(list),
    direction = Direction.SOUTH
  )
} answers {
  println(list.captured()) // probably copy paste error from the previous sample?
   Outcome.RECORDED
}
```