### PR TITLE
JvmAutoHinter to cope with ClassCastExceptions with a message being null

### DIFF
--- a/mockk/jvm/src/main/kotlin/io/mockk/impl/recording/JvmAutoHinter.kt
+++ b/mockk/jvm/src/main/kotlin/io/mockk/impl/recording/JvmAutoHinter.kt
@@ -44,7 +44,7 @@ class JvmAutoHinter : AutoHinter() {
     }
 
     private fun extractClassName(ex: ClassCastException): String? {
-        return exceptionMessage.find(ex.message!!)?.groups?.get(3)?.value
+        return ex.message?.let { exceptionMessage.find(it)?.groups?.get(3)?.value }
     }
 
     companion object {

--- a/mockk/jvm/src/main/kotlin/io/mockk/impl/recording/JvmAutoHinter.kt
+++ b/mockk/jvm/src/main/kotlin/io/mockk/impl/recording/JvmAutoHinter.kt
@@ -44,7 +44,7 @@ class JvmAutoHinter : AutoHinter() {
     }
 
     private fun extractClassName(ex: ClassCastException): String? {
-        return ex.message?.let { exceptionMessage.find(it)?.groups?.get(3)?.value }
+        return ex.message?.let { exceptionMessage.find(it)?.groups?.get(3)?.value } ?: throw ex
     }
 
     companion object {


### PR DESCRIPTION
* The ClassCastException thrown in case of missing hints for erased
  return types may have a null message when running in mixed mode.
* The code assumed the message can never be null. If it was null
  nevertheless, a KotlinNullPointerException was thrown (instead of the
  expected ClassCastException that should have been rethrown and would
  have been translated into a useful message that a hint might be
  necessary.)

This may solve or provide input for solving #240.
