### PR TITLE
Change then to than

### DIFF
--- a/mockk/common/src/main/kotlin/io/mockk/impl/verify/OrderedCallVerifier.kt
+++ b/mockk/common/src/main/kotlin/io/mockk/impl/verify/OrderedCallVerifier.kt
@@ -25,7 +25,7 @@ class OrderedCallVerifier(
 
         if (verificationSequence.size > allCalls.size) {
             return VerificationResult.Failure(safeToString.exec {
-                "less calls happened then demanded by order verification sequence. " +
+                "less calls happened than demanded by order verification sequence. " +
                         reportCalls(verificationSequence, allCalls)
             })
         }


### PR DESCRIPTION
Grammatical error. 
"Then" should be used when comparing two things (actual calls vs demanded calls)