### PR TITLE
Fix unit test PR #314

### DIFF
--- a/mockk/common/src/test/kotlin/io/mockk/it/VerificationErrorsTest.kt
+++ b/mockk/common/src/test/kotlin/io/mockk/it/VerificationErrorsTest.kt
@@ -105,8 +105,8 @@ class VerificationErrorsTest {
     }
 
     @Test
-    fun lessCallsHappenedThenDemanded() {
-        expectVerificationError("less calls happened then demanded by order verification sequence", "MockCls.otherOp") {
+    fun lessCallsHappenedThanDemanded() {
+        expectVerificationError("less calls happened than demanded by order verification sequence", "MockCls.otherOp") {
             every { mock.otherOp(1, any()) } answers { 2 + firstArg<Int>() }
 
             mock.otherOp(1, 3)


### PR DESCRIPTION
Fix failing Unit Test
Change "then" to "than".
Missed the changes in unit test when changing the implementation 

Reference: #314