### PR TITLE
add x86_64 and arm64-v8a mockkjvmtiagent so

### DIFF
--- a/agent/android/build.gradle
+++ b/agent/android/build.gradle
@@ -63,6 +63,10 @@ android {
         versionName project['version']
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
         testInstrumentationRunnerArgument "notAnnotation", "io.mockk.test.SkipInstrumentedAndroidTest"
+
+        ndk {
+            abiFilters "armeabi-v7a", "x86", "x86_64", "arm64-v8a"
+        }
     }
 
     externalNativeBuild {
@@ -70,7 +74,6 @@ android {
             path = 'CMakeLists.txt'
         }
     }
-
 }
 
 


### PR DESCRIPTION
@oleksiyp This should be enough to get me past this issue as it results in the creation of binaries that target the same architecture that I do: https://github.com/mockk/mockk/issues/297

I'm totally unaware of your policy regarding accepting community contributions and how you like to perform releases, so I'm willing to make updates as necessary.