### PR TITLE
Provide invokeReturnsUnit for private functions returning Unit

### DIFF
--- a/README.md
+++ b/README.md
@@ -881,7 +881,8 @@ Additionally more verbose syntax allows to get and set properties, do same dynam
 val mock = spyk(Team(), recordPrivateCalls = true)
 
 every { mock getProperty "speed" } returns 33
-every { mock setProperty "acceleration" value less(5) } just Runs
+every { mock setProperty "acceleration" value less(5) } just runs
+every { mock invokeReturnsUnit "privateMethod" } just runs
 every { mock invoke "openDoor" withArguments listOf("left", "rear") } returns "OK"
 
 verify { mock getProperty "speed" }

--- a/dsl/common/src/main/kotlin/io/mockk/API.kt
+++ b/dsl/common/src/main/kotlin/io/mockk/API.kt
@@ -1949,6 +1949,9 @@ open class MockKMatcherScope(
     infix fun Any.invokeNoArgs(name: String) =
         invoke(name).withArguments(listOf())
 
+    @Suppress("CAST_NEVER_SUCCEEDS")
+    infix fun Any.invokeReturnsUnit(name: String) = invoke(name) as Unit
+
     infix fun Any.getProperty(name: String) =
         InternalPlatformDsl.dynamicGet(this, name)
 

--- a/mockk/common/src/test/kotlin/io/mockk/gh/Issue346Test.kt
+++ b/mockk/common/src/test/kotlin/io/mockk/gh/Issue346Test.kt
@@ -1,0 +1,24 @@
+package io.mockk.gh
+
+import io.mockk.Runs
+import io.mockk.every
+import io.mockk.just
+import io.mockk.spyk
+import kotlin.test.Test
+
+class Issue346Test {
+    class Cls {
+        private fun privateCall() = Unit
+
+        fun pubCall() = privateCall()
+    }
+
+    @Test
+    fun test() {
+        val mock = spyk<Cls>()
+
+        every { mock invokeReturnsUnit "privateCall" } just Runs
+
+        mock.pubCall()
+    }
+}


### PR DESCRIPTION
Convenience syntax as an alternative to any of the following:

- `every { mock["privateMethod"]() } answers(ConstantAnswer(Unit))`
- `every { mock["privateMethod"]() as Unit} just runs`.

Resolves issue #346.