### PR TITLE
Fix 'withNullableArg' function to make it work properly with null values (#323)

### DIFF
--- a/dsl/common/src/main/kotlin/io/mockk/API.kt
+++ b/dsl/common/src/main/kotlin/io/mockk/API.kt
@@ -662,15 +662,11 @@ open class MockKMatcherScope(
         return callRecorder.matcher(matcher, T::class)
     }
 
-    inline fun <reified T : Any> match(noinline matcher: (T) -> Boolean): T = matchNullable {
-        when (it) {
-            null -> false
-            else -> matcher(it)
-        }
-    }
+    inline fun <reified T : Any> match(noinline matcher: (T) -> Boolean): T =
+        match(FunctionMatcher(matcher, T::class))
 
     inline fun <reified T : Any> matchNullable(noinline matcher: (T?) -> Boolean): T =
-        match(FunctionMatcher(matcher, T::class))
+        match(FunctionWithNullableArgMatcher(matcher, T::class))
 
     inline fun <reified T : Any> eq(value: T, inverse: Boolean = false): T =
         match(EqMatcher(value, inverse = inverse))

--- a/dsl/common/src/main/kotlin/io/mockk/Matchers.kt
+++ b/dsl/common/src/main/kotlin/io/mockk/Matchers.kt
@@ -50,12 +50,31 @@ data class ConstantMatcher<in T : Any>(val constValue: Boolean) : Matcher<T> {
  * Delegates matching to lambda function
  */
 data class FunctionMatcher<in T : Any>(
+    val matchingFunc: (T) -> Boolean,
+    override val argumentType: KClass<*>
+) : Matcher<T>, TypedMatcher, EquivalentMatcher {
+    override fun equivalent(): Matcher<Any> = ConstantMatcher(true)
+
+    override fun match(arg: T?): Boolean = if(arg == null) false else matchingFunc(arg)
+
+    override fun toString(): String = "matcher<${argumentType.simpleName}>()"
+}
+
+data class FunctionWithNullableArgMatcher<in T : Any>(
     val matchingFunc: (T?) -> Boolean,
     override val argumentType: KClass<*>
 ) : Matcher<T>, TypedMatcher, EquivalentMatcher {
-    override fun equivalent(): Matcher<Any> = ConstantMatcher<Any>(true)
+    override fun equivalent(): Matcher<Any> = ConstantMatcher(true)
 
     override fun match(arg: T?): Boolean = matchingFunc(arg)
+
+    override fun checkType(arg: Any?): Boolean {
+        if(arg == null) {
+            return true
+        }
+
+        return super.checkType(arg)
+    }
 
     override fun toString(): String = "matcher<${argumentType.simpleName}>()"
 }

--- a/mockk/common/src/test/kotlin/io/mockk/gh/Issue323Test.kt
+++ b/mockk/common/src/test/kotlin/io/mockk/gh/Issue323Test.kt
@@ -1,0 +1,32 @@
+package io.mockk.gh
+
+import io.mockk.mockk
+import io.mockk.verify
+import kotlin.test.Test
+
+class Issue323Test {
+    class MockedClass {
+        fun test(s: String?) {
+            println(s)
+        }
+    }
+
+    class TestedClass(private val mockedClass: MockedClass) {
+        fun test() {
+            val testString: String? = null
+            mockedClass.test(testString)
+        }
+    }
+
+    @Test
+    fun `withNullableArg matches and executes capture block when argument is null`() {
+        val mock = mockk<MockedClass>(relaxed = true)
+        val testedClass = TestedClass(mock)
+
+        testedClass.test()
+
+        verify(exactly = 1) {
+            mock.test(withNullableArg { println(it) })
+        }
+    }
+}


### PR DESCRIPTION
As reported on issue #323, the function `withNullableArg` is not working properly when receiving a null value. 

The problem comes from `TypedMatcher` interface and its `checkType` method. When `InvocationMatcher` executes its `match` method and the matcher is a `TypedMatcher`, the mentioned `checkType` method is executed and makes the invocation matcher to return false for any null argument. 
````
fun checkType(arg: Any?): Boolean {
    if (argumentType.simpleName === null) {
        return true
    }

    return argumentType.isInstance(arg)
}
````

`KClass.isInstance` method is going to always return false if the arg's value is null. Therefore we have a problem with `TypedMatcher` and null values.

The proposed solution consists of creating a new `FunctionMatcher` for nullable arguments (`FunctionWithNullableArgMatcher`). This new matcher has the same behavior as `FunctionMatcher` but it overrides the `checkType` function of `TypedMatcher` to take into account the problem with nullable args. Moreover, `FunctionMatcher` has been slightly modified and now the `matchingFunc` attribute doesn't support nullable types (not needed anymore due to the new matcher).