### PR TITLE
Updated Jacoco version to work with JDK11+

### DIFF
--- a/gradle/jacoco.gradle
+++ b/gradle/jacoco.gradle
@@ -1,5 +1,9 @@
 apply plugin: 'jacoco'
 
+jacoco {
+    toolVersion = "0.8.2"
+}
+
 afterEvaluate {
     jacocoTestReport {
         reports {


### PR DESCRIPTION
Jacoco does not work properly out of the box with JDK11+, so gradle builds results in this error being logged:

```
Caused by: java.lang.NoSuchFieldException: $jacocoAccess
        at java.base/java.lang.Class.getField(Class.java:1976)
        at org.jacoco.agent.rt.internal_c13123e.core.runtime.ModifiedSystemClassRuntime.createFor(ModifiedSystemClassRuntime.java:138)
        ... 9 more
```

And builds hanging forever.

As discussed [here](https://github.com/vaskoz/core-java9-impatient/issues/11) this is due to an issue in Jacoco that was fixed in v0.8.2.

By default Jacoco uses an older version, so to make the builds pass on JDK11+ explicitly setting the version to 0.8.2 is required.