### PR TITLE
Changed implementation of invokeReturnsUnit to fix #371

### DIFF
--- a/dsl/common/src/main/kotlin/io/mockk/API.kt
+++ b/dsl/common/src/main/kotlin/io/mockk/API.kt
@@ -1946,7 +1946,7 @@ open class MockKMatcherScope(
         invoke(name).withArguments(listOf())
 
     @Suppress("CAST_NEVER_SUCCEEDS")
-    infix fun Any.invokeReturnsUnit(name: String) = invoke(name) as Unit
+    infix fun Any.invokeReturnsUnit(name: String) = invokeNoArgs(name) as Unit
 
     infix fun Any.getProperty(name: String) =
         InternalPlatformDsl.dynamicGet(this, name)


### PR DESCRIPTION
I think I found the reason why Issue346Test is failing: the original implementation of `invokeReturnsUnit` calls `invoke`, which in turn returns a `DynamicCallLong`, but the test is expecting `invokeReturnsUnit` to return a `Unit`.

Casting a `DynamicCallLong` to `Unit` fails, triggering the exception detailed in #371.

The actual behavior of `invokeReturnsUnit` should be to call `invokeNoArgs`, which indeed returns a `Unit`.