### PR TITLE
Added collections to the AnyValueGenerator

### DIFF
--- a/mockk/common/src/main/kotlin/io/mockk/impl/instantiation/AnyValueGenerator.kt
+++ b/mockk/common/src/main/kotlin/io/mockk/impl/instantiation/AnyValueGenerator.kt
@@ -24,6 +24,13 @@ open class AnyValueGenerator {
             FloatArray::class -> FloatArray(0)
             DoubleArray::class -> DoubleArray(0)
 
+            List::class -> emptyList<Any>()
+            Map::class -> emptyMap<Any, Any>()
+            Set::class -> emptySet<Any>()
+            ArrayList::class -> arrayListOf<Any>()
+            HashMap::class -> hashMapOf<Any, Any>()
+            HashSet::class -> hashSetOf<Any>()
+
             else -> orInstantiateVia()
         }
     }

--- a/mockk/common/src/test/kotlin/io/mockk/impl/instantiation/AnyValueGeneratorTest.kt
+++ b/mockk/common/src/test/kotlin/io/mockk/impl/instantiation/AnyValueGeneratorTest.kt
@@ -89,4 +89,34 @@ class AnyValueGeneratorTest {
     fun givenDoubleArrayClassWhenRequestedForAnyValueThenEmptyDoubleArrayIsReturned() {
         assertArrayEquals(DoubleArray(0), generator.anyValue(DoubleArray::class, failOnPassThrough) as DoubleArray, 1e-6)
     }
+
+    @Test
+    fun givenListClassWhenRequestedForAnyValueThenEmptyListIsReturned() {
+        assertEquals(listOf<Any>(), generator.anyValue(List::class, failOnPassThrough) as List<*>)
+    }
+
+    @Test
+    fun givenMapClassWhenRequestedForAnyValueThenEmptyMapIsReturned() {
+        assertEquals(mapOf<Any, Any>(), generator.anyValue(Map::class, failOnPassThrough) as Map<*, *>)
+    }
+
+    @Test
+    fun givenSetClassWhenRequestedForAnyValueThenEmptySetIsReturned() {
+        assertEquals(setOf<Any>(), generator.anyValue(Set::class, failOnPassThrough) as Set<*>)
+    }
+
+    @Test
+    fun givenArrayListClassWhenRequestedForAnyValueThenEmptyArrayListIsReturned() {
+        assertEquals(arrayListOf<Any>(), generator.anyValue(ArrayList::class, failOnPassThrough) as ArrayList<*>)
+    }
+
+    @Test
+    fun givenHashMapClassWhenRequestedForAnyValueThenEmptyHashMapIsReturned() {
+        assertEquals(hashMapOf<Any, Any>(), generator.anyValue(HashMap::class, failOnPassThrough) as HashMap<*, *>)
+    }
+
+    @Test
+    fun givenHashSetClassWhenRequestedForAnyValueThenEmptyHashSetIsReturned() {
+        assertEquals(hashSetOf<Any>(), generator.anyValue(HashSet::class, failOnPassThrough) as HashSet<*>)
+    }
 }

--- a/mockk/jvm/src/main/kotlin/io/mockk/impl/instantiation/JvmAnyValueGenerator.kt
+++ b/mockk/jvm/src/main/kotlin/io/mockk/impl/instantiation/JvmAnyValueGenerator.kt
@@ -20,6 +20,13 @@ class JvmAnyValueGenerator(instantiator: JvmInstantiator) : AnyValueGenerator() 
             java.lang.Double::class -> 0.0
             java.lang.Class::class -> Object::class.java
 
+            java.util.List::class -> listOf<Any>()
+            java.util.Map::class -> mapOf<Any, Any>()
+            java.util.Set::class -> emptySet<Any>()
+            java.util.ArrayList::class -> arrayListOf<Any>()
+            java.util.HashMap::class -> hashMapOf<Any, Any>()
+            java.util.HashSet::class -> hashSetOf<Any>()
+
             else -> super.anyValue(cls) {
                 if (cls.java.isArray) {
                     java.lang.reflect.Array.newInstance(cls.java.componentType, 0)

--- a/mockk/jvm/src/test/kotlin/io/mockk/gh/Issue386Test.kt
+++ b/mockk/jvm/src/test/kotlin/io/mockk/gh/Issue386Test.kt
@@ -1,0 +1,83 @@
+package io.mockk.gh
+
+import io.mockk.MockKAnnotations
+import io.mockk.impl.annotations.RelaxedMockK
+import junit.framework.Assert.assertEquals
+import junit.framework.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+class ReturningCollections {
+    fun getList(): List<Any> {
+        return listOf()
+    }
+    fun getMap(): Map<Any, Any> {
+        return mapOf()
+    }
+    fun getSet(): Set<Any> {
+        return setOf()
+    }
+    fun getArrayList(): ArrayList<Any> {
+        return arrayListOf()
+    }
+    fun getHashMap(): HashMap<Any, Any> {
+        return hashMapOf()
+    }
+    fun getHashSet(): HashSet<Any> {
+        return hashSetOf()
+    }
+}
+
+class Issue386Test {
+
+    @RelaxedMockK
+    private lateinit var returningCollections : ReturningCollections
+
+    @Before
+    fun setup() {
+        MockKAnnotations.init(this, relaxUnitFun = true)
+    }
+
+    @Test
+    fun getList() {
+        val list = returningCollections.getList()
+        assertEquals(0, list.size)
+        assertTrue(list.isEmpty())
+    }
+
+    @Test
+    fun getMap() {
+        val map = returningCollections.getMap()
+        assertEquals(0, map.size)
+        assertTrue(map.isEmpty())
+    }
+
+    @Test
+    fun getSet() {
+        val set = returningCollections.getSet()
+        assertEquals(0, set.size)
+        assertTrue(set.isEmpty())
+    }
+
+    @Test
+    fun getArrayList() {
+        val arraylist = returningCollections.getArrayList()
+        assertEquals(0, arraylist.size)
+        assertTrue(arraylist.isEmpty())
+    }
+
+    @Test
+    fun getHashMap() {
+        val hashmap = returningCollections.getHashMap()
+        assertEquals(0, hashmap.size)
+        assertTrue(hashmap.isEmpty())
+    }
+
+    @Test
+    fun getHashSet() {
+        val hashset = returningCollections.getHashSet()
+        assertEquals(0, hashset.size)
+        assertTrue(hashset.isEmpty())
+    }
+
+}


### PR DESCRIPTION
This fixes #386 by providing anyValue implementations for some common collections, like list, map, set and their most common implementations.