### PR TITLE
Use `getOrElse` instead of `getOrDefault`

### DIFF
--- a/mockk/jvm/src/main/kotlin/io/mockk/impl/JvmMultiNotifier.kt
+++ b/mockk/jvm/src/main/kotlin/io/mockk/impl/JvmMultiNotifier.kt
@@ -60,7 +60,7 @@ class JvmMultiNotifier : MultiNotifier {
     private fun changeCounters(keys: List<Any>, delta: Int) {
         keys.forEach { it ->
             val ref = InternalPlatform.ref(it)
-            val value = counters.getOrDefault(ref, 0) + delta
+            val value = counters.getOrElse(ref) { 0 } + delta
             if (value == 0) {
                 conditionMet.remove(ref)
                 counters.remove(ref)


### PR DESCRIPTION
When running the Android Instrumented test (`verify(timeout = 1000) {}`) with API <= 23, exception occurs with stack trace:
```
E/TestRunner: java.lang.NoSuchMethodError: No interface method getOrDefault(Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object; in class Ljava/util/Map; or its super classes (declaration of 'java.util.Map' appears in /system/framework/core-libart.jar)
        at io.mockk.impl.JvmMultiNotifier.changeCounters(JvmMultiNotifier.kt:63)
        at io.mockk.impl.JvmMultiNotifier.openSession(JvmMultiNotifier.kt:18)
        at io.mockk.impl.stub.StubRepository.openRecordCallAwaitSession(StubRepository.kt:37)
        at io.mockk.impl.verify.TimeoutVerifier.verify(TimeoutVerifier.kt:19)
        at io.mockk.impl.recording.states.VerifyingState$recordingDone$outcome$1.invoke(VerifyingState.kt:31)
        at io.mockk.impl.recording.states.VerifyingState$recordingDone$outcome$1.invoke(VerifyingState.kt:11)
        at io.mockk.impl.recording.CommonCallRecorder.safeExec(CommonCallRecorder.kt:72)
        at io.mockk.impl.recording.states.VerifyingState.recordingDone(VerifyingState.kt:30)
        at io.mockk.impl.recording.CommonCallRecorder.done(CommonCallRecorder.kt:47)
        at io.mockk.impl.eval.RecordedBlockEvaluator.record(RecordedBlockEvaluator.kt:60)
        at io.mockk.impl.eval.VerifyBlockEvaluator.verify(VerifyBlockEvaluator.kt:30)
        at io.mockk.MockKDsl.internalVerify(API.kt:118)
        at io.mockk.MockKKt.verify(MockK.kt:139)
        at io.mockk.MockKKt.verify$default(MockK.kt:136)
```

The method `getOrDefault` only available with API >= 24, so I change it to use the Kotlin version.
I want to verify this patch but failed with task: `Task :mockk-android:transformClassesWithDexBuilderForDebugAndroidTest FAILED` 
😥