### PR TITLE
Fixed issue 389 by catching AssertionErrors in the FunctionMatcher

### DIFF
--- a/dsl/common/src/main/kotlin/io/mockk/Matchers.kt
+++ b/dsl/common/src/main/kotlin/io/mockk/Matchers.kt
@@ -55,7 +55,17 @@ data class FunctionMatcher<in T : Any>(
 ) : Matcher<T>, TypedMatcher, EquivalentMatcher {
     override fun equivalent(): Matcher<Any> = ConstantMatcher(true)
 
-    override fun match(arg: T?): Boolean = if(arg == null) false else matchingFunc(arg)
+    override fun match(arg: T?): Boolean {
+        return if(arg == null) {
+            false
+        } else {
+            try {
+                matchingFunc(arg)
+            } catch (a: AssertionError) {
+                false
+            }
+        }
+    }
 
     override fun toString(): String = "matcher<${argumentType.simpleName}>()"
 }

--- a/mockk/common/src/test/kotlin/io/mockk/gh/Issue389Test.kt
+++ b/mockk/common/src/test/kotlin/io/mockk/gh/Issue389Test.kt
@@ -1,0 +1,38 @@
+package io.mockk.gh
+
+import io.mockk.mockk
+import io.mockk.verifyAll
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class Tweet(val id: Int, val text: String)
+
+interface TweetRepository {
+
+    fun persist(tweet: Tweet)
+
+}
+
+class Issue389Test {
+
+    @Test
+    internal fun `verify multiple persists`() {
+        val repositoryMock = mockk<TweetRepository>(relaxed = true)
+
+        repositoryMock.persist(Tweet(1, "first tweet"))
+        repositoryMock.persist(Tweet(2, "second tweet"))
+
+        verifyAll {
+            repositoryMock.persist(
+                withArg {
+                    assertEquals(it.id, 1)
+                    assertEquals(it.text, "first tweet")
+                })
+            repositoryMock.persist(
+                withArg {
+                    assertEquals(it.id,2)
+                    assertEquals(it.text, "second tweet")
+                })
+        }
+    }
+}

--- a/mockk/common/src/test/kotlin/io/mockk/gh/Issue389Test.kt
+++ b/mockk/common/src/test/kotlin/io/mockk/gh/Issue389Test.kt
@@ -22,6 +22,7 @@ class Issue389Test {
         repositoryMock.persist(Tweet(1, "first tweet"))
         repositoryMock.persist(Tweet(2, "second tweet"))
 
+
         verifyAll {
             repositoryMock.persist(
                 withArg {


### PR DESCRIPTION
This fixes #389 by making sure that if a FunctionMatcher's `matchingFunc` throws an `AssertionError`, it is just considered non-matching rather than propagating the Error across all the application.