### PR TITLE
Fixed issue 353 by overriding checkType in the CaptureNullableMatcher…

### DIFF
--- a/dsl/common/src/main/kotlin/io/mockk/Matchers.kt
+++ b/dsl/common/src/main/kotlin/io/mockk/Matchers.kt
@@ -115,6 +115,13 @@ data class CaptureNullableMatcher<T : Any>(
     override fun match(arg: T?): Boolean = true
 
     override fun toString(): String = "captureNullable<${argumentType.simpleName}>()"
+
+    override fun checkType(arg: Any?): Boolean {
+        if(arg == null) {
+            return true
+        }
+        return super.checkType(arg)
+    }
 }
 
 /**

--- a/mockk/common/src/test/kotlin/io/mockk/gh/Issue353Test.kt
+++ b/mockk/common/src/test/kotlin/io/mockk/gh/Issue353Test.kt
@@ -1,0 +1,31 @@
+package io.mockk.gh
+
+import io.mockk.Runs
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class Issue353Test {
+
+    @Test
+    fun testNullableCapture() {
+        class Mock {
+            fun call(arg: String?) {
+            }
+        }
+
+        val list = mutableListOf<String?>()
+        val test: Mock = mockk {
+            every { call(captureNullable(list)) } just Runs
+        }
+
+        val args = listOf("One", "Two", "Three", null)
+        for (arg in args) {
+            test.call(arg)
+        }
+
+        assertEquals(args, list)
+    }
+}


### PR DESCRIPTION
This fixes #353 by overriding the `checkType` method in the `CaptureNullableMatcher` to allow null values.