### PR TITLE
Add missing documentation for the verify method parameters

### DIFF
--- a/mockk/common/src/main/kotlin/io/mockk/MockK.kt
+++ b/mockk/common/src/main/kotlin/io/mockk/MockK.kt
@@ -123,6 +123,9 @@ fun <T> coEvery(stubBlock: suspend MockKMatcherScope.() -> T): MockKStubScope<T,
  * @param atLeast verifies that the behaviour happened at least [atLeast] times
  * @param atMost verifies that the behaviour happened at most [atMost] times
  * @param exactly verifies that the behaviour happened exactly [exactly] times. Use -1 to disable
+ * @param timeout timeout value in milliseconds. Will wait until one of two following states: either verification is
+ * passed or timeout is reached.
+ * @param verifyBlock code block containing at least 1 call to verify
  *
  * @sample [io.mockk.VerifySample.verifyAmount]
  * @sample [io.mockk.VerifySample.verifyRange]
@@ -147,6 +150,9 @@ fun verify(
  * @param atLeast verifies that the behaviour happened at least [atLeast] times
  * @param atMost verifies that the behaviour happened at most [atMost] times
  * @param exactly verifies that the behaviour happened exactly [exactly] times. Use -1 to disable
+ * @param timeout timeout value in milliseconds. Will wait until one of two following states: either verification is
+ * passed or timeout is reached.
+ * @param verifyBlock code block containing at least 1 call to verify
  *
  * @see [verify]
  */


### PR DESCRIPTION
This PR adds missing documentation for the following `verify()` method parameters: `timeout`, `verifyBlock`.

The most important is the `timeout`'s doc as it's confusing not to know what time unit is used for it. :smile: 