### PR TITLE
Fix documentation referring to `moreInterfaces`

### DIFF
--- a/README.md
+++ b/README.md
@@ -918,7 +918,7 @@ every {
 Adding additional behaviours via interfaces and stubbing them:
 
 ```kotlin
-val spy = spyk(System.out, moreInterfaces = Runnable::class)
+val spy = spyk(System.out, moreInterfaces = *arrayOf(Runnable::class))
 
 spy.println(555)
 


### PR DESCRIPTION
Assigning single element to varargs in named form has been deprecated and is now forbidden.