### PR TITLE
fix: get rid of java warning exception

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ buildscript {
     ext.kotlin_gradle_version = '1.2.71'
     ext.android_gradle_version = '3.2.0'
     ext.android_build_tools_version = '28.0.2'
-    ext.byte_buddy_version = '1.9.10'
+    ext.byte_buddy_version = '1.10.9'
     ext.coroutines_version = '0.27.0'
     ext.dexmaker_version = '2.21.0'
     ext.objenesis_version = '3.0.1'


### PR DESCRIPTION
WARN  i.m.p.j.t.InliningClassTransformer - Failed to transform class java/lang/Object
    java.lang.IllegalArgumentException: Unsupported class file major version 58

https://github.com/mockk/mockk/issues/397