### PR TITLE
"Fewer" not "less"

### DIFF
--- a/mockk/common/src/main/kotlin/io/mockk/impl/verify/OrderedCallVerifier.kt
+++ b/mockk/common/src/main/kotlin/io/mockk/impl/verify/OrderedCallVerifier.kt
@@ -25,7 +25,7 @@ class OrderedCallVerifier(
 
         if (verificationSequence.size > allCalls.size) {
             return VerificationResult.Failure(safeToString.exec {
-                "less calls happened than demanded by order verification sequence. " +
+                "fewer calls happened than demanded by order verification sequence. " +
                         reportCalls(verificationSequence, allCalls)
             })
         }

--- a/mockk/common/src/test/kotlin/io/mockk/it/VerificationErrorsTest.kt
+++ b/mockk/common/src/test/kotlin/io/mockk/it/VerificationErrorsTest.kt
@@ -106,7 +106,7 @@ class VerificationErrorsTest {
 
     @Test
     fun lessCallsHappenedThanDemanded() {
-        expectVerificationError("less calls happened than demanded by order verification sequence", "MockCls.otherOp") {
+        expectVerificationError("fewer calls happened than demanded by order verification sequence", "MockCls.otherOp") {
             every { mock.otherOp(1, any()) } answers { 2 + firstArg<Int>() }
 
             mock.otherOp(1, 3)


### PR DESCRIPTION
Very, VERY trivial grammar correction to assertion failure. I apologise in advance for my pedantry!

Context: [Fewer vs. Less](https://www.grammarly.com/blog/fewer-vs-less/)