### PR TITLE
Fix issue 351 by setting hiddenApiExemptions

### DIFF
--- a/agent/android/src/main/kotlin/io/mockk/proxy/android/AndroidMockKAgentFactory.kt
+++ b/agent/android/src/main/kotlin/io/mockk/proxy/android/AndroidMockKAgentFactory.kt
@@ -11,6 +11,7 @@ import io.mockk.proxy.android.transformation.InliningClassTransformer
 import io.mockk.proxy.common.ProxyMaker
 import io.mockk.proxy.common.transformation.ClassTransformationSpecMap
 import java.io.IOException
+import java.lang.reflect.Method
 
 @Suppress("unused") // dynamically loaded
 class AndroidMockKAgentFactory : MockKAgentFactory {
@@ -79,6 +80,30 @@ class AndroidMockKAgentFactory : MockKAgentFactory {
                 )
             }
 
+            // Set up exemption for blacklisted APIs to allow mocking on SDK objects with hidden methods.
+            // https://android-developers.googleblog.com/2018/02/improving-stability-by-reducing-usage.html
+            try {
+                val vmRuntimeClass = Class.forName(vmRuntimeClassName)
+                val getDeclaredMethod = Class::class.java.getDeclaredMethod(
+                        getDeclaredMethodMethodName,
+                        String::class.java,
+                        arrayOf<Class<*>>()::class.java
+                ) as Method
+                val getRuntime = getDeclaredMethod(
+                        vmRuntimeClass,
+                        getRuntimeMethodName,
+                        null
+                ) as Method
+                val setHiddenApiExemptions = getDeclaredMethod(
+                        vmRuntimeClass,
+                        setHiddenApiExemptionsMethodName,
+                        arrayOf(arrayOf<String>()::class.java)
+                ) as Method
+
+                setHiddenApiExemptions(getRuntime(null), arrayOf("L"))
+            } catch (ex: Exception) {
+                throw MockKAgentException("Could not set up hiddenApiExemptions")
+            }
 
             log.debug("Android P or higher detected. Using inlining class transformer")
             val classTransformer = InliningClassTransformer(specMap)
@@ -137,7 +162,11 @@ class AndroidMockKAgentFactory : MockKAgentFactory {
     }
 
     companion object {
-        private val dispatcherClassName = "io.mockk.proxy.android.AndroidMockKDispatcher"
-        private val dispatcherJar = "dispatcher.jar"
+        private const val dispatcherClassName = "io.mockk.proxy.android.AndroidMockKDispatcher"
+        private const val dispatcherJar = "dispatcher.jar"
+        private const val vmRuntimeClassName = "dalvik.system.VMRuntime"
+        private const val getDeclaredMethodMethodName = "getDeclaredMethod"
+        private const val getRuntimeMethodName = "getRuntime"
+        private const val setHiddenApiExemptionsMethodName = "setHiddenApiExemptions"
     }
 }


### PR DESCRIPTION
This PR aims to fix https://github.com/mockk/mockk/issues/351 by taking advantage of `setHiddenApiExemptions` as mentioned in [this stack overflow answer](https://stackoverflow.com/a/55970138).

We're currently using this logic for Android tests as part of our `AndroidJUnitRunner`, but I think it makes sense to bring this into `mockk` as other people seem to be facing the same issue.

I've published these changes as a snapshot to maven local and it seems to do the trick - tested on P and R emulators and a physical Q device. 

@oleksiyp, let me know if you think this belongs somewhere different or if there are any cases you think it'd be good to test.