### PR TITLE
Fix #273 infinite loop when concurrentHashMap is spied

### DIFF
--- a/agent/jvm/src/main/java/io/mockk/proxy/jvm/advice/jvm/JvmMockKConstructorProxyAdvice.java
+++ b/agent/jvm/src/main/java/io/mockk/proxy/jvm/advice/jvm/JvmMockKConstructorProxyAdvice.java
@@ -11,7 +11,7 @@ import java.util.Map;
 
 @SuppressWarnings("unused")
 public class JvmMockKConstructorProxyAdvice extends BaseAdvice {
-    public JvmMockKConstructorProxyAdvice(@NotNull Map<Object, ? extends MockKInvocationHandler> handlers) {
+    public JvmMockKConstructorProxyAdvice(@NotNull MockHandlerMap handlers) {
         super(handlers);
     }
 

--- a/agent/jvm/src/main/java/io/mockk/proxy/jvm/advice/jvm/JvmMockKHashMapStaticProxyAdvice.java
+++ b/agent/jvm/src/main/java/io/mockk/proxy/jvm/advice/jvm/JvmMockKHashMapStaticProxyAdvice.java
@@ -18,7 +18,7 @@ import static net.bytebuddy.implementation.bytecode.assign.Assigner.Typing.DYNAM
  * Workaround #35
  */
 public class JvmMockKHashMapStaticProxyAdvice extends BaseAdvice {
-    public JvmMockKHashMapStaticProxyAdvice(Map<Object, MockKInvocationHandler> handlers) {
+    public JvmMockKHashMapStaticProxyAdvice(MockHandlerMap handlers) {
         super(handlers);
     }
 

--- a/agent/jvm/src/main/java/io/mockk/proxy/jvm/advice/jvm/JvmMockKProxyAdvice.java
+++ b/agent/jvm/src/main/java/io/mockk/proxy/jvm/advice/jvm/JvmMockKProxyAdvice.java
@@ -16,7 +16,7 @@ import static net.bytebuddy.implementation.bytecode.assign.Assigner.Typing.DYNAM
 
 @SuppressWarnings({"unused", "UnusedAssignment"})
 public class JvmMockKProxyAdvice extends BaseAdvice {
-    public JvmMockKProxyAdvice(Map<Object, MockKInvocationHandler> handlers) {
+    public JvmMockKProxyAdvice(MockHandlerMap handlers) {
         super(handlers);
     }
 

--- a/agent/jvm/src/main/java/io/mockk/proxy/jvm/advice/jvm/JvmMockKProxyAdvice.java
+++ b/agent/jvm/src/main/java/io/mockk/proxy/jvm/advice/jvm/JvmMockKProxyAdvice.java
@@ -41,7 +41,8 @@ public class JvmMockKProxyAdvice extends BaseAdvice {
         }
 
         JvmMockKDispatcher dispatcher = JvmMockKDispatcher.get(id, self);
-        if (dispatcher == null) {
+
+        if (dispatcher == null || !dispatcher.isMock(self)) {
             return null;
         }
 

--- a/agent/jvm/src/main/java/io/mockk/proxy/jvm/advice/jvm/JvmMockKProxyInterceptor.java
+++ b/agent/jvm/src/main/java/io/mockk/proxy/jvm/advice/jvm/JvmMockKProxyInterceptor.java
@@ -11,7 +11,7 @@ import java.util.Map;
 import java.util.concurrent.Callable;
 
 public class JvmMockKProxyInterceptor extends BaseAdvice {
-    public JvmMockKProxyInterceptor(Map<Object, MockKInvocationHandler> handlers) {
+    public JvmMockKProxyInterceptor(MockHandlerMap handlers) {
         super(handlers);
     }
 

--- a/agent/jvm/src/main/java/io/mockk/proxy/jvm/advice/jvm/JvmMockKStaticProxyAdvice.java
+++ b/agent/jvm/src/main/java/io/mockk/proxy/jvm/advice/jvm/JvmMockKStaticProxyAdvice.java
@@ -15,7 +15,7 @@ import static net.bytebuddy.implementation.bytecode.assign.Assigner.Typing.DYNAM
 
 @SuppressWarnings({"unused", "UnusedAssignment"})
 public class JvmMockKStaticProxyAdvice extends BaseAdvice {
-    public JvmMockKStaticProxyAdvice(Map<Object, MockKInvocationHandler> handlers) {
+    public JvmMockKStaticProxyAdvice(MockHandlerMap handlers) {
         super(handlers);
     }
 

--- a/agent/jvm/src/main/java/io/mockk/proxy/jvm/advice/jvm/MockHandlerMap.kt
+++ b/agent/jvm/src/main/java/io/mockk/proxy/jvm/advice/jvm/MockHandlerMap.kt
@@ -1,0 +1,39 @@
+package io.mockk.proxy.jvm.advice.jvm
+
+import io.mockk.proxy.MockKInvocationHandler
+import io.mockk.proxy.jvm.dispatcher.JvmMockKWeakMap
+import java.util.Collections
+
+class WeakMockHandlersMap(private val innerMap: JvmMockKWeakMap<Any, MockKInvocationHandler>) :
+        MockHandlerMap,
+        MutableMap<Any, MockKInvocationHandler> by innerMap {
+
+    constructor() : this(JvmMockKWeakMap())
+
+    override fun isMock(instance: Any): Boolean {
+        return instance !== innerMap.target && innerMap.containsKey(instance)
+    }
+}
+
+class SynchronizedMockHandlersMap(private val innerMap: MutableMap<Any, MockKInvocationHandler>) :
+        MockHandlerMap,
+        MutableMap<Any, MockKInvocationHandler> by innerMap {
+
+    constructor() : this(Collections.synchronizedMap(mutableMapOf<Any, MockKInvocationHandler>()))
+
+    override fun isMock(instance: Any): Boolean {
+        return instance !== innerMap && innerMap.containsKey(instance)
+    }
+}
+
+interface MockHandlerMap : MutableMap<Any, MockKInvocationHandler> {
+    fun isMock(instance: Any): Boolean
+
+    companion object {
+        fun create(hasInstrumentation: Boolean): MockHandlerMap =
+                if (hasInstrumentation)
+                    WeakMockHandlersMap()
+                else
+                    SynchronizedMockHandlersMap()
+    }
+}

--- a/agent/jvm/src/main/java/io/mockk/proxy/jvm/dispatcher/JvmMockKDispatcher.java
+++ b/agent/jvm/src/main/java/io/mockk/proxy/jvm/dispatcher/JvmMockKDispatcher.java
@@ -38,4 +38,5 @@ public abstract class JvmMockKDispatcher {
             Callable<Object> originalMethod
     ) throws Exception;
 
+    public abstract boolean isMock(Object instance);
 }

--- a/agent/jvm/src/main/java/io/mockk/proxy/jvm/dispatcher/JvmMockKWeakMap.java
+++ b/agent/jvm/src/main/java/io/mockk/proxy/jvm/dispatcher/JvmMockKWeakMap.java
@@ -9,30 +9,30 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
 public class JvmMockKWeakMap<K, V> implements Map<K, V> {
-    private final Map<Object, V> map = new ConcurrentHashMap<Object, V>();
+    private final Map<Object, V> target = new ConcurrentHashMap<Object, V>();
     private final ReferenceQueue<K> queue = new ReferenceQueue<K>();
 
     @SuppressWarnings("unchecked")
     public V get(Object key) {
-        return map.get(new StrongKey<K>((K) key));
+        return target.get(new StrongKey<K>((K) key));
     }
 
     public V put(K key, V value) {
         expunge();
-        return map.put(new WeakKey<K>(key, queue), value);
+        return target.put(new WeakKey<K>(key, queue), value);
     }
 
     @SuppressWarnings("unchecked")
     public V remove(Object key) {
         expunge();
-        return map.remove(new StrongKey<K>((K) key));
+        return target.remove(new StrongKey<K>((K) key));
     }
 
 
     private void expunge() {
         Reference<?> ref;
         while ((ref = queue.poll()) != null) {
-            map.remove(ref);
+            target.remove(ref);
         }
     }
 
@@ -106,12 +106,12 @@ public class JvmMockKWeakMap<K, V> implements Map<K, V> {
 
     @Override
     public int size() {
-        return map.size();
+        return target.size();
     }
 
     @Override
     public boolean isEmpty() {
-        return map.isEmpty();
+        return target.isEmpty();
     }
 
     @Override
@@ -121,7 +121,7 @@ public class JvmMockKWeakMap<K, V> implements Map<K, V> {
 
     @Override
     public boolean containsValue(Object value) {
-        return map.containsValue(value);
+        return target.containsValue(value);
     }
 
     @Override
@@ -131,7 +131,7 @@ public class JvmMockKWeakMap<K, V> implements Map<K, V> {
 
     @Override
     public void clear() {
-        map.clear();
+        target.clear();
     }
 
     @Override
@@ -141,7 +141,7 @@ public class JvmMockKWeakMap<K, V> implements Map<K, V> {
 
     @Override
     public Collection<V> values() {
-        return map.values();
+        return target.values();
     }
 
     @Override
@@ -149,4 +149,7 @@ public class JvmMockKWeakMap<K, V> implements Map<K, V> {
         throw new UnsupportedOperationException("entrySet");
     }
 
+    public Map<Object, V> getTarget() {
+        return target;
+    }
 }

--- a/agent/jvm/src/main/kotlin/io/mockk/proxy/jvm/JvmMockKAgentFactory.kt
+++ b/agent/jvm/src/main/kotlin/io/mockk/proxy/jvm/JvmMockKAgentFactory.kt
@@ -2,8 +2,8 @@ package io.mockk.proxy.jvm
 
 import io.mockk.proxy.*
 import io.mockk.proxy.common.transformation.ClassTransformationSpecMap
+import io.mockk.proxy.jvm.advice.jvm.MockHandlerMap
 import io.mockk.proxy.jvm.dispatcher.BootJarLoader
-import io.mockk.proxy.jvm.dispatcher.JvmMockKWeakMap
 import io.mockk.proxy.jvm.transformation.InliningClassTransformer
 import io.mockk.proxy.jvm.transformation.JvmInlineInstrumentation
 import io.mockk.proxy.jvm.transformation.SubclassInstrumentation
@@ -13,7 +13,6 @@ import net.bytebuddy.agent.ByteBuddyAgent
 import net.bytebuddy.description.type.TypeDescription
 import net.bytebuddy.dynamic.scaffold.TypeValidation
 import java.lang.instrument.Instrumentation
-import java.util.*
 import java.util.concurrent.atomic.AtomicLong
 
 class JvmMockKAgentFactory : MockKAgentFactory {
@@ -64,9 +63,9 @@ class JvmMockKAgentFactory : MockKAgentFactory {
                     byteBuddy
                 )
 
-                val handlers = handlerMap(jvmInstrumentation != null)
-                val staticHandlers = handlerMap(jvmInstrumentation != null)
-                val constructorHandlers = handlerMap(jvmInstrumentation != null)
+                val handlers = MockHandlerMap.create(jvmInstrumentation != null)
+                val staticHandlers = MockHandlerMap.create(jvmInstrumentation != null)
+                val constructorHandlers = MockHandlerMap.create(jvmInstrumentation != null)
 
                 val specMap = ClassTransformationSpecMap()
 
@@ -120,12 +119,6 @@ class JvmMockKAgentFactory : MockKAgentFactory {
 
                 )
             }
-
-            private fun handlerMap(hasInstrumentation: Boolean) =
-                if (hasInstrumentation)
-                    JvmMockKWeakMap<Any, MockKInvocationHandler>()
-                else
-                    Collections.synchronizedMap(mutableMapOf<Any, MockKInvocationHandler>())
         }
         Initializer().init()
     }

--- a/agent/jvm/src/main/kotlin/io/mockk/proxy/jvm/advice/BaseAdvice.kt
+++ b/agent/jvm/src/main/kotlin/io/mockk/proxy/jvm/advice/BaseAdvice.kt
@@ -1,14 +1,13 @@
 package io.mockk.proxy.jvm.advice
 
-import io.mockk.proxy.MockKInvocationHandler
+import io.mockk.proxy.jvm.advice.jvm.MockHandlerMap
 import io.mockk.proxy.jvm.dispatcher.JvmMockKDispatcher
-import io.mockk.proxy.jvm.dispatcher.JvmMockKWeakMap
 import java.lang.reflect.Method
 import java.util.Random
 import java.util.concurrent.Callable
 
 internal open class BaseAdvice(
-    private val handlers: Map<Any, MockKInvocationHandler>
+    private val handlers: MockHandlerMap
 ) : JvmMockKDispatcher() {
     val id = randomGen.nextLong()
 
@@ -45,12 +44,7 @@ internal open class BaseAdvice(
 
     override fun isMock(instance: Any): Boolean {
         // in order to avoid endless checks when concurrent hashmap is mocked we need to exclude handlers map explicitly
-        val castedHandlers = handlers as? JvmMockKWeakMap
-        if (castedHandlers != null) {
-            return instance !== castedHandlers.target && handlers.containsKey(instance)
-        }
-
-        return instance !== handlers && handlers.containsKey(instance)
+        return handlers.isMock(instance)
     }
 
     companion object {

--- a/agent/jvm/src/main/kotlin/io/mockk/proxy/jvm/advice/BaseAdvice.kt
+++ b/agent/jvm/src/main/kotlin/io/mockk/proxy/jvm/advice/BaseAdvice.kt
@@ -2,8 +2,9 @@ package io.mockk.proxy.jvm.advice
 
 import io.mockk.proxy.MockKInvocationHandler
 import io.mockk.proxy.jvm.dispatcher.JvmMockKDispatcher
+import io.mockk.proxy.jvm.dispatcher.JvmMockKWeakMap
 import java.lang.reflect.Method
-import java.util.*
+import java.util.Random
 import java.util.concurrent.Callable
 
 internal open class BaseAdvice(
@@ -40,6 +41,16 @@ internal open class BaseAdvice(
                     ?: originalMethod
 
         return handler?.call()
+    }
+
+    override fun isMock(instance: Any): Boolean {
+        // in order to avoid endless checks when concurrent hashmap is mocked we need to exclude handlers map explicitly
+        val castedHandlers = handlers as? JvmMockKWeakMap
+        if (castedHandlers != null) {
+            return instance !== castedHandlers.target && handlers.containsKey(instance)
+        }
+
+        return instance !== handlers && handlers.containsKey(instance)
     }
 
     companion object {

--- a/agent/jvm/src/main/kotlin/io/mockk/proxy/jvm/transformation/InliningClassTransformer.kt
+++ b/agent/jvm/src/main/kotlin/io/mockk/proxy/jvm/transformation/InliningClassTransformer.kt
@@ -8,6 +8,7 @@ import io.mockk.proxy.jvm.advice.jvm.JvmMockKConstructorProxyAdvice
 import io.mockk.proxy.jvm.advice.jvm.JvmMockKHashMapStaticProxyAdvice
 import io.mockk.proxy.jvm.advice.jvm.JvmMockKProxyAdvice
 import io.mockk.proxy.jvm.advice.jvm.JvmMockKStaticProxyAdvice
+import io.mockk.proxy.jvm.advice.jvm.MockHandlerMap
 import io.mockk.proxy.jvm.dispatcher.JvmMockKDispatcher
 import net.bytebuddy.ByteBuddy
 import net.bytebuddy.asm.Advice
@@ -24,9 +25,9 @@ import java.util.concurrent.atomic.AtomicLong
 internal class InliningClassTransformer(
     private val log: MockKAgentLogger,
     private val specMap: ClassTransformationSpecMap,
-    private val handlers: MutableMap<Any, MockKInvocationHandler>,
-    private val staticHandlers: MutableMap<Any, MockKInvocationHandler>,
-    private val constructorHandlers: MutableMap<Any, MockKInvocationHandler>,
+    private val handlers: MockHandlerMap,
+    private val staticHandlers: MockHandlerMap,
+    private val constructorHandlers: MockHandlerMap,
     private val byteBuddy: ByteBuddy
 ) : ClassFileTransformer {
 

--- a/agent/jvm/src/main/kotlin/io/mockk/proxy/jvm/transformation/SubclassInstrumentation.kt
+++ b/agent/jvm/src/main/kotlin/io/mockk/proxy/jvm/transformation/SubclassInstrumentation.kt
@@ -5,6 +5,7 @@ import io.mockk.proxy.MockKInvocationHandler
 import io.mockk.proxy.jvm.ClassLoadingStrategyChooser
 import io.mockk.proxy.jvm.advice.ProxyAdviceId
 import io.mockk.proxy.jvm.advice.jvm.JvmMockKProxyInterceptor
+import io.mockk.proxy.jvm.advice.jvm.MockHandlerMap
 import io.mockk.proxy.jvm.dispatcher.JvmMockKDispatcher
 import net.bytebuddy.ByteBuddy
 import net.bytebuddy.TypeCache
@@ -19,7 +20,7 @@ import java.util.concurrent.atomic.AtomicLong
 
 internal class SubclassInstrumentation(
     private val log: MockKAgentLogger,
-    private val handlers: Map<Any, MockKInvocationHandler>,
+    private val handlers: MockHandlerMap,
     private val byteBuddy: ByteBuddy
 ) {
     private val bootstrapMonitor = Any()

--- a/mockk/jvm/src/test/kotlin/io/mockk/jvm/HashMapMockTest.kt
+++ b/mockk/jvm/src/test/kotlin/io/mockk/jvm/HashMapMockTest.kt
@@ -1,0 +1,28 @@
+package io.mockk.jvm
+
+import io.mockk.mockk
+import io.mockk.spyk
+import io.mockk.verify
+import org.junit.jupiter.api.Disabled
+import org.junit.jupiter.api.assertDoesNotThrow
+import java.util.concurrent.ConcurrentHashMap
+import org.junit.jupiter.api.Test
+
+class HashMapMockTest {
+    @Test
+    fun concurrentHashMap_shouldBeSpied_Successfully() {
+        val map = spyk(ConcurrentHashMap<String, String>())
+        assertDoesNotThrow { map.put("key", "value")  }
+
+        verify(exactly = 1) { map.put("key", "value") }
+    }
+
+    @Test
+    @Disabled(value = "mocking of abstractMap don't work")
+    fun abstractMap_shouldBeMocked_SuccessFully() {
+        val map = mockk<AbstractMap<String, String>>()
+        assertDoesNotThrow { map.get("key")  }
+
+        verify(exactly = 1) { map.get("key") }
+    }
+}


### PR DESCRIPTION
Fix infinite loop when concurrent hashmap is spied. Discovered that abstract map mocking is not working. Should fix #273 