### PR TITLE
[#445] Fix MockKExtension support on JUnit 5 for constructor injection

### DIFF
--- a/mockk/jvm/src/test/kotlin/io/mockk/gh/Issue445Test.kt
+++ b/mockk/jvm/src/test/kotlin/io/mockk/gh/Issue445Test.kt
@@ -1,0 +1,27 @@
+package io.mockk.gh
+
+import io.mockk.impl.annotations.AdditionalInterface
+import io.mockk.impl.annotations.MockK
+import io.mockk.junit5.MockKExtension
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import kotlin.test.assertNotNull
+
+class Issue445Test {
+    class Foo() {}
+
+    @Nested
+    @ExtendWith(MockKExtension::class)
+    inner class InjectMockInNestedTest(
+            @MockK private val foo: Foo,
+            @MockK @AdditionalInterface(Runnable::class) private val bar: Foo) {
+
+        @Test
+        fun shouldHaveInjectMock() {
+            assertNotNull(foo, message = "Should have been injected")
+        }
+    }
+
+}
+


### PR DESCRIPTION
This intent of this PR is to fix the #445 issue using JUnit methods for finding annotations