### PR TITLE
Disable Objenesis cache on the JVM

### DIFF
--- a/agent/jvm/src/main/kotlin/io/mockk/proxy/jvm/ObjenesisInstantiator.kt
+++ b/agent/jvm/src/main/kotlin/io/mockk/proxy/jvm/ObjenesisInstantiator.kt
@@ -14,7 +14,7 @@ class ObjenesisInstantiator(
     private val log: MockKAgentLogger,
     private val byteBuddy: ByteBuddy
 ) : MockKInstantiatior {
-    private val objenesis = ObjenesisStd(true)
+    private val objenesis = ObjenesisStd(false)
 
     private val typeCache = TypeCache<CacheKey>(TypeCache.Sort.WEAK)
 


### PR DESCRIPTION
In a Robolectric testing environment, a new ClassLoader is created per
Android SDK level. Because of this, using MockK objects across SDK
levels is very likely to cause ClassCastException. Disable the Objenesis
cache on the JVM which makes MockK work more seamlessly in environments
with multiple ClassLoaders.

Fixes https://github.com/robolectric/robolectric/issues/5848