### PR TITLE
Added `mockkStatic` hard reference support

### DIFF
--- a/README.md
+++ b/README.md
@@ -792,6 +792,12 @@ verify {
 }
 ```
 
+On `jvm` environments you can replace the class name with a function reference:
+```kotlin
+mockkStatic(Obj::extensionFunc)
+```
+Note that this will mock the whole `pkg.FileKt` class, and not just `extensionFunc`. 
+
 If `@JvmName` is used, specify it as a class name.
 
 KHttp.kt:

--- a/mockk/jvm/src/main/kotlin/io/mockk/MockK.kt
+++ b/mockk/jvm/src/main/kotlin/io/mockk/MockK.kt
@@ -1,6 +1,9 @@
+@file:JvmName("JVMMockKKt")
 package io.mockk
 
 import io.mockk.impl.JvmMockKGateway
+import kotlin.reflect.KFunction
+import kotlin.reflect.jvm.javaMethod
 
 actual object MockK {
     actual inline fun <T> useImpl(block: () -> T): T {
@@ -8,3 +11,28 @@ actual object MockK {
         return block()
     }
 }
+
+/**
+ * Returns the defining top-level extension function's [Class].
+ */
+inline val KFunction<*>.declaringKotlinFile
+    get() = checkNotNull(javaMethod) { "$this is not a top-level extension function" }
+            .declaringClass.kotlin
+
+/**
+ * Builds a static mock. Any mocks of this function's declaring class are cancelled before it's mocked
+ */
+inline fun mockkStatic(vararg functions: KFunction<*>) =
+        mockkStatic(*functions.map { it.declaringKotlinFile }.toTypedArray())
+
+/**
+ * Cancel static mocks.
+ */
+inline fun unmockkStatic(vararg functions: KFunction<*>) =
+        unmockkStatic(*functions.map { it.declaringKotlinFile }.toTypedArray())
+
+/**
+ * Builds a static mock and unmocks it after the block has been executed.
+ */
+inline fun mockkStatic(vararg functions: KFunction<*>, block: () -> Unit) =
+        mockkStatic(classes = *functions.map { it.declaringKotlinFile }.toTypedArray(), block = block)

--- a/mockk/jvm/src/test/kotlin/io/mockk/it/StaticMockJVMTest.kt
+++ b/mockk/jvm/src/test/kotlin/io/mockk/it/StaticMockJVMTest.kt
@@ -1,0 +1,45 @@
+package io.mockk.it
+
+import io.mockk.every
+import io.mockk.mockkStatic
+import io.mockk.verify
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class StaticMockJVMTest {
+
+    @Test
+    fun simpleStaticMock() {
+        mockkStatic(Int::op)
+
+        every { 5 op 6 } returns 2
+
+        assertEquals(2, 5 op 6)
+
+        verify { 5 op 6 }
+    }
+
+    @Test
+    fun clearStateStaticMock() {
+        mockkStatic(Int::op)
+
+        every { 5 op 6 } returns 2
+
+        assertEquals(2, 5 op 6)
+
+        verify { 5 op 6 }
+
+        mockkStatic(Int::op)
+
+        verify(exactly = 0) { 5 op 6 }
+
+        assertEquals(11, 5 op 6)
+
+        every { 5 op 6 } returns 3
+
+        assertEquals(3, 5 op 6)
+
+        verify { 5 op 6 }
+    }
+
+}


### PR DESCRIPTION
Adds a `jvm`-only `mockkStatic` overload function that will allow passing a function reference to pick up the `declaringClass`.

This allows to write more robust tests as hardocded class references like:
```kotlin
// declared in File.kt ("pkg" package)
fun Obj.extensionFunc() = value + 5

mockkStatic("pkg.FileKt")
```
Can now be just:
```kotlin
// declared in File.kt ("pkg" package)
fun Obj.extensionFunc() = value + 5

mockkStatic(Obj::extensionFunc)
```
