### PR TITLE
Fix #214

### DIFF
--- a/dsl/common/src/main/kotlin/io/mockk/API.kt
+++ b/dsl/common/src/main/kotlin/io/mockk/API.kt
@@ -508,7 +508,7 @@ object MockKDsl {
 
             MockKCancellationRegistry
                 .subRegistry(MockKCancellationRegistry.Type.CONSTRUCTOR)
-                .cancelPut(it, cancellation)
+                .putIfNotThere(it, cancellation)
         }
     }
 
@@ -517,6 +517,16 @@ object MockKDsl {
      */
     inline fun internalUnmockkConstructor(vararg classes: KClass<*>) {
         classes.forEach {
+            MockKGateway.implementation().constructorMockFactory.clear(
+                    it,
+                    MockKGateway.ClearOptions(
+                            answers = true,
+                            recordedCalls = true,
+                            childMocks = true,
+                            verificationMarks = true,
+                            exclusionRules = true
+                    )
+            )
             MockKCancellationRegistry
                 .subRegistry(MockKCancellationRegistry.Type.CONSTRUCTOR)
                 .cancel(it)
@@ -2252,6 +2262,13 @@ object MockKCancellationRegistry {
             val map = mapTl.value
             map.remove(key)?.invoke()
             map[key] = newCancellation
+        }
+
+        fun putIfNotThere(key: Any, newCancellation: MockKCancellation) {
+            val map = mapTl.value
+            if (!map.containsKey(key)) {
+                map[key] = newCancellation
+            }
         }
 
         fun cancelAll() {

--- a/mockk/common/src/test/kotlin/io/mockk/it/ConstructorMockTest.kt
+++ b/mockk/common/src/test/kotlin/io/mockk/it/ConstructorMockTest.kt
@@ -5,12 +5,39 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 
 class ConstructorMockTest {
+    class ExampleClass {
+        val exampleProperty: Int = 1
+    }
+
+    object ExampleObject {
+        private val exampleClass = ExampleClass()
+        fun getExampleProperty(): Int = exampleClass.exampleProperty
+    }
+
     class MockCls(val x: Int = 0) {
         fun op(a: Int, b: Int) = a + b + x
 
         fun opList(a: Int, b: Int) = listOf(a, b)
 
         fun chainOp(a: Int, b: Int) = MockCls(a + b + x)
+    }
+
+    @Test
+    fun test1() {
+        mockkConstructor(ExampleClass::class)
+
+        every { anyConstructed<ExampleClass>().exampleProperty } returns 0
+
+        assertEquals(0, ExampleObject.getExampleProperty())
+    }
+
+    @Test
+    fun test2() {
+        mockkConstructor(ExampleClass::class)
+
+        every { anyConstructed<ExampleClass>().exampleProperty } returns 0
+
+        assertEquals(0, ExampleObject.getExampleProperty())
     }
 
     @Test


### PR DESCRIPTION

1. Use the same constructor mock for a class across all tests
2. Clear a mock constructor when unmocking it

Every time mockConstructor is called, the previous mock was canceled and removed from MockKCancellationRegistry.
This cannot work with kotlin object which is a singleton and holds the same references along the app lifecycle.
I try to solve this bug by keeping the same constructor mock (I don't see why not) and I also am clearing answers etc of constructor mock when unmocking it, as it had side effects and I don't see any reason why previous answers should still work since the user asks to be unmocked.

I run all the tests in the same package and they pass. Let me know if I need to test anything else too, to make sure we won't have regressions.