### PR TITLE
Upgraded kotlin to 1.4 and fixed the Nothing-related NPE rethrow

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
-    ext.kotlin_version = '1.3.61'
-    ext.kotlin_gradle_version = '1.3.61'
+    ext.kotlin_version = '1.4.0'
+    ext.kotlin_gradle_version = '1.4.0'
     ext.android_gradle_version = '3.6.3'
     ext.android_build_tools_version = '28.0.3'
     ext.byte_buddy_version = '1.10.14'

--- a/matrix/jvm.gradle
+++ b/matrix/jvm.gradle
@@ -1,6 +1,6 @@
 buildscript {
-    ext.kotlin_version = '1.3.61'
-    ext.kotlin_gradle_version = '1.3.61'
+    ext.kotlin_version = '1.4.0'
+    ext.kotlin_gradle_version = '1.4.0'
     ext.android_gradle_version = '3.6.0'
     ext.coroutines_version = '0.27.0-eap13'
     ext.junit_jupiter_version = '5.6.2'

--- a/mockk/common/src/main/kotlin/io/mockk/impl/eval/RecordedBlockEvaluator.kt
+++ b/mockk/common/src/main/kotlin/io/mockk/impl/eval/RecordedBlockEvaluator.kt
@@ -68,15 +68,15 @@ abstract class RecordedBlockEvaluator(
     private fun <T> enhanceWithNPERethrow(
         block: () -> T,
         checkLastCallReturnsNothing: () -> Boolean
-    ) =
+    ): () -> T =
         {
             try {
                 block()
-            } catch (npe: NullPointerException) {
+            } catch (e: Exception) {
                 if (checkLastCallReturnsNothing()) {
                     throw NothingThrownNullPointerException()
                 } else {
-                    throw npe
+                    throw e
                 }
             }
         }

--- a/mockk/common/src/main/kotlin/io/mockk/impl/eval/RecordedBlockEvaluator.kt
+++ b/mockk/common/src/main/kotlin/io/mockk/impl/eval/RecordedBlockEvaluator.kt
@@ -28,7 +28,7 @@ abstract class RecordedBlockEvaluator(
                 { throw MockKException("You should specify either 'mockBlock' or 'coMockBlock'") }
             }
 
-            val blockWithRethrow = enhanceWithNPERethrow(block, callRecorderInstance::isLastCallReturnsNothing)
+            val blockWithRethrow = enhanceWithRethrow(block, callRecorderInstance::isLastCallReturnsNothing)
 
             val autoHinter = autoHinterFactory()
 
@@ -65,7 +65,7 @@ abstract class RecordedBlockEvaluator(
 
     private class NothingThrownNullPointerException : RuntimeException()
 
-    private fun <T> enhanceWithNPERethrow(
+    private fun <T> enhanceWithRethrow(
         block: () -> T,
         checkLastCallReturnsNothing: () -> Boolean
     ): () -> T =


### PR DESCRIPTION
This upgrades the Kotlin version to 1.4.

All tests run fine except for Issue158Test: functions returning Nothing don't throw a NPE anymore in Kotlin 1.4, but they throw a KotlinNothingValueException.

Unfortunately, this is an internal exception, so it cannot be caught or referenced directly.

The hacky solution is to catch `Exception` in the `enhanceWithRethrow` function: it will rethrow any exceptions that were not thrown because the last call was returning Nothing, so it shouldn't break any existing behaviors.