### PR TITLE
Added a check to prevent slots from being used when verifying multiple calls

### DIFF
--- a/mockk/common/src/main/kotlin/io/mockk/impl/verify/LCSMatchingAlgo.kt
+++ b/mockk/common/src/main/kotlin/io/mockk/impl/verify/LCSMatchingAlgo.kt
@@ -5,8 +5,8 @@ import io.mockk.RecordedCall
 
 class LCSMatchingAlgo(
     val allCalls: List<Invocation>,
-    val verificationSequence: List<RecordedCall>,
-    val captureBlocks: MutableList<() -> Unit>? = null
+    private val verificationSequence: List<RecordedCall>,
+    private val captureBlocks: MutableList<() -> Unit>? = null
 ) {
     private val nEdits = Array(allCalls.size) { Array(verificationSequence.size) { 0 } }
     private val path = Array(allCalls.size) { Array(verificationSequence.size) { '?' } }
@@ -71,9 +71,5 @@ class LCSMatchingAlgo(
                 backTrackCalls(callIdx, matcherIdx - 1)
             }
         }
-    }
-
-    fun postProcess() {
-        backTrackCalls(allCalls.size - 1, verificationSequence.size - 1)
     }
 }

--- a/mockk/common/src/test/kotlin/io/mockk/gh/Issue352Test.kt
+++ b/mockk/common/src/test/kotlin/io/mockk/gh/Issue352Test.kt
@@ -1,0 +1,62 @@
+package io.mockk.gh
+
+import io.mockk.MockKException
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import io.mockk.verifyOrder
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+class Issue352Test {
+
+    open class MockedSubject {
+        open fun doSomething(id: String?, data: Any?): String {
+            throw IllegalStateException("Not mocked :(")
+        }
+    }
+
+    private val mock = mockk<MockedSubject>()
+
+    @BeforeTest
+    fun setup() {
+        every { mock.doSomething("1", "data1") } returns "result1"
+        every { mock.doSomething("2", "data2") } returns "result2"
+    }
+
+    @Test
+    fun `It throws a MockkException when verifying the same function twice with slots`() {
+        mock.doSomething("1", "data1")
+        mock.doSomething("2", "data2")
+
+        val dataSlotId1 = slot<String>()
+        val dataSlotId2 = slot<String>()
+
+        assertFailsWith<MockKException> {
+            verify {
+                mock.doSomething("1", capture(dataSlotId1))
+                mock.doSomething("2", capture(dataSlotId2))
+            }
+        }
+    }
+
+    @Test
+    fun `It allows multiple capturings of the same function using a mutableList`() {
+        mock.doSomething("1", "data1")
+        mock.doSomething("2", "data2")
+
+        val slotList = mutableListOf<String>()
+
+        verify {
+            mock.doSomething("1", capture(slotList))
+            mock.doSomething("2", capture(slotList))
+        }
+
+        assertEquals("data1", slotList[0])
+        assertEquals("data2", slotList[1])
+    }
+
+}

--- a/mockk/common/src/test/kotlin/io/mockk/gh/Issue353Test.kt
+++ b/mockk/common/src/test/kotlin/io/mockk/gh/Issue353Test.kt
@@ -12,7 +12,8 @@ class Issue353Test {
     @Test
     fun testNullableCapture() {
         class Mock {
-            fun call(_: String?) {
+            fun call(unused: String?) {
+                println(unused)
             }
         }
 

--- a/mockk/common/src/test/kotlin/io/mockk/gh/Issue353Test.kt
+++ b/mockk/common/src/test/kotlin/io/mockk/gh/Issue353Test.kt
@@ -12,7 +12,7 @@ class Issue353Test {
     @Test
     fun testNullableCapture() {
         class Mock {
-            fun call(arg: String?) {
+            fun call(_: String?) {
             }
         }
 

--- a/mockk/jvm/src/main/kotlin/io/mockk/impl/InternalPlatform.kt
+++ b/mockk/jvm/src/main/kotlin/io/mockk/impl/InternalPlatform.kt
@@ -147,7 +147,7 @@ actual object InternalPlatform {
 
     inline fun <reified T : Any> loadPlugin(className: String, msg: String = "") =
         try {
-            T::class.cast(Class.forName(className).newInstance())
+            T::class.cast(Class.forName(className).getDeclaredConstructor().newInstance())
         } catch (ex: Exception) {
             throw MockKException("Failed to load plugin. $className $msg", ex)
         }

--- a/mockk/jvm/src/test/kotlin/io/mockk/gh/Issue386Test.kt
+++ b/mockk/jvm/src/test/kotlin/io/mockk/gh/Issue386Test.kt
@@ -2,10 +2,10 @@ package io.mockk.gh
 
 import io.mockk.MockKAnnotations
 import io.mockk.impl.annotations.RelaxedMockK
-import junit.framework.Assert.assertEquals
-import junit.framework.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 class ReturningCollections {
     fun getList(): List<Any> {


### PR DESCRIPTION
This checks if a `verify` block contains the same function more than once and slots are being used to capture its arguments.

If this is the case, the `captured` property of the slot will contain only the argument of the last call, with the tests not behaving as expected.

An exception is now thrown in this case, to suggest using a mutableList to capture arguments.

This should fix #352 by clarifying to users the right way to capture multiple invocations of the same function.
