### PR TITLE
Changed the answers for collections to return a new instance every time

### DIFF
--- a/mockk/common/src/main/kotlin/io/mockk/impl/instantiation/AnyValueGenerator.kt
+++ b/mockk/common/src/main/kotlin/io/mockk/impl/instantiation/AnyValueGenerator.kt
@@ -24,12 +24,12 @@ open class AnyValueGenerator {
             FloatArray::class -> FloatArray(0)
             DoubleArray::class -> DoubleArray(0)
 
-            List::class -> emptyList<Any>()
-            Map::class -> emptyMap<Any, Any>()
-            Set::class -> emptySet<Any>()
-            ArrayList::class -> arrayListOf<Any>()
-            HashMap::class -> hashMapOf<Any, Any>()
-            HashSet::class -> hashSetOf<Any>()
+            List::class -> List<Any>(0) {}
+            Map::class -> HashMap<Any, Any>()
+            Set::class -> HashSet<Any>()
+            ArrayList::class -> ArrayList<Any>()
+            HashMap::class -> HashMap<Any, Any>()
+            HashSet::class -> HashSet<Any>()
 
             else -> orInstantiateVia()
         }

--- a/mockk/common/src/test/kotlin/io/mockk/gh/Issue510Test.kt
+++ b/mockk/common/src/test/kotlin/io/mockk/gh/Issue510Test.kt
@@ -1,0 +1,56 @@
+package io.mockk.gh
+
+import io.mockk.clearAllMocks
+import io.mockk.every
+import io.mockk.mockk
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+
+data class Product(val name: String, val price: Int)
+data class Order(val name: String)
+
+class ShopService {
+
+    fun buyProducts(products: List<Product>) {
+        println("You bought $products...")
+    }
+
+    fun addProductAndOrders(products: List<Product>, orders: List<Order>) {
+        println("Add $products and $orders...")
+    }
+}
+
+class TestMockk {
+
+    private val shopService = mockk<ShopService>()
+
+    @BeforeTest
+    internal fun setUp() {
+        clearAllMocks()
+    }
+
+    @Test
+    internal fun `should match list of arguments`() { // Passes
+
+        every {
+            shopService.buyProducts(any())
+        } returns Unit
+        val products = listOf(Product("raspberry", 2), Product("banana", 212))
+
+        shopService.buyProducts(products)
+
+    }
+
+    @Test
+    internal fun `should match with two arguments of type list`() { // Throws MockkException
+
+        every {
+            shopService.addProductAndOrders(products = any(), orders = any())
+        } returns Unit
+
+        val products = listOf(Product("raspberry", 2), Product("banana", 1))
+        val orders = listOf(Order("raspber"), Order("banana"))
+
+        shopService.addProductAndOrders(products, orders) // Throws MockkException
+    }
+}

--- a/mockk/common/src/test/kotlin/io/mockk/impl/instantiation/AnyValueGeneratorTest.kt
+++ b/mockk/common/src/test/kotlin/io/mockk/impl/instantiation/AnyValueGeneratorTest.kt
@@ -6,9 +6,9 @@ import kotlin.test.assertEquals
 import kotlin.test.fail
 
 class AnyValueGeneratorTest {
-    val generator = AnyValueGenerator()
+    private val generator = AnyValueGenerator()
 
-    val failOnPassThrough = { fail("Passed trough") }
+    private val failOnPassThrough = { fail("Passed trough") }
 
     @Test
     fun givenByteClassWhenRequestedForAnyValueThen0IsReturned() {

--- a/mockk/jvm/src/main/kotlin/io/mockk/impl/JvmMockKGateway.kt
+++ b/mockk/jvm/src/main/kotlin/io/mockk/impl/JvmMockKGateway.kt
@@ -55,7 +55,7 @@ class JvmMockKGateway : MockKGateway {
         instanceFactoryRegistryIntrnl
     )
 
-    val anyValueGenerator = JvmAnyValueGenerator(instantiator)
+    val anyValueGenerator = JvmAnyValueGenerator(instantiator.instantiate(Void::class))
     val signatureValueGenerator = JvmSignatureValueGenerator(Random())
 
 

--- a/mockk/jvm/src/main/kotlin/io/mockk/impl/instantiation/JvmAnyValueGenerator.kt
+++ b/mockk/jvm/src/main/kotlin/io/mockk/impl/instantiation/JvmAnyValueGenerator.kt
@@ -2,8 +2,9 @@ package io.mockk.impl.instantiation
 
 import kotlin.reflect.KClass
 
-class JvmAnyValueGenerator(instantiator: JvmInstantiator) : AnyValueGenerator() {
-    val voidInstance = instantiator.instantiate(Void::class)
+class JvmAnyValueGenerator(
+    private val voidInstance: Any
+) : AnyValueGenerator() {
 
     override fun anyValue(cls: KClass<*>, orInstantiateVia: () -> Any?): Any? {
         return when (cls) {
@@ -20,12 +21,12 @@ class JvmAnyValueGenerator(instantiator: JvmInstantiator) : AnyValueGenerator() 
             java.lang.Double::class -> 0.0
             java.lang.Class::class -> Object::class.java
 
-            java.util.List::class -> listOf<Any>()
-            java.util.Map::class -> mapOf<Any, Any>()
-            java.util.Set::class -> emptySet<Any>()
-            java.util.ArrayList::class -> arrayListOf<Any>()
-            java.util.HashMap::class -> hashMapOf<Any, Any>()
-            java.util.HashSet::class -> hashSetOf<Any>()
+            java.util.List::class -> List<Any>(0) {}
+            java.util.Map::class -> HashMap<Any, Any>()
+            java.util.Set::class -> HashSet<Any>()
+            java.util.ArrayList::class -> ArrayList<Any>()
+            java.util.HashMap::class -> HashMap<Any, Any>()
+            java.util.HashSet::class -> HashSet<Any>()
 
             else -> super.anyValue(cls) {
                 if (cls.java.isArray) {

--- a/mockk/jvm/src/main/kotlin/io/mockk/impl/instantiation/JvmInstantiator.kt
+++ b/mockk/jvm/src/main/kotlin/io/mockk/impl/instantiation/JvmInstantiator.kt
@@ -6,7 +6,7 @@ import io.mockk.proxy.MockKInstantiatior
 import kotlin.reflect.KClass
 
 class JvmInstantiator(
-    val instantiator: MockKInstantiatior,
+    private val instantiator: MockKInstantiatior,
     instanceFactoryRegistry: CommonInstanceFactoryRegistry
 ) : AbstractInstantiator(instanceFactoryRegistry) {
 

--- a/mockk/jvm/src/test/kotlin/io/mockk/jvm/JvmAnyValueGeneratorTest.kt
+++ b/mockk/jvm/src/test/kotlin/io/mockk/jvm/JvmAnyValueGeneratorTest.kt
@@ -1,6 +1,124 @@
 package io.mockk.jvm
 
+import io.mockk.impl.instantiation.JvmAnyValueGenerator
+import io.mockk.util.assertArrayEquals
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.fail
+
 class JvmAnyValueGeneratorTest {
 
-    // TODO more tests
+    private val generator = JvmAnyValueGenerator("")
+
+    private val failOnPassThrough = { fail("Passed trough") }
+
+    @Test
+    fun givenByteClassWhenRequestedForAnyValueThen0IsReturned() {
+        assertEquals(0.toByte(), generator.anyValue(Byte::class, failOnPassThrough))
+    }
+
+    @Test
+    fun givenShortClassWhenRequestedForAnyValueThen0IsReturned() {
+        assertEquals(0.toShort(), generator.anyValue(Short::class, failOnPassThrough))
+    }
+
+    @Test
+    fun givenCharClassWhenRequestedForAnyValueThen0IsReturned() {
+        assertEquals(0.toChar(), generator.anyValue(Char::class, failOnPassThrough))
+    }
+
+    @Test
+    fun givenIntClassWhenRequestedForAnyValueThen0IsReturned() {
+        assertEquals(0, generator.anyValue(Int::class, failOnPassThrough))
+    }
+
+    @Test
+    fun givenLongClassWhenRequestedForAnyValueThen0IsReturned() {
+        assertEquals(0L, generator.anyValue(Long::class, failOnPassThrough))
+    }
+
+    @Test
+    fun givenFloatClassWhenRequestedForAnyValueThen0IsReturned() {
+        assertEquals(0F, generator.anyValue(Float::class, failOnPassThrough))
+    }
+
+    @Test
+    fun givenDoubleClassWhenRequestedForAnyValueThen0IsReturned() {
+        assertEquals(0.0, generator.anyValue(Double::class, failOnPassThrough))
+    }
+
+    @Test
+    fun givenStringClassWhenRequestedForAnyValueThenEmptyStringIsReturned() {
+        assertEquals("", generator.anyValue(String::class, failOnPassThrough))
+    }
+
+    @Test
+    fun givenBooleanArrayClassWhenRequestedForAnyValueThenEmptyBooleanArrayIsReturned() {
+        assertArrayEquals(BooleanArray(0), generator.anyValue(BooleanArray::class, failOnPassThrough) as BooleanArray)
+    }
+
+    @Test
+    fun givenByteArrayClassWhenRequestedForAnyValueThenEmptyByteArrayIsReturned() {
+        assertArrayEquals(ByteArray(0), generator.anyValue(ByteArray::class, failOnPassThrough) as ByteArray)
+    }
+
+    @Test
+    fun givenCharArrayClassWhenRequestedForAnyValueThenEmptyCharArrayIsReturned() {
+        assertArrayEquals(CharArray(0), generator.anyValue(CharArray::class, failOnPassThrough) as CharArray)
+    }
+
+    @Test
+    fun givenShortArrayClassWhenRequestedForAnyValueThenEmptyShortArrayIsReturned() {
+        assertArrayEquals(ShortArray(0), generator.anyValue(ShortArray::class, failOnPassThrough) as ShortArray)
+    }
+
+    @Test
+    fun givenIntArrayClassWhenRequestedForAnyValueThenEmptyIntArrayIsReturned() {
+        assertArrayEquals(IntArray(0), generator.anyValue(IntArray::class, failOnPassThrough) as IntArray)
+    }
+
+    @Test
+    fun givenLongArrayClassWhenRequestedForAnyValueThenEmptyLongArrayIsReturned() {
+        assertArrayEquals(LongArray(0), generator.anyValue(LongArray::class, failOnPassThrough) as LongArray)
+    }
+
+    @Test
+    fun givenFloatArrayClassWhenRequestedForAnyValueThenEmptyFloatArrayIsReturned() {
+        assertArrayEquals(FloatArray(0), generator.anyValue(FloatArray::class, failOnPassThrough) as FloatArray, 1e-6f)
+    }
+
+    @Test
+    fun givenDoubleArrayClassWhenRequestedForAnyValueThenEmptyDoubleArrayIsReturned() {
+        assertArrayEquals(DoubleArray(0), generator.anyValue(DoubleArray::class, failOnPassThrough) as DoubleArray, 1e-6)
+    }
+
+    @Test
+    fun givenListClassWhenRequestedForAnyValueThenEmptyListIsReturned() {
+        assertEquals(listOf<Any>(), generator.anyValue(List::class, failOnPassThrough) as List<*>)
+    }
+
+    @Test
+    fun givenMapClassWhenRequestedForAnyValueThenEmptyMapIsReturned() {
+        assertEquals(mapOf<Any, Any>(), generator.anyValue(Map::class, failOnPassThrough) as Map<*, *>)
+    }
+
+    @Test
+    fun givenSetClassWhenRequestedForAnyValueThenEmptySetIsReturned() {
+        assertEquals(setOf<Any>(), generator.anyValue(Set::class, failOnPassThrough) as Set<*>)
+    }
+
+    @Test
+    fun givenArrayListClassWhenRequestedForAnyValueThenEmptyArrayListIsReturned() {
+        assertEquals(arrayListOf<Any>(), generator.anyValue(ArrayList::class, failOnPassThrough) as ArrayList<*>)
+    }
+
+    @Test
+    fun givenHashMapClassWhenRequestedForAnyValueThenEmptyHashMapIsReturned() {
+        assertEquals(hashMapOf<Any, Any>(), generator.anyValue(HashMap::class, failOnPassThrough) as HashMap<*, *>)
+    }
+
+    @Test
+    fun givenHashSetClassWhenRequestedForAnyValueThenEmptyHashSetIsReturned() {
+        assertEquals(hashSetOf<Any>(), generator.anyValue(HashSet::class, failOnPassThrough) as HashSet<*>)
+    }
 }


### PR DESCRIPTION
This fixes #510.

A change introduced in 1.10.2 added default answers for collections by using the helper `listOf()`, `mapOf()`...functions.

However, these all return the same instance of the corresponding collection, so when the `AnyValueGenerator` was used in creating matchers for recording calls the signature determination was broken: blocks stubbed as

```
every { doSomething(any(), any()) } just runs
```

Where both parameters are `List`s were being mistakenly matched as `doSomething(any(), eq([])`.

By making sure that the `AnyValueGenerator´ always returns a new instance of collections, the signatures now take into account different values of the same type and result in proper matchers.