### PR TITLE
Fix class file compatibility issue with mockk-agent-jvm

### DIFF
--- a/gradle/jvm-module.gradle
+++ b/gradle/jvm-module.gradle
@@ -11,6 +11,9 @@ apply plugin: 'java'
 apply plugin: 'kotlin-platform-jvm'
 apply plugin: 'org.jetbrains.dokka'
 
+sourceCompatibility = 1.8
+targetCompatibility = 1.8
+
 dependencies {
     compileOnly "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     testImplementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"


### PR DESCRIPTION
Set source and target compatibility to 1.8, to ensure jars produced with newer runtimes are still compatible with at least Java 8.

Fixes #539.