### PR TITLE
Added a configuration setting to drive stack traces alignment

### DIFF
--- a/README.md
+++ b/README.md
@@ -1060,7 +1060,7 @@ stackTracesOnVerify=true|false
 stackTracesAlignment=left|center
 ```
 
-Where `stackTracesAlignment` determines whether to align the stack traces displayed when showing recorded calls to the center (default) or to the left (more coherent with usual JVM stackTraces).
+Where `stackTracesAlignment` determines whether to align the stack traces displayed when showing recorded calls to the center (default) or to the left (more consistent with usual JVM stackTraces).
 
 ## DSL tables
 

--- a/README.md
+++ b/README.md
@@ -1050,14 +1050,17 @@ inline fun <reified T : List<E>, E : Any> MockKMatcherScope.matchListWithoutOrde
 To adjust parameters globally, there is a possibility to specify a few settings in a resource file.
 
 How to use: 
- 1. Create a `io/mockk/settings.properties` file in the resources.
+ 1. Create a `io/mockk/settings.properties` file in `src/main/resources`.
  2. Put one of following options:
 ```properties
 relaxed=true|false
 relaxUnitFun=true|false
 recordPrivateCalls=true|false
 stackTracesOnVerify=true|false
+stackTracesAlignment=left|center
 ```
+
+Where `stackTracesAlignment` determines whether to align the stack traces displayed when showing recorded calls to the center (default) or to the left (more coherent with usual JVM stackTraces).
 
 ## DSL tables
 

--- a/dsl/common/src/main/kotlin/io/mockk/MockKSettings.kt
+++ b/dsl/common/src/main/kotlin/io/mockk/MockKSettings.kt
@@ -8,4 +8,19 @@ expect object MockKSettings {
     val recordPrivateCalls: Boolean
 
     val stackTracesOnVerify: Boolean
+
+    val stackTracesAlignment: StackTracesAlignment
+}
+
+enum class StackTracesAlignment {
+    LEFT,
+    CENTER;
+}
+
+fun stackTracesAlignmentValueOf(property: String): StackTracesAlignment {
+    return try {
+        enumValueOf(property.toUpperCase())
+    } catch (e: IllegalArgumentException) {
+        StackTracesAlignment.CENTER
+    }
 }

--- a/dsl/js/src/main/kotlin/io/mockk/MockKSettings.kt
+++ b/dsl/js/src/main/kotlin/io/mockk/MockKSettings.kt
@@ -12,4 +12,9 @@ actual object MockKSettings {
 
     actual val stackTracesOnVerify: Boolean
         get() = js("global.io_mockk_settings_stackTracesOnVerify || false") as Boolean
+
+    actual val stackTracesAlignment: StackTracesAlignment
+        get() = stackTracesAlignmentValueOf(
+            js("global.io_mockk_settings_stackTracesAlignment || \"center\"") as String
+        )
 }

--- a/dsl/jvm/src/main/kotlin/io/mockk/MockKSettings.kt
+++ b/dsl/jvm/src/main/kotlin/io/mockk/MockKSettings.kt
@@ -30,6 +30,9 @@ actual object MockKSettings {
     actual val stackTracesOnVerify: Boolean
         get() = booleanProperty("stackTracesOnVerify", "true")
 
+    actual val stackTracesAlignment: StackTracesAlignment
+        get() = stackTracesAlignmentValueOf(properties.getProperty("stackTracesAlignment", "center"))
+
 
     fun setRelaxed(value: Boolean) {
         properties.setProperty("relaxed", value.toString());
@@ -41,5 +44,9 @@ actual object MockKSettings {
 
     fun setRecordPrivateCalls(value: Boolean) {
         properties.setProperty("recordPrivateCalls", value.toString());
+    }
+
+    fun setStackTracesAlignment(value: String) {
+        properties.setProperty("stackTracesAlignment", value)
     }
 }

--- a/mockk/common/src/main/kotlin/io/mockk/impl/verify/VerificationHelpers.kt
+++ b/mockk/common/src/main/kotlin/io/mockk/impl/verify/VerificationHelpers.kt
@@ -4,6 +4,7 @@ import io.mockk.Invocation
 import io.mockk.MockKSettings
 import io.mockk.RecordedCall
 import io.mockk.StackElement
+import io.mockk.StackTracesAlignment
 import io.mockk.impl.InternalPlatform
 import io.mockk.impl.stub.StubRepository
 
@@ -39,11 +40,24 @@ object VerificationHelpers {
         val maxMethodLen = columnSize { methodName }
         val maxThirdColumn = columnSize { fileLine() }
 
+        val lineFormatter: (StackElement) -> String = if(MockKSettings.stackTracesAlignment == StackTracesAlignment.CENTER) {
+            {
+                spaces(prefix) +
+                    columnRight(it.className, maxClassNameLen) + "." +
+                    columnLeft(it.methodName, maxMethodLen) + " " +
+                    columnLeft(it.fileLine(), maxThirdColumn)
+            }
+        } else {
+            {
+                spaces(prefix) +
+                    it.className + "." +
+                    it.methodName + " " +
+                    it.fileLine()
+            }
+        }
+
         return stackTrace.joinToString("\n") {
-            spaces(prefix) +
-                columnRight(it.className, maxClassNameLen) + "." +
-                columnLeft(it.methodName, maxMethodLen) + " " +
-                columnLeft(it.fileLine(), maxThirdColumn)
+            lineFormatter(it)
         }.substring(prefix)
     }
 


### PR DESCRIPTION
This adds a config setting to drive the alignment of the stacktraces printed when a verification fails.

It should fix #89 by allowing users to change the stacktraces alignment if they'd like to have it more consistent with the usual JVM behavior.