### PR TITLE
Fix issue 519 by not applying setHiddenApiExemptions workaround for API 30+

### DIFF
--- a/agent/android/src/main/kotlin/io/mockk/proxy/android/AndroidMockKAgentFactory.kt
+++ b/agent/android/src/main/kotlin/io/mockk/proxy/android/AndroidMockKAgentFactory.kt
@@ -82,27 +82,31 @@ class AndroidMockKAgentFactory : MockKAgentFactory {
 
             // Set up exemption for blacklisted APIs to allow mocking on SDK objects with hidden methods.
             // https://android-developers.googleblog.com/2018/02/improving-stability-by-reducing-usage.html
-            try {
-                val vmRuntimeClass = Class.forName(vmRuntimeClassName)
-                val getDeclaredMethod = Class::class.java.getDeclaredMethod(
-                        getDeclaredMethodMethodName,
-                        String::class.java,
-                        arrayOf<Class<*>>()::class.java
-                ) as Method
-                val getRuntime = getDeclaredMethod(
-                        vmRuntimeClass,
-                        getRuntimeMethodName,
-                        null
-                ) as Method
-                val setHiddenApiExemptions = getDeclaredMethod(
-                        vmRuntimeClass,
-                        setHiddenApiExemptionsMethodName,
-                        arrayOf(arrayOf<String>()::class.java)
-                ) as Method
+            //
+            // From API 30, this workaround no longer works.
+            if (Build.VERSION.SDK_INT < Build.VERSION_CODES.R) {
+                try {
+                    val vmRuntimeClass = Class.forName(vmRuntimeClassName)
+                    val getDeclaredMethod = Class::class.java.getDeclaredMethod(
+                            getDeclaredMethodMethodName,
+                            String::class.java,
+                            arrayOf<Class<*>>()::class.java
+                    ) as Method
+                    val getRuntime = getDeclaredMethod(
+                            vmRuntimeClass,
+                            getRuntimeMethodName,
+                            null
+                    ) as Method
+                    val setHiddenApiExemptions = getDeclaredMethod(
+                            vmRuntimeClass,
+                            setHiddenApiExemptionsMethodName,
+                            arrayOf(arrayOf<String>()::class.java)
+                    ) as Method
 
-                setHiddenApiExemptions(getRuntime(null), arrayOf("L"))
-            } catch (ex: Exception) {
-                throw MockKAgentException("Could not set up hiddenApiExemptions")
+                    setHiddenApiExemptions(getRuntime(null), arrayOf("L"))
+                } catch (ex: Exception) {
+                    throw MockKAgentException("Could not set up hiddenApiExemptions")
+                }
             }
 
             log.debug("Android P or higher detected. Using inlining class transformer")


### PR DESCRIPTION
Proposed fix for https://github.com/mockk/mockk/issues/519.

The workaround introduced in https://github.com/mockk/mockk/pull/442 for allowing [hidden APIs](https://developer.android.com/distribute/best-practices/develop/restrictions-non-sdk-interfaces) to be accessed via reflection no longer works from API 30. This PR ensures that the workaround is not applied in this case

This means that https://github.com/mockk/mockk/issues/351 will occur for API 30 and above, but this would be a smaller issue.

In the long term, to fix https://github.com/mockk/mockk/issues/351 for later APIs, it might be worth trying to integrate https://github.com/ChickenHook/RestrictionBypass which offers another solution.