### PR TITLE
Fix #538: Change exception message when using not mocked class in every block

### DIFF
--- a/mockk/common/src/main/kotlin/io/mockk/impl/recording/states/StubbingState.kt
+++ b/mockk/common/src/main/kotlin/io/mockk/impl/recording/states/StubbingState.kt
@@ -11,7 +11,7 @@ class StubbingState(recorder: CommonCallRecorder) : RecordingState(recorder) {
 
     private fun checkMissingCalls() {
         if (recorder.calls.isEmpty()) {
-            throw MockKException("Missing calls inside every { ... } block.")
+            throw MockKException("Cannot use every { ... } block with not mocked class")
         }
     }
 }

--- a/mockk/common/src/main/kotlin/io/mockk/impl/recording/states/StubbingState.kt
+++ b/mockk/common/src/main/kotlin/io/mockk/impl/recording/states/StubbingState.kt
@@ -11,7 +11,7 @@ class StubbingState(recorder: CommonCallRecorder) : RecordingState(recorder) {
 
     private fun checkMissingCalls() {
         if (recorder.calls.isEmpty()) {
-            throw MockKException("Cannot use every { ... } block with not mocked class")
+            throw MockKException("Cannot use every { ... } block with a non mocked class")
         }
     }
 }

--- a/mockk/common/src/main/kotlin/io/mockk/impl/recording/states/StubbingState.kt
+++ b/mockk/common/src/main/kotlin/io/mockk/impl/recording/states/StubbingState.kt
@@ -11,7 +11,7 @@ class StubbingState(recorder: CommonCallRecorder) : RecordingState(recorder) {
 
     private fun checkMissingCalls() {
         if (recorder.calls.isEmpty()) {
-            throw MockKException("Cannot use every { ... } block with a non mocked class")
+            throw MockKException("Missing mocked calls inside every { ... } block: make sure the object inside the block is a mock")
         }
     }
 }

--- a/mockk/jvm/src/test/kotlin/io/mockk/gh/Issue538Test.kt
+++ b/mockk/jvm/src/test/kotlin/io/mockk/gh/Issue538Test.kt
@@ -1,0 +1,21 @@
+package io.mockk.gh
+
+import io.mockk.MockKException
+import io.mockk.every
+import kotlin.test.Test
+import kotlin.test.assertFailsWith
+
+class Issue538Test {
+
+    @Test
+    fun `throw exception if not mocked class is in every block`() {
+        assertFailsWith<MockKException>("Cannot use every { ... } block with not mocked class") {
+            val notMockedClass = NotMockedClass()
+            every { notMockedClass.methodThatReturnsANumber() } returns 22
+        }
+    }
+
+    private class NotMockedClass {
+        fun methodThatReturnsANumber() = 55
+    }
+}

--- a/mockk/jvm/src/test/kotlin/io/mockk/gh/Issue538Test.kt
+++ b/mockk/jvm/src/test/kotlin/io/mockk/gh/Issue538Test.kt
@@ -9,7 +9,9 @@ class Issue538Test {
 
     @Test
     fun `throw exception if not mocked class is in every block`() {
-        assertFailsWith<MockKException>("Cannot use every { ... } block with not mocked class") {
+        val expectedExceptionMessage =
+            "Missing mocked calls inside every { ... } block: make sure the object inside the block is a mock"
+        assertFailsWith<MockKException>(expectedExceptionMessage) {
             val notMockedClass = NotMockedClass()
             every { notMockedClass.methodThatReturnsANumber() } returns 22
         }


### PR DESCRIPTION
Proposed fix for #538.

# Background

Exception message that is being thrown when a non mocked class is in every block it's not clear.

### Current message

`Missing calls inside every { ... } block.`

### Proposed message

`Cannot use every { ... } block with a non mocked class`