### PR TITLE
Bring MockK up to Kotlin 1.4

### DIFF
--- a/agent/android/build.gradle
+++ b/agent/android/build.gradle
@@ -59,7 +59,7 @@ android {
 
     defaultConfig {
         minSdkVersion 14
-        targetSdkVersion 28
+        targetSdkVersion 30
         versionName project['version']
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
         testInstrumentationRunnerArgument "notAnnotation", "io.mockk.test.SkipInstrumentedAndroidTest"

--- a/agent/common/build.gradle
+++ b/agent/common/build.gradle
@@ -11,10 +11,3 @@ apply from: "${gradles}/upload.gradle"
 dependencies {
     api project(path: ':mockk-agent-api')
 }
-
-compileKotlin {
-    kotlinOptions {
-        apiVersion = '1.3'
-        languageVersion = '1.3'
-    }
-}

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_gradle_version = '1.4.20'
+    ext.kotlin_gradle_version = '1.4.21'
     ext.android_gradle_version = '4.2.0-beta04'
     ext.android_build_tools_version = '28.0.3'
     ext.byte_buddy_version = '1.10.14'
@@ -27,8 +27,8 @@ buildscript {
 subprojects { subProject ->
     group = 'io.mockk'
 
-    ext.kotlin_version = '1.4.20'
-    ext.kotlin_gradle_version = '1.4.20'
+    ext.kotlin_version = '1.4.21'
+    ext.kotlin_gradle_version = '1.4.21'
 
     repositories {
         mavenCentral()

--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ buildscript {
     ext.objenesis_android_version = '2.6'
     ext.junit_jupiter_version = '5.6.2'
     ext.junit_vintage_version = '5.6.2'
-    ext.dokka_version = '1.4.10'
+    ext.dokka_version = '1.4.20'
     ext.gradles = project.projectDir.toString() + "/gradle"
 
     repositories {

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_gradle_version = '1.4.30'
+    ext.kotlin_gradle_version = '1.4.20'
     ext.android_gradle_version = '3.6.3'
     ext.android_build_tools_version = '28.0.3'
     ext.byte_buddy_version = '1.10.14'
@@ -27,8 +27,8 @@ buildscript {
 subprojects { subProject ->
     group = 'io.mockk'
 
-    ext.kotlin_version = '1.4.30'
-    ext.kotlin_gradle_version = '1.4.30'
+    ext.kotlin_version = '1.4.20'
+    ext.kotlin_gradle_version = '1.4.20'
 
     repositories {
         mavenCentral()

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
     ext.kotlin_gradle_version = '1.4.20'
-    ext.android_gradle_version = '3.6.3'
+    ext.android_gradle_version = '4.2.0-beta04'
     ext.android_build_tools_version = '28.0.3'
     ext.byte_buddy_version = '1.10.14'
     ext.coroutines_version = '1.3.3'

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
     ext.kotlin_gradle_version = '1.4.21'
     ext.android_gradle_version = '4.2.0-beta04'
-    ext.android_build_tools_version = '28.0.3'
+    ext.android_build_tools_version = '30.0.2'
     ext.byte_buddy_version = '1.10.14'
     ext.coroutines_version = '1.3.3'
     ext.dexmaker_version = '2.21.0'

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_gradle_version = '1.3.72'
+    ext.kotlin_gradle_version = '1.4.30'
     ext.android_gradle_version = '3.6.3'
     ext.android_build_tools_version = '28.0.3'
     ext.byte_buddy_version = '1.10.14'
@@ -27,8 +27,8 @@ buildscript {
 subprojects { subProject ->
     group = 'io.mockk'
 
-    ext.kotlin_version = '1.3.72'
-    ext.kotlin_gradle_version = '1.3.72'
+    ext.kotlin_version = '1.4.30'
+    ext.kotlin_gradle_version = '1.4.30'
 
     repositories {
         mavenCentral()

--- a/client-tests/jvm/build.gradle
+++ b/client-tests/jvm/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = "1.3.72"
+    ext.kotlin_version = "1.4.30"
     ext.mockk_version = rootProject.properties["version"]
 
     repositories {
@@ -17,13 +17,6 @@ apply plugin: 'kotlin'
 sourceCompatibility = JavaVersion.VERSION_1_8
 targetCompatibility = JavaVersion.VERSION_1_8
 
-compileTestKotlin {
-    kotlinOptions {
-        apiVersion = '1.3'
-        languageVersion = '1.3'
-    }
-}
-
 configurations.all {
     resolutionStrategy.cacheChangingModulesFor 0, 'seconds'
     resolutionStrategy.cacheDynamicVersionsFor 0, 'seconds'
@@ -36,21 +29,7 @@ repositories {
 }
 
 dependencies {
-    implementation("org.jetbrains.kotlin:kotlin-stdlib") {
-        version {
-            strictly "$kotlin_version"
-        }
-    }
-    implementation("org.jetbrains.kotlin:kotlin-stdlib-common") {
-        version {
-            strictly "$kotlin_version"
-        }
-    }
-    implementation("org.jetbrains.kotlin:kotlin-reflect") {
-        version {
-            strictly "$kotlin_version"
-        }
-    }
+    implementation "org.jetbrains.kotlin:kotlin-stdlib"
     testImplementation "io.mockk:mockk:latest.integration"
     // testImplementation "io.mockk:mockk:1.10.4"
 

--- a/client-tests/jvm/build.gradle
+++ b/client-tests/jvm/build.gradle
@@ -29,7 +29,6 @@ repositories {
 }
 
 dependencies {
-    implementation "org.jetbrains.kotlin:kotlin-stdlib"
     testImplementation "io.mockk:mockk:latest.integration"
     // testImplementation "io.mockk:mockk:1.10.4"
 

--- a/client-tests/jvm/build.gradle
+++ b/client-tests/jvm/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = "1.4.20"
+    ext.kotlin_version = "1.4.21"
     ext.mockk_version = rootProject.properties["version"]
 
     repositories {

--- a/client-tests/jvm/build.gradle
+++ b/client-tests/jvm/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = "1.4.30"
+    ext.kotlin_version = "1.4.20"
     ext.mockk_version = rootProject.properties["version"]
 
     repositories {

--- a/gradle/android-module.gradle
+++ b/gradle/android-module.gradle
@@ -22,7 +22,3 @@ task androidSourcesJar(type: Jar) {
     archiveClassifier.set('sources')
     from android.sourceSets.main.java.srcDirs
 }
-
-dependencies {
-    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-}

--- a/gradle/common-module.gradle
+++ b/gradle/common-module.gradle
@@ -1,7 +1,6 @@
 apply plugin: 'kotlin-platform-common'
 
 dependencies {
-    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     testImplementation "org.jetbrains.kotlin:kotlin-test-common:$kotlin_version"
     testImplementation "org.jetbrains.kotlin:kotlin-test-annotations-common:$kotlin_version"
 }

--- a/gradle/jvm-module.gradle
+++ b/gradle/jvm-module.gradle
@@ -15,9 +15,6 @@ sourceCompatibility = JavaVersion.VERSION_1_8
 targetCompatibility = JavaVersion.VERSION_1_8
 
 dependencies {
-
-    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-
     testImplementation("org.jetbrains.kotlin:kotlin-test-junit:$kotlin_version") {
         exclude group: "junit", module: "junit"
     }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Sat Apr 18 18:09:30 CEST 2020
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.1-all.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME

--- a/mockk/android/build.gradle
+++ b/mockk/android/build.gradle
@@ -7,7 +7,7 @@ apply from: "${gradles}/android-module.gradle"
 apply from: "${gradles}/upload.gradle"
 
 android {
-    compileSdkVersion 'android-28'
+    compileSdkVersion 'android-30'
     buildToolsVersion android_build_tools_version
 
     lintOptions {
@@ -24,7 +24,7 @@ android {
 
     defaultConfig {
         minSdkVersion 14
-        targetSdkVersion 28
+        targetSdkVersion 30
         versionName project['version']
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
         testInstrumentationRunnerArgument "notAnnotation", "io.mockk.test.SkipInstrumentedAndroidTest"
@@ -38,7 +38,6 @@ android {
         sourceCompatibility = JavaVersion.VERSION_1_8
         targetCompatibility = JavaVersion.VERSION_1_8
     }
-
 }
 
 dependencies {


### PR DESCRIPTION
Updated Kotlin to 1.4.21, and updated Android projects to properly support the change.
The Android Gradle plugin comes with it's own version of kotlin-stdlib as far as I can tell, so in order to keep Kotlin version as consistent as possible I updated that as well. The new version of the Android Gradle plugin also requires at least Android build-tools 30.0.2, so that's been updated as well.
Unfortunately Dokka scrictly supports Kotlin 1.4.20 at the latest, however I don't expect a minor patch to make a difference in doc creation.
I initially wanted to bring this up to Kotlin 1.4.30, but it seems like the Android Gradle plugin isn't quite there yet (it might be in 7.0.0-alpha, but that's too risky for my liking).