### PR TITLE
Fix issue 563 by allowing hidden api reflection from MethodDescriptor

### DIFF
--- a/agent/android/src/main/kotlin/io/mockk/proxy/android/AndroidMockKAgentFactory.kt
+++ b/agent/android/src/main/kotlin/io/mockk/proxy/android/AndroidMockKAgentFactory.kt
@@ -2,6 +2,7 @@
 
 package io.mockk.proxy.android
 
+import android.annotation.SuppressLint
 import android.os.Build
 import io.mockk.proxy.*
 import io.mockk.proxy.android.advice.Advice
@@ -107,6 +108,19 @@ class AndroidMockKAgentFactory : MockKAgentFactory {
                 } catch (ex: Exception) {
                     throw MockKAgentException("Could not set up hiddenApiExemptions")
                 }
+            } else {
+                try {
+                    val vmDebugClass = Class.forName(vmDebugClassName)
+                    @SuppressLint("DiscouragedPrivateApi")
+                    val allowHiddenApiReflectionFrom = vmDebugClass.getDeclaredMethod(
+                            allowHiddenApiReflectionFromMethodName,
+                            Class::class.java
+                    ) as Method
+
+                    allowHiddenApiReflectionFrom(null, MethodDescriptor::class.java)
+                } catch (e: Exception) {
+                    throw MockKAgentException("Could not set up hiddenApiExemptions")
+                }
             }
 
             log.debug("Android P or higher detected. Using inlining class transformer")
@@ -169,7 +183,9 @@ class AndroidMockKAgentFactory : MockKAgentFactory {
         private const val dispatcherClassName = "io.mockk.proxy.android.AndroidMockKDispatcher"
         private const val dispatcherJar = "dispatcher.jar"
         private const val vmRuntimeClassName = "dalvik.system.VMRuntime"
+        private const val vmDebugClassName = "dalvik.system.VMDebug"
         private const val getDeclaredMethodMethodName = "getDeclaredMethod"
+        private const val allowHiddenApiReflectionFromMethodName = "allowHiddenApiReflectionFrom"
         private const val getRuntimeMethodName = "getRuntime"
         private const val setHiddenApiExemptionsMethodName = "setHiddenApiExemptions"
     }

--- a/agent/android/src/main/kotlin/io/mockk/proxy/android/advice/Advice.kt
+++ b/agent/android/src/main/kotlin/io/mockk/proxy/android/advice/Advice.kt
@@ -151,7 +151,9 @@ internal class Advice(
     }
 
     companion object {
-        private tailrec fun Class<*>.isOverridden(origin: Method): Boolean {
+        private tailrec fun Class<*>?.isOverridden(origin: Method): Boolean {
+            if (this == null) return false
+
             val method = findMethod(origin.name, origin.parameterTypes)
                     ?: return superclass.isOverridden(origin)
             return origin.declaringClass !== method.declaringClass

--- a/client-tests/jvm/src/test/kotlin/io/mockk/test/BasicClientTest.kt
+++ b/client-tests/jvm/src/test/kotlin/io/mockk/test/BasicClientTest.kt
@@ -17,7 +17,7 @@ class BasicClientTest {
     }
 
     @Test
-    fun `a very basic client test`() {
+    fun aVeryBasicClientTest() {
         val collab = mockk<Collaborator>()
         every { collab.anotherFunction(any()) } returns "hello everyone"
 

--- a/mockk/android/build.gradle
+++ b/mockk/android/build.gradle
@@ -60,6 +60,7 @@ dependencies {
     androidTestImplementation("org.jetbrains.kotlin:kotlin-test-junit:$kotlin_version") {
         exclude group: "junit", module: "junit"
     }
+    androidTestImplementation 'com.android.support.test:rules:1.0.2'
 
     androidTestImplementation "org.junit.jupiter:junit-jupiter-api:$junit_jupiter_version"
     androidTestImplementation "org.junit.jupiter:junit-jupiter-engine:$junit_jupiter_version"

--- a/mockk/android/src/androidTest/java/io/mockk/gh/Issue563Test.kt
+++ b/mockk/android/src/androidTest/java/io/mockk/gh/Issue563Test.kt
@@ -1,0 +1,22 @@
+package io.mockk.gh
+
+import android.support.test.rule.ActivityTestRule
+import android.widget.FrameLayout
+import io.mockk.debug.TestActivity
+import io.mockk.mockk
+import org.junit.Rule
+import org.junit.Test
+
+class Issue563Test {
+
+    @Rule
+    @JvmField
+    val rule = ActivityTestRule(TestActivity::class.java)
+
+    @Test
+    fun test() {
+        // This tests that the hidden api logic in AndroidMockKAgentFactory works. Otherwise,
+        // we would fail when mocking the FrameLayout here
+        mockk<FrameLayout>()
+    }
+}

--- a/mockk/android/src/debug/AndroidManifest.xml
+++ b/mockk/android/src/debug/AndroidManifest.xml
@@ -1,0 +1,9 @@
+<manifest
+    package="io.mockk"
+    xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <application>
+        <activity android:name="io.mockk.debug.TestActivity"/>
+    </application>
+
+</manifest>

--- a/mockk/android/src/debug/java/io/mockk/debug/TestActivity.kt
+++ b/mockk/android/src/debug/java/io/mockk/debug/TestActivity.kt
@@ -1,0 +1,8 @@
+package io.mockk.debug
+
+import android.app.Activity
+
+/**
+ * An empty activity added to debug for use in androidTests.
+ */
+class TestActivity : Activity()

--- a/mockk/common/src/test/kotlin/io/mockk/gh/Issue352Test.kt
+++ b/mockk/common/src/test/kotlin/io/mockk/gh/Issue352Test.kt
@@ -28,7 +28,7 @@ class Issue352Test {
     }
 
     @Test
-    fun `It throws a MockkException when verifying the same function twice with slots`() {
+    fun itThrowsAMockkExceptionWhenVerifyingTheSameFunctionTwiceWithSlots() {
         mock.doSomething("1", "data1")
         mock.doSomething("2", "data2")
 
@@ -44,7 +44,7 @@ class Issue352Test {
     }
 
     @Test
-    fun `It does not throw a MockkException when there are multiple tests verifying with slots`() {
+    fun itDoesNotThrowAMockkExceptionWhenThereAreMultipleTestsVerifyingWithSlots() {
         mock.doSomething("1", "data1")
 
         val slot = slot<String>()
@@ -56,7 +56,7 @@ class Issue352Test {
     }
 
     @Test
-    fun `Another test to test the coexistence of tests with slots`() {
+    fun anotherTestToTestTheCoexistenceOfTestsWithSlots() {
         mock.doSomething("1", "data1")
 
         val slot = slot<String>()
@@ -68,7 +68,7 @@ class Issue352Test {
     }
 
     @Test
-    fun `It allows multiple capturings of the same function using a mutableList`() {
+    fun itAllowsMultipleCapturingsOfTheSameFunctionUsingAMutableList() {
         mock.doSomething("1", "data1")
         mock.doSomething("2", "data2")
 

--- a/mockk/common/src/test/kotlin/io/mockk/gh/Issue510Test.kt
+++ b/mockk/common/src/test/kotlin/io/mockk/gh/Issue510Test.kt
@@ -30,7 +30,7 @@ class TestMockk {
     }
 
     @Test
-    internal fun `should match list of arguments`() { // Passes
+    internal fun shouldMatchListOfArguments() { // Passes
 
         every {
             shopService.buyProducts(any())
@@ -42,7 +42,7 @@ class TestMockk {
     }
 
     @Test
-    internal fun `should match with two arguments of type list`() { // Throws MockkException
+    internal fun shouldMatchWithTwoArgumentsOfTypeList() { // Throws MockkException
 
         every {
             shopService.addProductAndOrders(products = any(), orders = any())

--- a/mockk/jvm/src/test/kotlin/io/mockk/gh/Issue323Test.kt
+++ b/mockk/jvm/src/test/kotlin/io/mockk/gh/Issue323Test.kt
@@ -21,7 +21,7 @@ class Issue323Test {
     }
 
     @Test
-    fun `withNullableArg matches and executes capture block when argument is null`() {
+    fun withNullableArgMatchesAndExecutesCaptureBlockWhenArgumentIsNull() {
         val mock = mockk<MockedClass>(relaxed = true)
         val testedClass = TestedClass(mock)
 

--- a/mockk/jvm/src/test/kotlin/io/mockk/gh/Issue99Test.kt
+++ b/mockk/jvm/src/test/kotlin/io/mockk/gh/Issue99Test.kt
@@ -10,7 +10,7 @@ import kotlin.test.assertNotEquals
 
 class Issue99Test {
     @Test
-    fun `unmockStatic() unmocks static mocks`() {
+    fun unmockStatic_unmocksStaticMocks() {
         mockkStatic(Instant::class)
         every { Instant.now().toEpochMilli() } returns 123L
 


### PR DESCRIPTION
Following on from my comments in https://github.com/mockk/mockk/issues/563, I have applied the workaround from dexmaker for `MethodDescriptor` for Android R. This fixes the issue of mocking Android SDK objects in classes that also use real ones.

For this to work, I had to make a couple of additional changes:

1. To make the android tests run locally, I had to remove the back tick method names from tests. I'm not sure why the unit tests in `mockk-common` are being compiled as part of the androidTests in `mockk-android`, but maybe this is just a local issue. I'm happy to drop this change if the tests work elsewhere.
2. The `isOverridden` extension function in `Advice` began to throw with a null `superclass` after I applied the workaround. I worked around this by making the receiver nullable, but I'm not sure if this has any unexpected consequences.