### PR TITLE
Unmock all after each test with JUnit5 extension

### DIFF
--- a/mockk/jvm/src/main/kotlin/io/mockk/junit5/MockKExtension.kt
+++ b/mockk/jvm/src/main/kotlin/io/mockk/junit5/MockKExtension.kt
@@ -6,10 +6,8 @@ import io.mockk.impl.annotations.MockK
 import io.mockk.impl.annotations.RelaxedMockK
 import io.mockk.impl.annotations.SpyK
 import io.mockk.mockkClass
-import org.junit.jupiter.api.extension.ExtensionContext
-import org.junit.jupiter.api.extension.ParameterContext
-import org.junit.jupiter.api.extension.ParameterResolver
-import org.junit.jupiter.api.extension.TestInstancePostProcessor
+import io.mockk.unmockkAll
+import org.junit.jupiter.api.extension.*
 import java.lang.reflect.Parameter
 
 /**
@@ -22,7 +20,7 @@ import java.lang.reflect.Parameter
  *
  * Alternatively –Djunit.extensions.autodetection.enabled=true may be placed on a command line.
  */
-class MockKExtension : TestInstancePostProcessor, ParameterResolver {
+class MockKExtension : TestInstancePostProcessor, ParameterResolver, AfterEachCallback {
     override fun supportsParameter(parameterContext: ParameterContext, extensionContext: ExtensionContext): Boolean {
         return getMockKAnnotation(parameterContext) != null
     }
@@ -77,5 +75,9 @@ class MockKExtension : TestInstancePostProcessor, ParameterResolver {
 
     override fun postProcessTestInstance(testInstance: Any, context: ExtensionContext) {
         MockKAnnotations.init(testInstance)
+    }
+
+    override fun afterEach(context: ExtensionContext?) {
+        unmockkAll()
     }
 }

--- a/mockk/jvm/src/test/kotlin/io/mockk/junit5/MockKExtensionTest.kt
+++ b/mockk/jvm/src/test/kotlin/io/mockk/junit5/MockKExtensionTest.kt
@@ -112,12 +112,13 @@ class MockKExtensionTest {
         @AfterAll
         @JvmStatic
         internal fun afterAll() {
-            assertFalse(isMockKMock(TestMock))
+            assertFalse(isMockKMock(TestMock, objectMock = true))
         }
     }
 
     @Test
     fun prepareAfterAllUnmockTest() {
         mockkObject(TestMock)
+        assertTrue(isMockKMock(TestMock, objectMock = true))
     }
 }


### PR DESCRIPTION
Closes #142 

As explained in https://github.com/mockk/mockk/issues/142#issuecomment-781674022 I think that the associated test needs to be adapted because the tests in `MockKExtensionTest` don't seem to get run at all.