### PR TITLE
Add CI test matrix

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -1,4 +1,4 @@
-name: Java CI with Gradle
+name: All tests
 
 on:
   push:
@@ -7,17 +7,29 @@ on:
     branches: [ master ]
 
 jobs:
-  build:
-
+  tests:
+    strategy:
+      matrix:
+        java-version: [1.8, 10, 11, 12, 13, 14, 15]
+      # in case one JDK fails, we still want to see results from others
+      fail-fast: false
     runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up JDK 11
+    - uses: actions/cache@v2
+      with:
+        path: |
+          ~/.gradle/caches
+          ~/.gradle/wrapper
+        key: ${{ runner.os }}-${{ matrix.java-version }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+        restore-keys: |
+          ${{ runner.os }}-${{ matrix.java-version }}-gradle-
+    - name: Set up JDK ${{ matrix.java-version }}
       uses: actions/setup-java@v1
       with:
-        java-version: 11
+        java-version: ${{ matrix.java-version }}
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew
-    - name: Build with Gradle
-      run: ./gradlew build
+    - name: Run tests with Gradle
+      run: ./gradlew test

--- a/gradle/jacoco.gradle
+++ b/gradle/jacoco.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'jacoco'
 
 jacoco {
-    toolVersion = "0.8.5"
+    toolVersion = "0.8.6"
 }
 
 afterEvaluate {


### PR DESCRIPTION
So tests will be run on multiple Java versions. I also added a cache.

Building releases from tags and uploading them should be possible, too. 
I'm a bit concerned about the failing regression test for `Issue3test89Test` - are you perchance aware of that?