### PR TITLE
Added `mockkStatic` support for `val Any.xxx get()`

### DIFF
--- a/README.md
+++ b/README.md
@@ -803,6 +803,13 @@ mockkStatic(Obj::extensionFunc)
 ```
 Note that this will mock the whole `pkg.FileKt` class, and not just `extensionFunc`. 
 
+This syntax also applies for extension properties:
+```kotlin
+val Obj.squareValue get() = value * value
+
+mockkStatic(Obj::squareValue)
+```
+
 If `@JvmName` is used, specify it as a class name.
 
 KHttp.kt:

--- a/mockk/jvm/src/main/kotlin/io/mockk/MockK.kt
+++ b/mockk/jvm/src/main/kotlin/io/mockk/MockK.kt
@@ -3,6 +3,7 @@ package io.mockk
 
 import io.mockk.impl.JvmMockKGateway
 import kotlin.reflect.KFunction
+import kotlin.reflect.KProperty
 import kotlin.reflect.jvm.javaMethod
 
 actual object MockK {
@@ -26,13 +27,31 @@ fun mockkStatic(vararg functions: KFunction<*>) =
         mockkStatic(*functions.map { it.declaringKotlinFile }.toTypedArray())
 
 /**
+ * Builds a static mock. Any mocks of this function's declaring class are cancelled before it's mocked
+ */
+fun mockkStatic(vararg functions: KProperty<*>) =
+    mockkStatic(*functions.map(KProperty<*>::getter).toTypedArray())
+
+/**
  * Cancel static mocks.
  */
 fun unmockkStatic(vararg functions: KFunction<*>) =
         unmockkStatic(*functions.map { it.declaringKotlinFile }.toTypedArray())
 
 /**
+ * Cancel static mocks.
+ */
+fun unmockkStatic(vararg functions: KProperty<*>) =
+    unmockkStatic(*functions.map(KProperty<*>::getter).toTypedArray())
+
+/**
  * Builds a static mock and unmocks it after the block has been executed.
  */
 inline fun mockkStatic(vararg functions: KFunction<*>, block: () -> Unit) =
         mockkStatic(*functions.map { it.declaringKotlinFile }.toTypedArray(), block = block)
+
+/**
+ * Builds a static mock and unmocks it after the block has been executed.
+ */
+inline fun mockkStatic(vararg functions: KProperty<*>, block: () -> Unit) =
+    mockkStatic(*functions.map(KProperty<*>::getter).toTypedArray(), block = block)

--- a/mockk/jvm/src/test/kotlin/io/mockk/it/StaticMockJVMTest.kt
+++ b/mockk/jvm/src/test/kotlin/io/mockk/it/StaticMockJVMTest.kt
@@ -6,10 +6,12 @@ import io.mockk.verify
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
+val Int.selfOp get() = this * this
+
 class StaticMockJVMTest {
 
     @Test
-    fun simpleStaticMock() {
+    fun extensionFunctionStaticMock() {
         mockkStatic(Int::op)
 
         every { 5 op 6 } returns 2
@@ -20,7 +22,7 @@ class StaticMockJVMTest {
     }
 
     @Test
-    fun clearStateStaticMock() {
+    fun extensionFunctionClearStateStaticMock() {
         mockkStatic(Int::op)
 
         every { 5 op 6 } returns 2
@@ -40,6 +42,40 @@ class StaticMockJVMTest {
         assertEquals(3, 5 op 6)
 
         verify { 5 op 6 }
+    }
+
+    @Test
+    fun extensionPropertyStaticMock() {
+        mockkStatic(Int::selfOp)
+
+        every { 5.selfOp } returns 2
+
+        assertEquals(2, 5.selfOp)
+
+        verify { 5.selfOp }
+    }
+
+    @Test
+    fun extensionPropertyClearStateStaticMock() {
+        mockkStatic(Int::selfOp)
+
+        every { 5.selfOp } returns 2
+
+        assertEquals(2, 5.selfOp)
+
+        verify { 5.selfOp }
+
+        mockkStatic(Int::selfOp)
+
+        verify(exactly = 0) { 5.selfOp }
+
+        assertEquals(25, 5.selfOp)
+
+        every { 5.selfOp } returns 3
+
+        assertEquals(3, 5.selfOp)
+
+        verify { 5.selfOp }
     }
 
 }


### PR DESCRIPTION
We have found another use case for `mockkStatic`. Basically it's syntax sugar for when you try to mock an extension property like this:
```kotlin
val Int.square get()= this * this
```