### PR TITLE
java 16 - update byte buddy and github ci

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -10,7 +10,7 @@ jobs:
   tests:
     strategy:
       matrix:
-        java-version: [8, 10, 11, 12, 13, 14, 15]
+        java-version: [8, 10, 11, 12, 13, 14, 15, 16]
         kotlin-version: [1.3.72, 1.4.30]
         kotlin-ir-enabled: [true, false]
         exclude:

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -10,7 +10,7 @@ jobs:
   tests:
     strategy:
       matrix:
-        java-version: [1.8, 10, 11, 12, 13, 14, 15]
+        java-version: [8, 10, 11, 12, 13, 14, 15]
         kotlin-version: [1.3.72, 1.4.30]
         kotlin-ir-enabled: [true, false]
         exclude:
@@ -31,8 +31,9 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-${{ matrix.java-version }}-gradle-
     - name: Set up JDK ${{ matrix.java-version }}
-      uses: actions/setup-java@v1
+      uses: actions/setup-java@v2
       with:
+        distribution: 'zulu'
         java-version: ${{ matrix.java-version }}
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
     ext.kotlin_gradle_version = findProperty('kotlin.version')?.toString() ?: '1.3.72'
     ext.android_gradle_version = '4.1.0'
-    ext.byte_buddy_version = '1.10.14'
+    ext.byte_buddy_version = '1.11.0'
     ext.coroutines_version = '1.3.3'
     ext.dexmaker_version = '2.28.1'
     ext.objenesis_version = '3.1'


### PR DESCRIPTION
running in a personal project with java 16 i got the following error

```
2021-04-28 11:54:00.140 [Test worker] WARN  i.m.p.j.t.InliningClassTransformer - Failed to transform class java/lang/constant/Constable
java.lang.IllegalArgumentException: Unsupported class file major version 60
```

i worked around it by using this version of bytebuddy in testImplementation

in this pr i update byte buddy to the latest version and add java 16 to github ci. i updated the setup-java action to v2 to support java 16 and set the distro to zulu (preserving the v1 default)
