### PR TITLE
fix[614]: ArrayIndexOutOfBoundException in verifyOrder when no call was recorded

### DIFF
--- a/mockk/common/src/main/kotlin/io/mockk/impl/verify/LCSMatchingAlgo.kt
+++ b/mockk/common/src/main/kotlin/io/mockk/impl/verify/LCSMatchingAlgo.kt
@@ -49,7 +49,7 @@ class LCSMatchingAlgo(
         backTrackCalls(allCalls.size - 1, verificationSequence.size - 1)
 
         // match only if all matchers present
-        return nEdits[allCalls.size - 1][verificationSequence.size - 1] == verificationSequence.size
+        return nEdits.getOrNull(allCalls.size - 1)?.getOrNull(verificationSequence.size -1) == verificationSequence.size
     }
 
     private tailrec fun backTrackCalls(callIdx: Int, matcherIdx: Int) {

--- a/mockk/common/src/test/kotlin/io/mockk/gh/Issue614Test.kt
+++ b/mockk/common/src/test/kotlin/io/mockk/gh/Issue614Test.kt
@@ -8,7 +8,7 @@ import kotlin.test.assertFailsWith
 class Issue614Test {
 
     @Test
-    fun `verifyOrder should throw AssertionError if no matching is found`() {
+    fun verifyOrderThrowAssertionErrorIfNoCallHasBeenMade() {
         val mock: Something = mockk(relaxed = true, relaxUnitFun = true)
 
         assertFailsWith<AssertionError> { verifyOrder { mock.doSomething() } }

--- a/mockk/common/src/test/kotlin/io/mockk/gh/Issue614Test.kt
+++ b/mockk/common/src/test/kotlin/io/mockk/gh/Issue614Test.kt
@@ -1,0 +1,20 @@
+package io.mockk.gh
+
+import io.mockk.mockk
+import io.mockk.verifyOrder
+import kotlin.test.Test
+import kotlin.test.assertFailsWith
+
+class Issue614Test {
+
+    @Test
+    fun `verifyOrder should throw AssertionError if no matching is found`() {
+        val mock: Something = mockk(relaxed = true, relaxUnitFun = true)
+
+        assertFailsWith<AssertionError> { verifyOrder { mock.doSomething() } }
+    }
+
+    open class Something {
+        fun doSomething() {}
+    }
+}


### PR DESCRIPTION
Added safe calls in the `LCSMatchingAlgo` to avoid `ArrayIndexOutOfBoundException` as in #614 .
The output in this scenario is now:
```
 java.lang.AssertionError: Verification failed: fewer calls happened than demanded by order verification sequence. 

    Matchers: 
    Something(#732).doSomething())

    Calls:


```