### PR TITLE
fix reading return type for suspending function returning generic type

### DIFF
--- a/mockk/jvm/src/main/kotlin/io/mockk/ValueClassSupport.kt
+++ b/mockk/jvm/src/main/kotlin/io/mockk/ValueClassSupport.kt
@@ -30,10 +30,19 @@ fun <T : Any> T.boxedValue(): Any? {
  * @return class of boxed value, if this is value class, else just class of itself
  */
 fun <T : Any> T.boxedClass(): KClass<*> {
-    if (!this::class.isValueClass()) return this::class
+    return this::class.boxedClass()
+}
+
+/**
+ * Get the KClass of boxed value if this is a value class.
+ *
+ * @return class of boxed value, if this is value class, else just class of itself
+ */
+fun KClass<*>.boxedClass(): KClass<*> {
+    if (!this.isValueClass()) return this
 
     // get backing field
-    val backingField = this::class.valueField()
+    val backingField = this.valueField()
 
     // get boxed value
     return backingField.returnType.classifier as KClass<*>

--- a/mockk/jvm/src/test/kotlin/io/mockk/it/RelaxedSuspendingMockingTest.kt
+++ b/mockk/jvm/src/test/kotlin/io/mockk/it/RelaxedSuspendingMockingTest.kt
@@ -8,9 +8,11 @@ import kotlin.test.assertEquals
 
 @Suppress("UNUSED_PARAMETER")
 class RelaxedSuspendingMockingTest {
+    @Suppress("RedundantSuspendModifier")
     class MockCls {
         suspend fun op(a: Int, b: Int) = a + b
         suspend fun opUnit(a: Int, b: Int) {}
+        suspend fun complexOp(a: Int, b: Int): List<Int> = listOf(a, b)
     }
 
     @Test
@@ -18,10 +20,12 @@ class RelaxedSuspendingMockingTest {
         val mock = mockk<MockCls>(relaxUnitFun = true) {
             coEvery { op(1, 2) } returns 4
             coEvery { opUnit(1, 2) } returns Unit
+            coEvery { complexOp(1, 2) } returns listOf(4, 5)
         }
 
         assertEquals(4, runBlocking { mock.op(1, 2) })
         assertEquals(Unit, runBlocking { mock.opUnit(1, 2) })
+        assertEquals(listOf(4, 5), runBlocking { mock.complexOp(1, 2) })
     }
 
     @Test
@@ -29,6 +33,7 @@ class RelaxedSuspendingMockingTest {
         val mock = mockk<MockCls>(relaxed = true)
 
         assertEquals(0, runBlocking { mock.op(1, 2) })
+        assertEquals(emptyList(), runBlocking { mock.complexOp(1, 2) })
     }
 
 


### PR DESCRIPTION
The previous #641 implemetnation was buggy, a fix here.