### PR TITLE
Add optional constructor arguments support for @InjectMockKs

### DIFF
--- a/mockk/jvm/src/main/kotlin/io/mockk/impl/annotations/MockInjector.kt
+++ b/mockk/jvm/src/main/kotlin/io/mockk/impl/annotations/MockInjector.kt
@@ -64,7 +64,7 @@ class MockInjector(
     private fun matchParameter(param: KParameter): Any? {
         return lookupValueByName(param.name, param.type.classifier)
             ?: lookupValueByType(param.type.classifier)
-            ?: if (!param.isOptional) throw MockKException("Parameter unmatched: $param") else null
+            ?: if (param.isOptional) null else throw MockKException("Parameter unmatched: $param")
     }
 
     private fun tryMatchingParameters(parameters: List<KParameter>): Boolean {

--- a/mockk/jvm/src/main/kotlin/io/mockk/impl/annotations/MockInjector.kt
+++ b/mockk/jvm/src/main/kotlin/io/mockk/impl/annotations/MockInjector.kt
@@ -44,7 +44,10 @@ class MockInjector(
     }
 
     private fun injectViaConstructor(firstMatching: KFunction<Any>): Any {
-        return firstMatching.call(*matchParameters(firstMatching.valueParameters))
+        return firstMatching.valueParameters
+            .associateWith { matchParameter(it) }
+            .filterNot { it.value == null }
+            .let { firstMatching.callBy(it) }
     }
 
     private fun findMatchingConstructor(type: KClass<*>): KFunction<Any>? {
@@ -58,21 +61,18 @@ class MockInjector(
             .firstOrNull { tryMatchingParameters(it.valueParameters) }
     }
 
-    private fun matchParameters(parameters: List<KParameter>): Array<Any> {
-        return parameters.map { param ->
-            lookupValueByName(param.name, param.type.classifier)
-                    ?: lookupValueByType(param.type.classifier)
-                    ?: throw MockKException("Parameter unmatched: $param")
-        }.toTypedArray()
+    private fun matchParameter(param: KParameter): Any? {
+        return lookupValueByName(param.name, param.type.classifier)
+            ?: lookupValueByType(param.type.classifier)
+            ?: if (!param.isOptional) throw MockKException("Parameter unmatched: $param") else null
     }
 
     private fun tryMatchingParameters(parameters: List<KParameter>): Boolean {
-        return !parameters
-            .map { param ->
-                lookupValueByName(param.name, param.type.classifier)
-                        ?: lookupValueByType(param.type.classifier)
-            }
-            .any { it == null }
+        return parameters.all { param ->
+            lookupValueByName(param.name, param.type.classifier) != null
+                    || lookupValueByType(param.type.classifier) != null
+                    || param.isOptional
+        }
     }
 
     private fun lookupValueByName(name: String?, type: KClassifier?): Any? {

--- a/mockk/jvm/src/test/kotlin/io/mockk/impl/annotations/MockInjectorTest.kt
+++ b/mockk/jvm/src/test/kotlin/io/mockk/impl/annotations/MockInjectorTest.kt
@@ -350,7 +350,26 @@ class MockInjectorTest {
 
     @Test
     fun constructorWithDefaultArgumentInjection() {
-        class InjectTarget(param1: MockCls, param2: MockCls = MockCls())
+        class InjectTarget(param1: MockIf, param2: MockCls = MockCls())
+
+        class InjectDeclaration {
+            val param1 = mockk<MockIf>()
+        }
+
+        val declaration = InjectDeclaration()
+
+        val instance = inject(
+            InjectTarget::class,
+            InjectionLookupType.BOTH,
+            declaration
+        )
+
+        assertNotNull(instance)
+    }
+
+    @Test
+    fun matchingDefaultArgumentConstructorInjection() {
+        class InjectTarget(param1: MockCls = MockCls())
 
         class InjectDeclaration {
             val param1 = mockk<MockCls>()
@@ -360,7 +379,7 @@ class MockInjectorTest {
 
         val instance = inject(
             InjectTarget::class,
-            InjectionLookupType.BY_NAME,
+            InjectionLookupType.BOTH,
             declaration
         )
 

--- a/mockk/jvm/src/test/kotlin/io/mockk/impl/annotations/MockInjectorTest.kt
+++ b/mockk/jvm/src/test/kotlin/io/mockk/impl/annotations/MockInjectorTest.kt
@@ -349,6 +349,25 @@ class MockInjectorTest {
     }
 
     @Test
+    fun constructorWithDefaultArgumentInjection() {
+        class InjectTarget(param1: MockCls, param2: MockCls = MockCls())
+
+        class InjectDeclaration {
+            val param1 = mockk<MockCls>()
+        }
+
+        val declaration = InjectDeclaration()
+
+        val instance = inject(
+            InjectTarget::class,
+            InjectionLookupType.BY_NAME,
+            declaration
+        )
+
+        assertNotNull(instance)
+    }
+
+    @Test
     fun simplePropertyInjection() {
         class InjectTarget {
             lateinit var property: MockCls


### PR DESCRIPTION
Currently, when using `@InjectMockKs` annotation with constructor injection, it is required to provide mocked values for all constructor arguments, even if they are optional and have default values (See example below). 
With this PR `@InjectMockks` will still look for mockks for all parameters, including optional, but if nothing is found, default value will be used.

```
class Example (param1: Param1, param2: Param2 = Param2()) {...}

...

@Mockk
lateinit var param1: Param1

@InjectMockks //Will not work since no mockk for param2 is provided
lateinit var example: Example
```