### PR TITLE
remove deprecated jcenter repository

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,6 @@ buildscript {
     repositories {
         mavenCentral()
         google()
-        jcenter()
     }
     dependencies {
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_gradle_version"
@@ -31,9 +30,7 @@ subprojects { subProject ->
 
     repositories {
         mavenCentral()
-        maven { url = "https://dl.bintray.com/linkedin/maven/" }
         google()
-        jcenter()
     }
 
     tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {

--- a/gradle/android-module.gradle
+++ b/gradle/android-module.gradle
@@ -2,7 +2,6 @@ buildscript {
     repositories {
         mavenCentral()
         google()
-        jcenter()
     }
 }
 

--- a/gradle/jvm-module.gradle
+++ b/gradle/jvm-module.gradle
@@ -1,6 +1,6 @@
 buildscript {
     repositories {
-        jcenter()
+        mavenCentral()
     }
     dependencies {
         classpath "org.jetbrains.dokka:dokka-gradle-plugin:${rootProject.dokka_version}"

--- a/matrix/android.gradle
+++ b/matrix/android.gradle
@@ -8,7 +8,6 @@ buildscript {
     repositories {
         mavenCentral()
         google()
-        jcenter()
     }
     dependencies {
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_gradle_version"
@@ -20,7 +19,6 @@ repositories {
     mavenLocal()
     mavenCentral()
     google()
-    jcenter()
 }
 
 apply plugin: 'com.android.library'

--- a/matrix/jvm.gradle
+++ b/matrix/jvm.gradle
@@ -8,7 +8,6 @@ buildscript {
     repositories {
         mavenCentral()
         google()
-        jcenter()
     }
     dependencies {
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_gradle_version"
@@ -20,7 +19,6 @@ repositories {
     mavenLocal()
     mavenCentral()
     google()
-    jcenter()
 }
 
 apply plugin: "kotlin"


### PR DESCRIPTION
> JFrog announced the decommission of JCenter. This has the potential to impact
> many Gradle builds. Gradle emits a deprecation warning when jcenter() is used
> in the repository configuration. Consider using mavenCentral(), google() or a
> private maven repository instead.

https://docs.gradle.org/7.0/userguide/upgrading_version_6.html#jcenter_deprecation