### PR TITLE
Fix mocking of  javax.sql.DataSource

### DIFF
--- a/agent/jvm/src/main/java/io/mockk/proxy/jvm/ClassLoadingStrategyChooser.java
+++ b/agent/jvm/src/main/java/io/mockk/proxy/jvm/ClassLoadingStrategyChooser.java
@@ -1,5 +1,6 @@
 package io.mockk.proxy.jvm;
 
+import java.lang.invoke.MethodHandles;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import net.bytebuddy.dynamic.loading.ClassInjector;
@@ -31,7 +32,10 @@ public class ClassLoadingStrategyChooser {
     public static <T> ClassLoadingStrategy<ClassLoader> chooseClassLoadingStrategy(Class<T> type) {
         try {
             final ClassLoadingStrategy<ClassLoader> strategy;
-            if (!type.getName().startsWith("java.") && ClassInjector.UsingLookup.isAvailable()
+            if (!type.getName().startsWith("java.") &&
+                    ClassInjector.UsingLookup.isAvailable() &&
+                    // based on https://github.com/jmock-developers/jmock-library/issues/127
+                    type.getClassLoader() == ClassLoadingStrategyChooser.class.getClassLoader()
                 && PRIVATE_LOOKUP_IN != null && LOOKUP != null) {
                 Object privateLookup = PRIVATE_LOOKUP_IN.invoke(null, type, LOOKUP);
                 strategy = ClassLoadingStrategy.UsingLookup.of(privateLookup);

--- a/mockk/jvm/src/test/kotlin/io/mockk/jvm/Issue280.kt
+++ b/mockk/jvm/src/test/kotlin/io/mockk/jvm/Issue280.kt
@@ -1,0 +1,15 @@
+package io.mockk.jvm
+
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.Test
+import javax.sql.DataSource
+
+class Issue280 {
+    private val dataSource = mockk<DataSource>()
+
+    @Test
+    fun test() {
+        every { dataSource.getConnection(any(), any()) } returns null
+    }
+}


### PR DESCRIPTION
Apparently javax.sql.DataSource is loaded via a different classloader, which leads to a missing instrumenter. Found similar fix has been applied to jmock. Fixes #280 