### PR TITLE
Fix stubbing by chained calls on collections (#565)

### DIFF
--- a/mockk/jvm/src/test/kotlin/io/mockk/it/CollectionChainStubbingTest.kt
+++ b/mockk/jvm/src/test/kotlin/io/mockk/it/CollectionChainStubbingTest.kt
@@ -1,0 +1,68 @@
+package io.mockk.it
+
+import io.mockk.every
+import io.mockk.mockk
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+// Regression tests for GitHub issue #565.
+class CollectionChainStubbingTest {
+
+    private interface ReturningCollections {
+        val list: List<Int>
+        val map: Map<String, Int>
+        val set: Set<Int>
+        val arrayList: ArrayList<Int>
+        val hashMap: Map<String, Int>
+        val hashSet: HashSet<Int>
+    }
+
+    @Test
+    fun list() {
+        val mock = mockk<ReturningCollections>()
+        every { mock.list[0] } returns 1
+
+        assertEquals(1, mock.list[0])
+    }
+
+    @Test
+    fun map() {
+        val mock = mockk<ReturningCollections>()
+        every { mock.map["foo"] } returns 1
+
+        assertEquals(1, mock.map["foo"])
+    }
+
+    @Test
+    fun set() {
+        val mock = mockk<ReturningCollections>()
+        every { mock.set.contains(1) } returns true
+
+        assertTrue(mock.set.contains(1))
+    }
+
+    @Test
+    fun arrayList() {
+        val mock = mockk<ReturningCollections>()
+        every { mock.arrayList[0] } returns 1
+
+        assertEquals(1, mock.arrayList[0])
+    }
+
+    @Test
+    fun hashMap() {
+        val mock = mockk<ReturningCollections>()
+        every { mock.hashMap["foo"] } returns 1
+
+        assertEquals(1, mock.hashMap["foo"])
+    }
+
+    @Test
+    fun hashSet() {
+        val mock = mockk<ReturningCollections>()
+        every { mock.hashSet.contains(0) } returns true
+
+        assertTrue(mock.hashSet.contains(0))
+    }
+}


### PR DESCRIPTION
## Related links
Issue: https://github.com/mockk/mockk/issues/565
Changes that affected expected behavior: https://github.com/mockk/mockk/pull/387, https://github.com/mockk/mockk/pull/536

## Introduction
Any feedback is appreciated. I'm completely new to the internals of MockK, so please excuse any shortcomings of my solutions.

**I recommend checking commits separately**, because there are alternative solutions. I'll clean those up in case a solution is chosen.

Tests pass for both solutions.

## Explanation

This is an attempt at fixing stubbing by chained calls on collection, such as:
```kotlin
val mock = mockk<SomeClass>()
every { mock.map.get("foo") } returns 0
```

Expected behavior broke when `(Jvm)AnyValueGenerator` started returning concrete instances for collection types. Before those branches existed, the generator would fall back to `orInstantiateVia` lambda, which – when passed from `RecordingState.call` – created a temporary mock on invocation.

## Solutions

### Solution 1: Return temporary mocks for collection types in `RecordingState.call`
Encapsulating the change here helps avoid concerning other consumers of `AnyValueGenerator`, making the scope of the change much smaller than solution 2.

A possible disadvantage is that these collection (or other) types have to be kept in sync between `RecordingState` and `AnyValueGenerator`. Perhaps we could obtain expose those types from `AnyValueGenerator` instead?

### Solution 2: Add flag to configure `AnyValueGenerator`'s behavior
If interfering in `AnyValueGenerator` isn't a concern, we can pass a flag to indicate whether generated objects should be mocks. This adds more complexity than solution 1.