### PR TITLE
Reorganize mockk-android tests

### DIFF
--- a/mockk/android/src/androidTest/java/io/mockk/MethodDescriptionTest.kt
+++ b/mockk/android/src/androidTest/java/io/mockk/MethodDescriptionTest.kt
@@ -1,12 +1,14 @@
-package io.mockk.gh
+package io.mockk
 
-import io.mockk.every
-import io.mockk.mockk
 import java.util.concurrent.Callable
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
-class Issue170Test {
+class MethodDescriptionTest {
+
+    /**
+     * Verifies issue #170.
+     */
     @Test
     fun test() {
         val mock = mockk<Callable<String>>()

--- a/mockk/android/src/androidTest/java/io/mockk/proxy/android/AndroidMockKAgentFactoryTest.kt
+++ b/mockk/android/src/androidTest/java/io/mockk/proxy/android/AndroidMockKAgentFactoryTest.kt
@@ -1,4 +1,4 @@
-package io.mockk.gh
+package io.mockk.proxy.android
 
 import android.support.test.rule.ActivityTestRule
 import android.widget.FrameLayout
@@ -7,16 +7,19 @@ import io.mockk.mockk
 import org.junit.Rule
 import org.junit.Test
 
-class Issue563Test {
+class AndroidMockKAgentFactoryTest {
 
     @Rule
     @JvmField
     val rule = ActivityTestRule(TestActivity::class.java)
 
+    /**
+     * This tests that the hidden api logic in [AndroidMockKAgentFactory] works. Otherwise, we would fail when mocking
+     * the FrameLayout.
+     * Verifies issue #563.
+     */
     @Test
     fun test() {
-        // This tests that the hidden api logic in AndroidMockKAgentFactory works. Otherwise,
-        // we would fail when mocking the FrameLayout here
         mockk<FrameLayout>()
     }
 }


### PR DESCRIPTION
The io.mockk.gh package tests in the mockk-android module are moved
and renamed to better describe which features are being tested.

This commit is part of #618.