### PR TITLE
Moves `MockKExtension`'s `unmockkAll` behavior to the `afterAll` callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,11 @@ fun calculateAddsValues1(@MockK car1: Car, @RelaxedMockK car2: Car) {
 }
 ```
 
+Finally, this extension will call `unmockkAll` in a `@AfterAll` callback, ensuring your test environment is clean after
+each test class execution.
+You can disable this behavior by adding the `@MockKExtension.KeepMocks` annotation to your class or globally by setting 
+the `mockk.junit.extension.keepmocks=true` property
+
 ### Spy
 
 Spies allow you to mix mocks and real objects.

--- a/mockk/jvm/src/test/kotlin/io/mockk/junit5/MockKExtensionAfterAllTestTest.kt
+++ b/mockk/jvm/src/test/kotlin/io/mockk/junit5/MockKExtensionAfterAllTestTest.kt
@@ -1,0 +1,72 @@
+package io.mockk.junit5
+
+import io.mockk.isMockKMock
+import io.mockk.junit5.MockKExtension.Companion.KEEP_MOCKS_PROPERTY
+import io.mockk.mockkObject
+import io.mockk.unmockkObject
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.AfterAllCallback
+import org.junit.jupiter.api.extension.BeforeAllCallback
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.extension.ExtensionContext
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+abstract class MockKExtensionAfterAllTestTest {
+
+    @Test
+    open fun prepareAfterAllUnmockTest() {
+        mockkObject(TestMock)
+        assertTrue(isMockKMock(TestMock, objectMock = true))
+    }
+
+    @ExtendWith(CheckIsNotMock::class, MockKExtension::class)
+    class AfterAllClearMocks : MockKExtensionAfterAllTestTest()
+
+    @MockKExtension.KeepMocks
+    @ExtendWith(CheckIsStillMock::class, MockKExtension::class)
+    class AnnotatedClassAfterAllKeepMocks : MockKExtensionAfterAllTestTest()
+
+    @ExtendWith(CheckIsStillMock::class, MockKExtension::class)
+    class AnnotatedMethodAfterAllKeepMocks : MockKExtensionAfterAllTestTest() {
+
+        @MockKExtension.KeepMocks
+        override fun prepareAfterAllUnmockTest() = super.prepareAfterAllUnmockTest()
+
+    }
+
+    @ExtendWith(CheckIsStillMock::class, PropertyExtension::class, MockKExtension::class)
+    class PropertyAfterAllKeepMocks : MockKExtensionAfterAllTestTest()
+
+    object TestMock
+
+    class CheckIsNotMock : AfterAllCallback {
+
+        override fun afterAll(context: ExtensionContext) {
+            assertFalse(isMockKMock(TestMock, objectMock = true))
+        }
+
+    }
+
+    class CheckIsStillMock : AfterAllCallback {
+
+        override fun afterAll(context: ExtensionContext) {
+            assertTrue(isMockKMock(TestMock, objectMock = true))
+            unmockkObject(TestMock)
+        }
+
+    }
+
+    class PropertyExtension : BeforeAllCallback, AfterAllCallback {
+
+        override fun beforeAll(context: ExtensionContext?) {
+            System.setProperty(KEEP_MOCKS_PROPERTY, "true")
+        }
+
+        override fun afterAll(context: ExtensionContext) {
+            System.clearProperty(KEEP_MOCKS_PROPERTY)
+        }
+
+    }
+
+}

--- a/mockk/jvm/src/test/kotlin/io/mockk/junit5/MockKExtensionTest.kt
+++ b/mockk/jvm/src/test/kotlin/io/mockk/junit5/MockKExtensionTest.kt
@@ -1,18 +1,15 @@
 @file:Suppress("UNUSED_PARAMETER")
+
 package io.mockk.junit5
 
 import io.mockk.every
 import io.mockk.impl.annotations.MockK
 import io.mockk.impl.annotations.RelaxedMockK
 import io.mockk.impl.annotations.SpyK
-import io.mockk.isMockKMock
-import io.mockk.mockkObject
 import io.mockk.verify
-import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import kotlin.test.assertEquals
-import kotlin.test.assertFalse
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
@@ -55,10 +52,10 @@ class MockKExtensionTest {
     fun injectsValidMockInMethods(@MockK car: Car) {
         every {
             car.recordTelemetry(
-                    speed = more(50),
-                    direction = Direction.NORTH,
-                    lat = any(),
-                    long = any()
+                speed = more(50),
+                direction = Direction.NORTH,
+                lat = any(),
+                long = any()
             )
         } returns Outcome.RECORDED
 
@@ -71,10 +68,10 @@ class MockKExtensionTest {
     fun injectsValidMockInClass() {
         every {
             car2.recordTelemetry(
-                    speed = more(50),
-                    direction = Direction.NORTH,
-                    lat = any(),
-                    long = any()
+                speed = more(50),
+                direction = Direction.NORTH,
+                lat = any(),
+                long = any()
             )
         } returns Outcome.RECORDED
 
@@ -106,19 +103,4 @@ class MockKExtensionTest {
         verify { carSpy.relaxedTest() }
     }
 
-    companion object {
-        object TestMock
-
-        @AfterAll
-        @JvmStatic
-        internal fun afterAll() {
-            assertFalse(isMockKMock(TestMock, objectMock = true))
-        }
-    }
-
-    @Test
-    fun prepareAfterAllUnmockTest() {
-        mockkObject(TestMock)
-        assertTrue(isMockKMock(TestMock, objectMock = true))
-    }
 }


### PR DESCRIPTION
This change is motivated by the comment I've dropped at https://github.com/mockk/mockk/issues/142#issuecomment-964500401.

`MockKExtension` is calling `unmockkAll` by default at the end of *each* test, which interferes with the `@TestInstance(TestInstance.Lifecycle.PER_CLASS)`  configuration.

We discovered this issue after enabling `junit.extensions.autodetection.enabled=true` (by other rules, not this one) and all tests with cached mocks (per instance) started to fail because of the reset.

This PR moves the `unmockkAll`  behavior to the `afterAll` callback, and also introduces a new `@KeepMocks` (and a `mockk.junit.extension.keepmocks` property) to allow disabling just this feature while keeping the others of `MockKExtension`.