### PR TITLE
Added latest Kotlin version to build verification

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -11,10 +11,12 @@ jobs:
     strategy:
       matrix:
         java-version: [1.8, 10, 11, 12, 13, 14, 15]
-        kotlin-version: [1.3.72, 1.4.32, 1.5.31]
+        kotlin-version: [1.3.72, 1.4.32, 1.5.31, 1.6.10]
         kotlin-ir-enabled: [true, false]
         exclude:
           - kotlin-version: 1.3.72
+            kotlin-ir-enabled: true
+          - kotlin-version: 1.6.10
             kotlin-ir-enabled: true
       # in case one JDK fails, we still want to see results from others
       fail-fast: false


### PR DESCRIPTION
Updated the build file to run tests for the latest Kotlin version `1.6.10`. The Kotlin 1.6 doesn't support IR. So, it has been added to exclusion list similar to `1.3` version.

https://github.com/JetBrains/kotlin/releases/tag/v1.6.10