### PR TITLE
JUnit 5 upgrade to latest version

### DIFF
--- a/plugins/dependencies/src/main/kotlin/io/mockk/dependencies/Deps.kt
+++ b/plugins/dependencies/src/main/kotlin/io/mockk/dependencies/Deps.kt
@@ -12,8 +12,8 @@ object Deps {
         const val coroutines = "1.3.3"
         const val slfj = "1.7.32"
         const val logback = "1.2.9"
-        const val junitJupiter = "5.6.2"
-        const val junitVintage = "5.6.2"
+        const val junitJupiter = "5.8.2"
+        const val junitVintage = "5.8.2"
     }
 
     object Libs {


### PR DESCRIPTION
JUnit upgrade to latest version `5.8.2`

https://junit.org/junit5/docs/current/release-notes/index.html#release-notes