### PR TITLE
Added logging when matcher fails with an assertion error

### DIFF
--- a/dsl/common/src/main/kotlin/io/mockk/Matchers.kt
+++ b/dsl/common/src/main/kotlin/io/mockk/Matchers.kt
@@ -59,11 +59,7 @@ data class FunctionMatcher<in T : Any>(
         return if(arg == null) {
             false
         } else {
-            try {
-                matchingFunc(arg)
-            } catch (a: AssertionError) {
-                false
-            }
+            matchingFunc(arg)
         }
     }
 


### PR DESCRIPTION
Based on the issue documented [here](https://github.com/mockk/mockk/issues/707), there is no logging when a matcher using `withArg` fails due to a nested assertion exception. After some discussion, it was determined that the best solution would be to remove the try/catch from the matcher so that the error will bubble up and be logged when it fails the matching