### PR TITLE
Avoid Lookup strategy when constructing javax classes

### DIFF
--- a/agent/jvm/src/main/java/io/mockk/proxy/jvm/ClassLoadingStrategyChooser.java
+++ b/agent/jvm/src/main/java/io/mockk/proxy/jvm/ClassLoadingStrategyChooser.java
@@ -33,10 +33,9 @@ public class ClassLoadingStrategyChooser {
         try {
             final ClassLoadingStrategy<ClassLoader> strategy;
             if (!type.getName().startsWith("java.") &&
+                !type.getName().startsWith("javax.") &&
                     ClassInjector.UsingLookup.isAvailable() &&
-                    // based on https://github.com/jmock-developers/jmock-library/issues/127
-                    type.getClassLoader() == ClassLoadingStrategyChooser.class.getClassLoader()
-                && PRIVATE_LOOKUP_IN != null && LOOKUP != null) {
+                PRIVATE_LOOKUP_IN != null && LOOKUP != null) {
                 Object privateLookup = PRIVATE_LOOKUP_IN.invoke(null, type, LOOKUP);
                 strategy = ClassLoadingStrategy.UsingLookup.of(privateLookup);
             } else if (ClassInjector.UsingReflection.isAvailable()) {


### PR DESCRIPTION
This fixes an issue using MockK on classes defined in a Robolectric
class loader.

Fixes #754
Partially fixes https://github.com/robolectric/robolectric/issues/5871