### PR TITLE
Add quarkus support section

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,10 @@ Check the series of articles "Mocking is not rocket science" at [Kt. Academy](ht
 
  * [springmockk](https://github.com/Ninja-Squad/springmockk) introduced in official [Spring Boot Kotlin tutorial](https://spring.io/guides/tutorials/spring-boot-kotlin/)
 
+ ### Quarkus support
+
+ * [quarkus-mockk](https://github.com/quarkiverse/quarkus-mockk) adds support for mocking beans in Quarkus. Documentation can be found [here](https://quarkiverse.github.io/quarkiverse-docs/quarkus-mockk/dev/index.html)
+
 ### Kotlin version support
 
 From version 1.10.0 MockK does not support Kotlin 1.2.*


### PR DESCRIPTION
Quarkus also support `mockk` as mock provider in the bean container. This adds the link to the library. 

Thanks for your work on this project! 