### PR TITLE
Better detection of unnecessary stubbing

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,6 +262,12 @@ This will internally call `confirmVerified` on all mocks after each test, to mak
 
 Please note that this behavior may not work as expected when running tests in your IDE, as it is Gradle who takes care of handling the exception being thrown when these `confirmVerified` calls fail.
 
+#### Automatic unnecessary stubbing check
+
+You can make sure that all stubbed methods are useful - used at least once - by also annotating your test class with `@MockKExtension.CheckUnnecessaryStub`.
+
+This will internally call `checkUnnecessaryStub` on all mocks after each test, to make sure there are no unnecessary stubbings.
+
 
 ### Spy
 
@@ -717,6 +723,18 @@ verify {
 
 confirmVerified(car) // makes sure all calls were covered with verification
 ```
+
+### Unnecessary stubbing
+
+Because clean & maintainable test code requires zero unnecessary code, you can ensure that there is no unnecessary stubs.
+
+```
+checkUnnecessaryStub(mock1, mock2)
+```
+
+It will throw an exception if there are some declared calls on the mocks that are not used by the tested code.
+This can happen if you have declared some really unnecessary stubs or if the tested code doesn't call an expected one.  
+
 
 ### Recording exclusions
 
@@ -1174,37 +1192,38 @@ Here are a few tables to help you master the DSL.
 
 ### Top level functions
 
-|Function|Description|
-|--------|-----------|
-|`mockk<T>(...)`|builds a regular mock|
-|`spyk<T>()`|builds a spy using the default constructor|
-|`spyk(obj)`|builds a spy by copying from `obj`|
-|`slot`|creates a capturing slot|
-|`every`|starts a stubbing block|
-|`coEvery`|starts a stubbing block for coroutines|
-|`verify`|starts a verification block|
-|`coVerify`|starts a verification block for coroutines|
-|`verifyAll`|starts a verification block that should include all calls|
-|`coVerifyAll`|starts a verification block that should include all calls for coroutines|
-|`verifyOrder`|starts a verification block that checks the order|
-|`coVerifyOrder`|starts a verification block that checks the order for coroutines|
-|`verifySequence`|starts a verification block that checks whether all calls were made in a specified sequence|
-|`coVerifySequence`|starts a verification block that checks whether all calls were made in a specified sequence for coroutines|
-|`excludeRecords`|exclude some calls from being recorded|
-|`confirmVerified`|confirms that all recorded calls were verified|
-|`clearMocks`|clears specified mocks|
-|`registerInstanceFactory`|allows you to redefine the way of instantiation for certain object|
-|`mockkClass`|builds a regular mock by passing the class as parameter|
-|`mockkObject`|turns an object into an object mock, or clears it if was already transformed|
-|`unmockkObject`|turns an object mock back into a regular object|
-|`mockkStatic`|makes a static mock out of a class, or clears it if it was already transformed|
-|`unmockkStatic`|turns a static mock back into a regular class|
-|`clearStaticMockk`|clears a static mock|
-|`mockkConstructor`|makes a constructor mock out of a class, or clears it if it was already transformed|
-|`unmockkConstructor`|turns a constructor mock back into a regular class|
-|`clearConstructorMockk`|clears the constructor mock|
-|`unmockkAll`|unmocks object, static and constructor mocks|
-|`clearAllMocks`|clears regular, object, static and constructor mocks|
+|Function| Description                                                                                                |
+|--------|------------------------------------------------------------------------------------------------------------|
+|`mockk<T>(...)`| builds a regular mock                                                                                      |
+|`spyk<T>()`| builds a spy using the default constructor                                                                 |
+|`spyk(obj)`| builds a spy by copying from `obj`                                                                         |
+|`slot`| creates a capturing slot                                                                                   |
+|`every`| starts a stubbing block                                                                                    |
+|`coEvery`| starts a stubbing block for coroutines                                                                     |
+|`verify`| starts a verification block                                                                                |
+|`coVerify`| starts a verification block for coroutines                                                                 |
+|`verifyAll`| starts a verification block that should include all calls                                                  |
+|`coVerifyAll`| starts a verification block that should include all calls for coroutines                                   |
+|`verifyOrder`| starts a verification block that checks the order                                                          |
+|`coVerifyOrder`| starts a verification block that checks the order for coroutines                                           |
+|`verifySequence`| starts a verification block that checks whether all calls were made in a specified sequence                |
+|`coVerifySequence`| starts a verification block that checks whether all calls were made in a specified sequence for coroutines |
+|`excludeRecords`| exclude some calls from being recorded                                                                     |
+|`confirmVerified`| confirms that all recorded calls were verified                                                             |
+|`checkUnnecessaryStub`| confirms that all recorded calls are used at least once                                                    |
+|`clearMocks`| clears specified mocks                                                                                     |
+|`registerInstanceFactory`| allows you to redefine the way of instantiation for certain object                                         |
+|`mockkClass`| builds a regular mock by passing the class as parameter                                                    |
+|`mockkObject`| turns an object into an object mock, or clears it if was already transformed                               |
+|`unmockkObject`| turns an object mock back into a regular object                                                            |
+|`mockkStatic`| makes a static mock out of a class, or clears it if it was already transformed                             |
+|`unmockkStatic`| turns a static mock back into a regular class                                                              |
+|`clearStaticMockk`| clears a static mock                                                                                       |
+|`mockkConstructor`| makes a constructor mock out of a class, or clears it if it was already transformed                        |
+|`unmockkConstructor`| turns a constructor mock back into a regular class                                                         |
+|`clearConstructorMockk`| clears the constructor mock                                                                                |
+|`unmockkAll`| unmocks object, static and constructor mocks                                                               |
+|`clearAllMocks`| clears regular, object, static and constructor mocks                                                       |
 
 
 ### Matchers

--- a/dsl/common/src/main/kotlin/io/mockk/API.kt
+++ b/dsl/common/src/main/kotlin/io/mockk/API.kt
@@ -279,6 +279,19 @@ object MockKDsl {
     }
 
     /**
+     * Checks if all recorded calls are necessary.
+     */
+    fun internalCheckUnnecessaryStub(vararg mocks: Any) {
+        if (mocks.isEmpty()) {
+            MockKGateway.implementation().verificationAcknowledger.checkUnnecessaryStub()
+        }
+
+        for (mock in mocks) {
+            MockKGateway.implementation().verificationAcknowledger.checkUnnecessaryStub(mock)
+        }
+    }
+
+    /**
      * Resets information associated with mock
      */
     inline fun internalClearMocks(

--- a/dsl/common/src/main/kotlin/io/mockk/GatewayAPI.kt
+++ b/dsl/common/src/main/kotlin/io/mockk/GatewayAPI.kt
@@ -253,6 +253,10 @@ interface MockKGateway {
         fun acknowledgeVerified(mock: Any)
 
         fun acknowledgeVerified()
+
+        fun checkUnnecessaryStub(mock: Any)
+
+        fun checkUnnecessaryStub()
     }
 
     interface MockTypeChecker {

--- a/mockk/common/src/main/kotlin/io/mockk/MockK.kt
+++ b/mockk/common/src/main/kotlin/io/mockk/MockK.kt
@@ -320,6 +320,13 @@ fun confirmVerified(vararg mocks: Any) = MockK.useImpl {
 }
 
 /**
+ * Checks if all recorded calls are necessary.
+ */
+fun checkUnnecessaryStub(vararg mocks: Any) = MockK.useImpl {
+    MockKDsl.internalCheckUnnecessaryStub(*mocks)
+}
+
+/**
  * Resets information associated with specified mocks.
  * To clear all mocks use clearAllMocks.
  */

--- a/mockk/common/src/main/kotlin/io/mockk/impl/stub/ConstructorStub.kt
+++ b/mockk/common/src/main/kotlin/io/mockk/impl/stub/ConstructorStub.kt
@@ -77,6 +77,8 @@ class ConstructorStub(
             it.substitute(revertRepresentation)
         }
 
+    override fun matcherUsages() = stub.matcherUsages()
+
     override fun clear(options: MockKGateway.ClearOptions) =
         stub.clear(options)
 

--- a/mockk/common/src/main/kotlin/io/mockk/impl/stub/Stub.kt
+++ b/mockk/common/src/main/kotlin/io/mockk/impl/stub/Stub.kt
@@ -28,6 +28,8 @@ interface Stub : Disposable {
 
     fun verifiedCalls(): List<Invocation>
 
+    fun matcherUsages(): Map<InvocationMatcher, Int>
+
     fun clear(options: MockKGateway.ClearOptions)
 
     fun handleInvocation(

--- a/mockk/jvm/api/mockk-jvm.api
+++ b/mockk/jvm/api/mockk-jvm.api
@@ -1133,6 +1133,9 @@ public final class io/mockk/junit5/MockKExtension$Companion {
 public abstract interface annotation class io/mockk/junit5/MockKExtension$ConfirmVerification : java/lang/annotation/Annotation {
 }
 
+public abstract interface annotation class io/mockk/junit5/MockKExtension$CheckUnnecessaryStub : java/lang/annotation/Annotation {
+}
+
 public abstract interface annotation class io/mockk/junit5/MockKExtension$KeepMocks : java/lang/annotation/Annotation {
 }
 

--- a/mockk/jvm/src/test/kotlin/io/mockk/it/VerificationAcknowledgeTest.kt
+++ b/mockk/jvm/src/test/kotlin/io/mockk/it/VerificationAcknowledgeTest.kt
@@ -75,6 +75,7 @@ class VerificationAcknowledgeTest {
 
     @Test
     fun `checkUnnecessaryStubAll with single call to each stub`() {
+        clearAllMocks() // ensure that previous tests haven't created unnecessary stubs
         doCalls1()
         val mock2 = mockk<MockCls>()
         every { mock2.op(98) } returns 1
@@ -84,6 +85,7 @@ class VerificationAcknowledgeTest {
 
     @Test
     fun `checkUnnecessaryStubAll with some used and some unused stubs`() {
+        clearAllMocks() // ensure that previous tests haven't created unnecessary stubs
         doCalls1()
         val mock2 = mockk<MockCls> { every { op(42) } returns 1 }
         assertFailsWith<AssertionError> {


### PR DESCRIPTION
[Automatic verification confirmation](https://github.com/mockk/mockk#automatic-verification-confirmation) introduces a new mechanism that ensure that all declared stubs are verified. This is cool but doesn't exactly match which is requested in #558 and exposed in [mockito doc](http://site.mockito.org/javadoc/current/index.html?org/mockito/exceptions/misusing/UnnecessaryStubbingException.html)

This PR add a new `checkUnnecessaryStub()` method, and its companion JUnit annotion `@CheckUnnecessaryStub`.

The main usecase of this feature is to avoid the `verify` steps when all stubs are done with precision and every stubs are used only once.