### PR TITLE
Add kotlin 1.7.0 to the versions testing matrix

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         java-version: [11, 12, 13, 14, 15, 16, 17]
-        kotlin-version: [1.4.32, 1.5.31, 1.6.0]
+        kotlin-version: [1.4.32, 1.5.31, 1.6.0, 1.7.0]
         kotlin-ir-enabled: [true, false]
         exclude:
           - kotlin-version: 1.4.32


### PR DESCRIPTION
Creating the PR to validate that there is a problem with kotlin 1.7.0.