### PR TITLE
bump kotlin 1.7.10, and language level to 1.5

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -11,13 +11,8 @@ jobs:
     strategy:
       matrix:
         java-version: [11, 12, 13, 14, 15, 16, 17]
-        kotlin-version: [1.4.32, 1.5.31, 1.6.0]
+        kotlin-version: [1.5.31, 1.6.0, 1.7.10]
         kotlin-ir-enabled: [true, false]
-        exclude:
-          - kotlin-version: 1.4.32
-            java-version: 16
-          - kotlin-version: 1.4.32
-            java-version: 17
       # in case one JDK fails, we still want to see results from others
       fail-fast: false
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ![mockk](doc/logo-site.png) ![kotlin](doc/kotlin-logo.png)
 
 [![Gitter](https://badges.gitter.im/mockk-io/Lobby.svg)](https://gitter.im/mockk-io/Lobby?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=body_badge) 
-[![Relase Version](https://img.shields.io/maven-central/v/io.mockk/mockk.svg?label=release)](http://search.maven.org/#search%7Cga%7C1%7Cmockk)
+[![Relase Version](https://img.shields.io/maven-central/v/io.mockk/mockk.svg?label=release)](https://search.maven.org/#search%7Cga%7C1%7Cmockk)
 [![Change log](https://img.shields.io/badge/change%20log-%E2%96%A4-yellow.svg)](https://github.com/mockk/mockk/releases)
 [![codecov](https://codecov.io/gh/mockk/mockk/branch/master/graph/badge.svg)](https://codecov.io/gh/mockk/mockk) 
 [![Android](https://img.shields.io/badge/android-support-green.svg)](https://mockk.io/ANDROID)
@@ -1397,7 +1397,7 @@ This project exists thanks to all the people who contribute.
 To ask questions, please use Stack Overflow or Gitter.
 
 * Chat/Gitter: [https://gitter.im/mockk-io/Lobby](https://gitter.im/mockk-io/Lobby)
-* Stack Overflow: [http://stackoverflow.com/questions/tagged/mockk](http://stackoverflow.com/questions/tagged/mockk)
+* Stack Overflow: [http://stackoverflow.com/questions/tagged/mockk](https://stackoverflow.com/questions/tagged/mockk)
 
 To report bugs, please use the GitHub project.
 

--- a/agent/jvm/api/mockk-agent-jvm.api
+++ b/agent/jvm/api/mockk-agent-jvm.api
@@ -73,7 +73,7 @@ public final class io/mockk/proxy/jvm/advice/jvm/SynchronizedMockHandlersMap : i
 	public final fun containsValue (Ljava/lang/Object;)Z
 	public final fun entrySet ()Ljava/util/Set;
 	public fun get (Ljava/lang/Object;)Lio/mockk/proxy/MockKInvocationHandler;
-	public final fun get (Ljava/lang/Object;)Ljava/lang/Object;
+	public synthetic fun get (Ljava/lang/Object;)Ljava/lang/Object;
 	public fun getEntries ()Ljava/util/Set;
 	public fun getKeys ()Ljava/util/Set;
 	public fun getSize ()I
@@ -85,7 +85,7 @@ public final class io/mockk/proxy/jvm/advice/jvm/SynchronizedMockHandlersMap : i
 	public synthetic fun put (Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;
 	public fun putAll (Ljava/util/Map;)V
 	public fun remove (Ljava/lang/Object;)Lio/mockk/proxy/MockKInvocationHandler;
-	public final fun remove (Ljava/lang/Object;)Ljava/lang/Object;
+	public synthetic fun remove (Ljava/lang/Object;)Ljava/lang/Object;
 	public final fun size ()I
 	public final fun values ()Ljava/util/Collection;
 }
@@ -99,7 +99,7 @@ public final class io/mockk/proxy/jvm/advice/jvm/WeakMockHandlersMap : io/mockk/
 	public final fun containsValue (Ljava/lang/Object;)Z
 	public final fun entrySet ()Ljava/util/Set;
 	public fun get (Ljava/lang/Object;)Lio/mockk/proxy/MockKInvocationHandler;
-	public final fun get (Ljava/lang/Object;)Ljava/lang/Object;
+	public synthetic fun get (Ljava/lang/Object;)Ljava/lang/Object;
 	public fun getEntries ()Ljava/util/Set;
 	public fun getKeys ()Ljava/util/Set;
 	public fun getSize ()I
@@ -111,7 +111,7 @@ public final class io/mockk/proxy/jvm/advice/jvm/WeakMockHandlersMap : io/mockk/
 	public synthetic fun put (Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;
 	public fun putAll (Ljava/util/Map;)V
 	public fun remove (Ljava/lang/Object;)Lio/mockk/proxy/MockKInvocationHandler;
-	public final fun remove (Ljava/lang/Object;)Ljava/lang/Object;
+	public synthetic fun remove (Ljava/lang/Object;)Ljava/lang/Object;
 	public final fun size ()I
 	public final fun values ()Ljava/util/Collection;
 }

--- a/build.gradle
+++ b/build.gradle
@@ -40,8 +40,8 @@ subprojects { subProject ->
     tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
         kotlinOptions {
             jvmTarget = "1.8"
-            apiVersion = "1.7"
-            languageVersion = "1.7"
+            apiVersion = "1.5"
+            languageVersion = "1.5"
         }
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -29,7 +29,7 @@ plugins {
 subprojects { subProject ->
     group = 'io.mockk'
 
-    ext.kotlin_version = findProperty('kotlin.version')?.toString() ?: '1.6.0'
+    ext.kotlin_version = findProperty('kotlin.version')?.toString() ?: '1.7.10'
     ext.kotlin_gradle_version = findProperty('kotlin.version')?.toString() ?: '1.6.0'
 
     repositories {
@@ -40,9 +40,8 @@ subprojects { subProject ->
     tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
         kotlinOptions {
             jvmTarget = "1.8"
-            apiVersion = "1.4"
-            languageVersion = "1.4"
-            useIR = findProperty("kotlin.ir.enabled")?.toBoolean() == true
+            apiVersion = "1.7"
+            languageVersion = "1.7"
         }
     }
 }

--- a/dsl/common/src/main/kotlin/io/mockk/MockKSettings.kt
+++ b/dsl/common/src/main/kotlin/io/mockk/MockKSettings.kt
@@ -19,7 +19,7 @@ enum class StackTracesAlignment {
 
 fun stackTracesAlignmentValueOf(property: String): StackTracesAlignment {
     return try {
-        enumValueOf(property.toUpperCase())
+        enumValueOf(property.uppercase())
     } catch (e: IllegalArgumentException) {
         StackTracesAlignment.CENTER
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,4 +4,4 @@ org.gradle.configureondemand=false
 org.gradle.jvmargs=-XX:MaxMetaspaceSize=768m
 # localrepo=build/mockk-repo
 localrepo=/Users/raibaz/.m2/repository
-# kotlin.version=1.5.10
+kotlin.version=1.7.10

--- a/gradle/upload.gradle
+++ b/gradle/upload.gradle
@@ -28,7 +28,7 @@ afterEvaluate {
                 pom {
                     name = mavenName
                     description = mavenDescription
-                    url = 'http://mockk.io'
+                    url = 'https://mockk.io'
 
                     scm {
                         connection = 'scm:git:git@github.com:mockk/mockk.git'
@@ -52,7 +52,7 @@ afterEvaluate {
                     licenses {
                         license {
                             name = 'Apache License, Version 2.0'
-                            url = 'http://www.apache.org/licenses/LICENSE-2.0'
+                            url = 'https://www.apache.org/licenses/LICENSE-2.0'
                         }
                     }
                 }

--- a/mockk/common/src/main/kotlin/io/mockk/MockK.kt
+++ b/mockk/common/src/main/kotlin/io/mockk/MockK.kt
@@ -342,7 +342,7 @@ fun clearMocks(
     MockK.useImpl {
         MockKDsl.internalClearMocks(
             firstMock = firstMock,
-            mocks = *mocks,
+            mocks = mocks,
             answers = answers,
             recordedCalls = recordedCalls,
             childMocks = childMocks,

--- a/mockk/common/src/main/kotlin/io/mockk/impl/recording/PermanentMocker.kt
+++ b/mockk/common/src/main/kotlin/io/mockk/impl/recording/PermanentMocker.kt
@@ -138,7 +138,7 @@ class PermanentMocker(
             args.isEmpty()
         ) {
             return prefix +
-                    methodName[3].toLowerCase() +
+                    methodName[3].lowercase() +
                     methodName.substring(4)
         }
 

--- a/mockk/common/src/main/kotlin/io/mockk/impl/recording/states/StubbingAwaitingAnswerState.kt
+++ b/mockk/common/src/main/kotlin/io/mockk/impl/recording/states/StubbingAwaitingAnswerState.kt
@@ -71,5 +71,5 @@ class StubbingAwaitingAnswerState(recorder: CommonCallRecorder) : CallRecordingS
         }
     }
 
-    private fun String.toCamelCase() = if (isEmpty()) this else substring(0, 1).toLowerCase() + substring(1)
+    private fun String.toCamelCase() = if (isEmpty()) this else substring(0, 1).lowercase() + substring(1)
 }

--- a/mockk/common/src/main/kotlin/io/mockk/impl/recording/states/VerifyingState.kt
+++ b/mockk/common/src/main/kotlin/io/mockk/impl/recording/states/VerifyingState.kt
@@ -54,18 +54,13 @@ class VerifyingState(
     }
 
     private fun failIfNotPassed(outcome: VerificationResult, inverse: Boolean) {
-        if (inverse) {
-            when (outcome) {
-                is VerificationResult.OK      -> {
-                    val callsReport = VerificationHelpers.formatCalls(outcome.verifiedCalls)
-                    throw AssertionError("Inverse verification failed.\n\nVerified calls:\n$callsReport")
-                }
-                is VerificationResult.Failure -> {}
+        when (outcome) {
+            is VerificationResult.OK -> if (inverse) {
+                val callsReport = VerificationHelpers.formatCalls(outcome.verifiedCalls)
+                throw AssertionError("Inverse verification failed.\n\nVerified calls:\n$callsReport")
             }
-        } else {
-            when (outcome) {
-                is VerificationResult.Failure -> throw AssertionError("Verification failed: ${outcome.message}")
-                is VerificationResult.OK      -> {}
+            is VerificationResult.Failure -> if (!inverse) {
+                throw AssertionError("Verification failed: ${outcome.message}")
             }
         }
     }

--- a/mockk/common/src/main/kotlin/io/mockk/impl/recording/states/VerifyingState.kt
+++ b/mockk/common/src/main/kotlin/io/mockk/impl/recording/states/VerifyingState.kt
@@ -92,14 +92,11 @@ class VerifyingState(
             if (calledStubs.size == 1) {
                 val calledStub = calledStubs[0]
                 throw AssertionError(recorder.safeExec {
-                    "Verification failed: ${calledStub.toStr()} should not be called:\n" +
-                        calledStub.allRecordedCalls().joinToString("\n")
+                    "Verification failed: ${calledStub.toStr()} should not be called:\n" + calledStub.allRecordedCalls().joinToString("\n")
                 })
             } else {
                 throw AssertionError(recorder.safeExec {
-                    "Verification failed: ${
-                        calledStubs.map { it.toStr() }.joinToString(", ")
-                    } should not be called:\n" +
+                    "Verification failed: ${calledStubs.joinToString(", ") { it.toStr() }} should not be called:\n" +
                         calledStubs.flatMap { it.allRecordedCalls() }.joinToString("\n")
                 })
             }

--- a/mockk/common/src/main/kotlin/io/mockk/impl/recording/states/VerifyingState.kt
+++ b/mockk/common/src/main/kotlin/io/mockk/impl/recording/states/VerifyingState.kt
@@ -60,10 +60,12 @@ class VerifyingState(
                     val callsReport = VerificationHelpers.formatCalls(outcome.verifiedCalls)
                     throw AssertionError("Inverse verification failed.\n\nVerified calls:\n$callsReport")
                 }
+                is VerificationResult.Failure -> {}
             }
         } else {
             when (outcome) {
                 is VerificationResult.Failure -> throw AssertionError("Verification failed: ${outcome.message}")
+                is VerificationResult.OK -> {}
             }
         }
     }
@@ -86,17 +88,19 @@ class VerifyingState(
             }
         }
 
-        if (!calledStubs.isEmpty()) {
+        if (calledStubs.isNotEmpty()) {
             if (calledStubs.size == 1) {
                 val calledStub = calledStubs[0]
                 throw AssertionError(recorder.safeExec {
                     "Verification failed: ${calledStub.toStr()} should not be called:\n" +
-                            calledStub.allRecordedCalls().joinToString("\n")
+                        calledStub.allRecordedCalls().joinToString("\n")
                 })
             } else {
                 throw AssertionError(recorder.safeExec {
-                    "Verification failed: ${calledStubs.map { it.toStr() }.joinToString(", ")} should not be called:\n" +
-                            calledStubs.flatMap { it.allRecordedCalls() }.joinToString("\n")
+                    "Verification failed: ${
+                        calledStubs.map { it.toStr() }.joinToString(", ")
+                    } should not be called:\n" +
+                        calledStubs.flatMap { it.allRecordedCalls() }.joinToString("\n")
                 })
             }
         }

--- a/mockk/common/src/main/kotlin/io/mockk/impl/recording/states/VerifyingState.kt
+++ b/mockk/common/src/main/kotlin/io/mockk/impl/recording/states/VerifyingState.kt
@@ -56,7 +56,7 @@ class VerifyingState(
     private fun failIfNotPassed(outcome: VerificationResult, inverse: Boolean) {
         if (inverse) {
             when (outcome) {
-                is VerificationResult.OK -> {
+                is VerificationResult.OK      -> {
                     val callsReport = VerificationHelpers.formatCalls(outcome.verifiedCalls)
                     throw AssertionError("Inverse verification failed.\n\nVerified calls:\n$callsReport")
                 }
@@ -65,7 +65,7 @@ class VerifyingState(
         } else {
             when (outcome) {
                 is VerificationResult.Failure -> throw AssertionError("Verification failed: ${outcome.message}")
-                is VerificationResult.OK -> {}
+                is VerificationResult.OK      -> {}
             }
         }
     }
@@ -92,7 +92,8 @@ class VerifyingState(
             if (calledStubs.size == 1) {
                 val calledStub = calledStubs[0]
                 throw AssertionError(recorder.safeExec {
-                    "Verification failed: ${calledStub.toStr()} should not be called:\n" + calledStub.allRecordedCalls().joinToString("\n")
+                    "Verification failed: ${calledStub.toStr()} should not be called:\n" +
+                        calledStub.allRecordedCalls().joinToString("\n")
                 })
             } else {
                 throw AssertionError(recorder.safeExec {

--- a/mockk/jvm/src/main/kotlin/io/mockk/impl/InternalPlatform.kt
+++ b/mockk/jvm/src/main/kotlin/io/mockk/impl/InternalPlatform.kt
@@ -159,7 +159,7 @@ actual object InternalPlatform {
 
     fun isRunningAndroidInstrumentationTest(): Boolean {
         return System.getProperty("java.vendor", "")
-            .toLowerCase(Locale.US)
+            .lowercase(Locale.US)
             .contains("android")
     }
 

--- a/plugins/dependencies/src/main/kotlin/io/mockk/dependencies/Deps.kt
+++ b/plugins/dependencies/src/main/kotlin/io/mockk/dependencies/Deps.kt
@@ -8,7 +8,7 @@ object Deps {
     object Versions {
         const val androidTools = "4.1.1"
         const val dokka = "1.6.0"
-        const val kotlinDefault = "1.6.0"
+        const val kotlinDefault = "1.7.10"
         const val coroutines = "1.3.3"
         const val slfj = "1.7.32"
         const val logback = "1.2.10"


### PR DESCRIPTION
This PR updates the version of Kotlin to the latest version, 1.7.10.

~I also set the API and language levels to 1.7. I have NO idea if this is the best choice! On one hand, I think it's best to 'go big or go home' - this kind of change only needs to be done once, and now mockk is at a high language level that will be available for years. On the other hand, perhaps maintaining and providing as wide compatibility is best.~ discussed below, will bump to 1.5

I'm making this change to help work related to supporting value classes - see #152 and #849 

### Summary

* bumped Kotlin to 1.7.10
* bumped Kotlin language & API levels to 1.5 
* regenerated binary-compatibility API specs
* updated the GitHub action matrix to remove 1.4 and add 1.7
* minor Kotlin migrations
  * `toUpperCase()` -> `uppercase()`, `toLowerCase()` -> `lowercase()`
  * made a couple of `when` branches exhaustive
* As a minor change, I also converted some `http` URLs in the docs to `https`, since I spotted them.