### PR TITLE
Update 'all tests' GitHub action, enable Gradle Build Cache

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -10,9 +10,9 @@ jobs:
   tests:
     strategy:
       matrix:
-        java-version: [11, 12, 13, 14, 15, 16, 17]
-        kotlin-version: [1.5.31, 1.6.0, 1.7.10]
-        kotlin-ir-enabled: [true, false]
+        java-version: [ 11, 17, 18 ] # test LTS versions, and the newest
+        kotlin-version: [ 1.5.31, 1.6.21, 1.7.10 ]
+        kotlin-ir-enabled: [ true, false ]
       # in case one JDK fails, we still want to see results from others
       fail-fast: false
     runs-on: ubuntu-latest

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -22,14 +22,21 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/cache@v2
+
+      # Cache Gradle dependencies
+      - name: Setup Gradle Dependencies Cache
+        uses: actions/cache@v3
         with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-          key: ${{ runner.os }}-${{ matrix.java-version }}-${{ matrix.kotlin-version }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
-          restore-keys: |
-            ${{ runner.os }}-${{ matrix.java-version }}-gradle-
+          path: ~/.gradle/caches
+          key: ${{ runner.os }}-gradle-caches-${{ hashFiles('**/*.gradle', '**/*.gradle.kts') }}
+
+      # Cache Gradle Wrapper
+      - name: Setup Gradle Wrapper Cache
+        uses: actions/cache@v3
+        with:
+          path: ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-wrapper-${{ hashFiles('**/gradle/wrapper/gradle-wrapper.properties') }}
+
       - name: Set up JDK ${{ matrix.java-version }}
         uses: actions/setup-java@v1
         with:

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -18,25 +18,25 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/cache@v2
-      with:
-        path: |
-          ~/.gradle/caches
-          ~/.gradle/wrapper
-        key: ${{ runner.os }}-${{ matrix.java-version }}-${{ matrix.kotlin-version }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
-        restore-keys: |
-          ${{ runner.os }}-${{ matrix.java-version }}-gradle-
-    - name: Set up JDK ${{ matrix.java-version }}
-      uses: actions/setup-java@v1
-      with:
-        java-version: ${{ matrix.java-version }}
-    - name: Grant execute permission for gradlew
-      run: chmod +x gradlew
-    - name: Run tests with Gradle
-      uses: eskatos/gradle-command-action@v1
-      with:
-        arguments: test --stacktrace -Pkotlin.version=${{ matrix.kotlin-version }} -Pkotlin.ir.enabled=${{ matrix.kotlin-ir-enabled }}
+      - uses: actions/checkout@v2
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-${{ matrix.java-version }}-${{ matrix.kotlin-version }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ matrix.java-version }}-gradle-
+      - name: Set up JDK ${{ matrix.java-version }}
+        uses: actions/setup-java@v1
+        with:
+          java-version: ${{ matrix.java-version }}
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+      - name: Run tests with Gradle
+        uses: eskatos/gradle-command-action@v1
+        with:
+          arguments: test --stacktrace -Pkotlin.version=${{ matrix.kotlin-version }} -Pkotlin.ir.enabled=${{ matrix.kotlin-ir-enabled }}
   android-instrumented-tests:
     runs-on: macos-latest
     strategy:
@@ -61,4 +61,3 @@ jobs:
         with:
           api-level: ${{ matrix.api-level }}
           script: ./gradlew connectedCheck
-

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [ master ]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   tests:
     strategy:
@@ -16,11 +20,6 @@ jobs:
       # in case one JDK fails, we still want to see results from others
       fail-fast: false
     runs-on: ubuntu-latest
-
-    concurrency:
-      group: ${{ github.ref }}
-      cancel-in-progress: true
-
     steps:
       - uses: actions/checkout@v2
       - uses: actions/cache@v2
@@ -41,6 +40,7 @@ jobs:
         uses: eskatos/gradle-command-action@v1
         with:
           arguments: test --stacktrace -Pkotlin.version=${{ matrix.kotlin-version }} -Pkotlin.ir.enabled=${{ matrix.kotlin-ir-enabled }}
+
   android-instrumented-tests:
     runs-on: macos-latest
     strategy:

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -17,6 +17,10 @@ jobs:
       fail-fast: false
     runs-on: ubuntu-latest
 
+    concurrency:
+      group: ${{ github.ref }}
+      cancel-in-progress: true
+
     steps:
       - uses: actions/checkout@v2
       - uses: actions/cache@v2

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -6,8 +6,9 @@ on:
   pull_request:
     branches: [ master ]
 
+# This allows a subsequently queued workflow run to interrupt previous runs
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}'
   cancel-in-progress: true
 
 jobs:
@@ -23,14 +24,12 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      # Cache Gradle dependencies
       - name: Setup Gradle Dependencies Cache
         uses: actions/cache@v3
         with:
           path: ~/.gradle/caches
           key: ${{ runner.os }}-gradle-caches-${{ hashFiles('**/*.gradle', '**/*.gradle.kts') }}
 
-      # Cache Gradle Wrapper
       - name: Setup Gradle Wrapper Cache
         uses: actions/cache@v3
         with:
@@ -59,14 +58,19 @@ jobs:
           distribution: 'adopt'
           java-version: '11'
       - uses: actions/checkout@v2
-      - uses: actions/cache@v2
+
+      - name: Setup Gradle Dependencies Cache
+        uses: actions/cache@v3
         with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-          key: ${{ runner.os }}-${{ matrix.api-level }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
-          restore-keys: |
-            ${{ runner.os }}-${{ matrix.api-level }}-gradle-
+          path: ~/.gradle/caches
+          key: ${{ runner.os }}-gradle-caches-${{ hashFiles('**/*.gradle', '**/*.gradle.kts') }}
+
+      - name: Setup Gradle Wrapper Cache
+        uses: actions/cache@v3
+        with:
+          path: ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-wrapper-${{ hashFiles('**/gradle/wrapper/gradle-wrapper.properties') }}
+
       - name: run tests
         uses: reactivecircus/android-emulator-runner@v2
         with:

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -13,6 +13,7 @@ concurrency:
 
 jobs:
   tests:
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         java-version: [ 11, 17, 18 ] # test LTS versions, and the newest
@@ -20,7 +21,7 @@ jobs:
         kotlin-ir-enabled: [ true, false ]
       # in case one JDK fails, we still want to see results from others
       fail-fast: false
-    runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v2
 
@@ -52,6 +53,7 @@ jobs:
     strategy:
       matrix:
         api-level: [ 28, 29 ]
+    timeout-minutes: 30
     steps:
       - uses: actions/setup-java@v2
         with:

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,10 @@
 version=1.12.5-SNAPSHOT
-org.gradle.parallel=true
+# Enable Gradle build cache https://docs.gradle.org/current/userguide/build_cache.html
+org.gradle.caching=true
 org.gradle.configureondemand=false
+org.gradle.parallel=true
+# disable annoying Gradle Welcome in CI/CD
+org.gradle.welcome=never
 org.gradle.jvmargs=-XX:MaxMetaspaceSize=768m
 # localrepo=build/mockk-repo
 localrepo=/Users/raibaz/.m2/repository


### PR DESCRIPTION
This PR contains some proposals for improving the 'all tests' GitHub action. I hope to make them faster.

I'm making a PR before an issue to test/demo that it works as intended :)

* Only test LTS JDK versions (11, 17), plus the latest version (18 at the moment - this can change more frequently). I'm making an assumption here that there's not going to be major differences between the non-LTS versions, and even if there are, as far as I know they're not well supported. 

   Reducing the number of versions improves the actions speed, as I think there's a limit on how many jobs can run in parallel.
   
* Add 'concurrency'. I've noticed when I've pushed a few changes in rapid succession, each change will be tested. This isn't necessary - the tests should be cancelled and restarted if there's a newer commit. 
   
   I copied the concurrency config from here: https://docs.github.com/en/actions/examples/using-concurrency-expressions-and-a-test-matrix#understanding-the-example

* I bumped Kotlin 1.6.0 to 1.6.21. It seemed odd that 1.5 and 1.7 were on the latest version, but 1.6 wasn't.

* I updated the Gradle caching, copied from 

   https://github.com/JetBrains/intellij-platform-plugin-template/actions/runs/242898088/workflow#L46-L58

   This means the cache key is less specific (I think sharing the Gradle cache between Kotlin & JVM versions is fine, Gradle will rebuild/reuse tasks if necessary), and the wrapper and dependencies are cached separately (if the dependencies change, the wrapper can still be cached)

* I enabled [Gradle Build cache](https://docs.gradle.org/current/userguide/build_cache.html). This should really help build speeds.