### PR TITLE
Fix unmockkAll to work if constructor was mocked multiple times

### DIFF
--- a/dsl/common/src/main/kotlin/io/mockk/API.kt
+++ b/dsl/common/src/main/kotlin/io/mockk/API.kt
@@ -526,7 +526,7 @@ object MockKDsl {
 
             MockKCancellationRegistry
                 .subRegistry(MockKCancellationRegistry.Type.CONSTRUCTOR)
-                .putIfNotThere(it, cancellation)
+                .cancelPut(it, cancellation)
         }
     }
 
@@ -2300,13 +2300,6 @@ object MockKCancellationRegistry {
             val map = mapTl.value
             map.remove(key)?.invoke()
             map[key] = newCancellation
-        }
-
-        fun putIfNotThere(key: Any, newCancellation: MockKCancellation) {
-            val map = mapTl.value
-            if (!map.containsKey(key)) {
-                map[key] = newCancellation
-            }
         }
 
         fun cancelAll() {

--- a/mockk/common/src/test/kotlin/io/mockk/it/ConstructorMockTest.kt
+++ b/mockk/common/src/test/kotlin/io/mockk/it/ConstructorMockTest.kt
@@ -9,11 +9,6 @@ class ConstructorMockTest {
         val exampleProperty: Int = 1
     }
 
-    object ExampleObject {
-        private val exampleClass = ExampleClass()
-        fun getExampleProperty(): Int = exampleClass.exampleProperty
-    }
-
     data class MockCls(private val x: Int = 0) {
 
         constructor(x: String) : this(x.toInt())
@@ -31,16 +26,21 @@ class ConstructorMockTest {
 
         every { anyConstructed<ExampleClass>().exampleProperty } returns 0
 
-        assertEquals(0, ExampleObject.getExampleProperty())
+        assertEquals(0, ExampleClass().exampleProperty)
     }
 
     @Test
-    fun test2() {
+    fun unmockkAllTest() {
+        mockkConstructor(ExampleClass::class)
         mockkConstructor(ExampleClass::class)
 
         every { anyConstructed<ExampleClass>().exampleProperty } returns 0
 
-        assertEquals(0, ExampleObject.getExampleProperty())
+        assertEquals(0, ExampleClass().exampleProperty)
+
+        unmockkAll()
+
+        assertEquals(1, ExampleClass().exampleProperty)
     }
 
     @Test


### PR DESCRIPTION
Hi all! 

This PR is to fix the Issue #838 

I changed `internalMockkConstructor` to work like `internalMockkObject` and `internalMockkStatic` by changing it to use `cancelPut`

I added a new test but I had to remove `test2`.
I'm unsure what exactly they test, but with my change the mocked instance in `ExampleObject` `private val exampleClass` is reset once mockkConstructor is called again in test2. And since it's in an object which is not reset between test1 and test2, test2 fails because it is not re-instantiated with the mocked class. 

