### PR TITLE
only sign if the signing properties are present

### DIFF
--- a/buildSrc/src/main/kotlin/buildsrc/convention/mockk-publishing.gradle.kts
+++ b/buildSrc/src/main/kotlin/buildsrc/convention/mockk-publishing.gradle.kts
@@ -72,7 +72,9 @@ publishing {
 
         artifact(tasks.provider<Jar>("javadocJar"))
 
-        signing.sign(this)
+        if (signingKeyId.isPresent() && signingKey.isPresent() && signingPassword.isPresent()) {
+            signing.sign(this)
+        }
     }
 }
 


### PR DESCRIPTION
Quick fix to allow for publishing to Maven Local without having the signing properties set up.

This was useful here: https://github.com/mockk/mockk/issues/883#issuecomment-1223585788