### PR TITLE
Update android-sdk-detector.settings.gradle.kts

### DIFF
--- a/buildSrc/android-sdk-detector.settings.gradle.kts
+++ b/buildSrc/android-sdk-detector.settings.gradle.kts
@@ -33,6 +33,7 @@ if (sdkDirFile != null) {
     ) {
         val path = sdkDirFile.canonicalPath
         props.setProperty(sdkDirProperty, path)
+        logger.info("updated $sdkDirProperty in $path")
     }
 } else {
     androidSdkDetected = false


### PR DESCRIPTION
I got a weird error in this file when running any Gradle command when `local.properties` isn't set, but `ANDROID_HOME` is.

```none
[android-sdk-detector] Android SDK detected: /usr/local/share/android-commandlinetools

FAILURE: Build failed with an exception.

* Where:
Script '.../mockk/buildSrc/android-sdk-detector.settings.gradle.kts' line: 35

* What went wrong:
class java.lang.String cannot be cast to class kotlin.Unit (java.lang.String is in module java.base of loader 'bootstrap'; kotlin.Unit is in unnamed module of loader org.gradle.internal.classloader.VisitableURLClassLoader @39c0f4a)
```

I guess for some reason Gradle wants the script to return Unit, but instead it returns a String (the result of `props.setProperty(...)`)?

Here's a quick fix. 
