### PR TITLE
Fix an issue that Android libraries was not published

### DIFF
--- a/buildSrc/src/main/kotlin/buildsrc/convention/android-library.gradle.kts
+++ b/buildSrc/src/main/kotlin/buildsrc/convention/android-library.gradle.kts
@@ -1,7 +1,5 @@
 package buildsrc.convention
 
-import org.gradle.jvm.tasks.Jar
-
 plugins {
     id("com.android.library")
 

--- a/buildSrc/src/main/kotlin/buildsrc/convention/mockk-publishing.gradle.kts
+++ b/buildSrc/src/main/kotlin/buildsrc/convention/mockk-publishing.gradle.kts
@@ -80,7 +80,7 @@ publishing {
             description.set(provider { mavenDescription })
         }
 
-        artifact(tasks.provider<Task>("javadocJar"))
+        artifact(tasks.provider<Jar>("javadocJar"))
 
         signing.sign(this)
     }

--- a/buildSrc/src/main/kotlin/buildsrc/convention/mockk-publishing.gradle.kts
+++ b/buildSrc/src/main/kotlin/buildsrc/convention/mockk-publishing.gradle.kts
@@ -64,13 +64,23 @@ publishing {
             }
         }*/
     }
+    // Configure for Android libraries
+    publications {
+        if (project.extensions.findByName("android") != null) {
+            register<MavenPublication>("release") {
+                afterEvaluate {
+                    from(components["release"])
+                }
+            }
+        }
+    }
     publications.withType<MavenPublication>().configureEach {
         createMockKPom {
             name.set(provider { mavenName })
             description.set(provider { mavenDescription })
         }
 
-        artifact(tasks.provider<Jar>("javadocJar"))
+        artifact(tasks.provider<Task>("javadocJar"))
 
         signing.sign(this)
     }


### PR DESCRIPTION
Fixes: https://github.com/mockk/mockk/issues/883

The official Android documentation about publications is [here](https://developer.android.com/studio/publish-library/upload-library#create-pub).

I confirmed that `mockk-android` is published with the following command.

```
$ ./gradlew publishToMavenLocal
$ tree ~/.m2/repository/io/mockk/
~/.m2/repository/io/mockk
├── mockk
│   ├── 1.12.7-SNAPSHOT
│   │   ├── maven-metadata-local.xml
│   │   ├── mockk-1.12.7-SNAPSHOT-javadoc.jar
│   │   ├── mockk-1.12.7-SNAPSHOT-kotlin-tooling-metadata.json
│   │   ├── mockk-1.12.7-SNAPSHOT-sources.jar
│   │   ├── mockk-1.12.7-SNAPSHOT.jar
│   │   ├── mockk-1.12.7-SNAPSHOT.module
│   │   └── mockk-1.12.7-SNAPSHOT.pom
│   └── maven-metadata-local.xml
├── mockk-agent
│   ├── 1.12.7-SNAPSHOT
│   │   ├── maven-metadata-local.xml
│   │   ├── mockk-agent-1.12.7-SNAPSHOT-javadoc.jar
│   │   ├── mockk-agent-1.12.7-SNAPSHOT-kotlin-tooling-metadata.json
│   │   ├── mockk-agent-1.12.7-SNAPSHOT-sources.jar
│   │   ├── mockk-agent-1.12.7-SNAPSHOT.jar
│   │   ├── mockk-agent-1.12.7-SNAPSHOT.module
│   │   └── mockk-agent-1.12.7-SNAPSHOT.pom
│   └── maven-metadata-local.xml
├── mockk-agent-android
│   ├── 1.12.7-SNAPSHOT
│   │   ├── maven-metadata-local.xml
│   │   ├── mockk-agent-android-1.12.7-SNAPSHOT-javadoc.jar
│   │   ├── mockk-agent-android-1.12.7-SNAPSHOT.aar
│   │   ├── mockk-agent-android-1.12.7-SNAPSHOT.module
│   │   └── mockk-agent-android-1.12.7-SNAPSHOT.pom
│   └── maven-metadata-local.xml
├── mockk-agent-api
│   ├── 1.12.7-SNAPSHOT
│   │   ├── maven-metadata-local.xml
│   │   ├── mockk-agent-api-1.12.7-SNAPSHOT-javadoc.jar
│   │   ├── mockk-agent-api-1.12.7-SNAPSHOT-kotlin-tooling-metadata.json
│   │   ├── mockk-agent-api-1.12.7-SNAPSHOT-sources.jar
│   │   ├── mockk-agent-api-1.12.7-SNAPSHOT.jar
│   │   ├── mockk-agent-api-1.12.7-SNAPSHOT.module
│   │   └── mockk-agent-api-1.12.7-SNAPSHOT.pom
│   └── maven-metadata-local.xml
├── mockk-agent-api-jvm
│   ├── 1.12.7-SNAPSHOT
│   │   ├── maven-metadata-local.xml
│   │   ├── mockk-agent-api-jvm-1.12.7-SNAPSHOT-javadoc.jar
│   │   ├── mockk-agent-api-jvm-1.12.7-SNAPSHOT-sources.jar
│   │   ├── mockk-agent-api-jvm-1.12.7-SNAPSHOT.jar
│   │   ├── mockk-agent-api-jvm-1.12.7-SNAPSHOT.module
│   │   └── mockk-agent-api-jvm-1.12.7-SNAPSHOT.pom
│   └── maven-metadata-local.xml
├── mockk-agent-jvm
│   ├── 1.12.7-SNAPSHOT
│   │   ├── maven-metadata-local.xml
│   │   ├── mockk-agent-jvm-1.12.7-SNAPSHOT-javadoc.jar
│   │   ├── mockk-agent-jvm-1.12.7-SNAPSHOT-sources.jar
│   │   ├── mockk-agent-jvm-1.12.7-SNAPSHOT.jar
│   │   ├── mockk-agent-jvm-1.12.7-SNAPSHOT.module
│   │   └── mockk-agent-jvm-1.12.7-SNAPSHOT.pom
│   └── maven-metadata-local.xml
├── mockk-android
│   ├── 1.12.7-SNAPSHOT
│   │   ├── maven-metadata-local.xml
│   │   ├── mockk-android-1.12.7-SNAPSHOT-javadoc.jar
│   │   ├── mockk-android-1.12.7-SNAPSHOT.aar
│   │   ├── mockk-android-1.12.7-SNAPSHOT.module
│   │   └── mockk-android-1.12.7-SNAPSHOT.pom
│   └── maven-metadata-local.xml
├── mockk-dsl
│   ├── 1.12.7-SNAPSHOT
│   │   ├── maven-metadata-local.xml
│   │   ├── mockk-dsl-1.12.7-SNAPSHOT-javadoc.jar
│   │   ├── mockk-dsl-1.12.7-SNAPSHOT-kotlin-tooling-metadata.json
│   │   ├── mockk-dsl-1.12.7-SNAPSHOT-sources.jar
│   │   ├── mockk-dsl-1.12.7-SNAPSHOT.jar
│   │   ├── mockk-dsl-1.12.7-SNAPSHOT.module
│   │   └── mockk-dsl-1.12.7-SNAPSHOT.pom
│   └── maven-metadata-local.xml
├── mockk-dsl-jvm
│   ├── 1.12.7-SNAPSHOT
│   │   ├── maven-metadata-local.xml
│   │   ├── mockk-dsl-jvm-1.12.7-SNAPSHOT-javadoc.jar
│   │   ├── mockk-dsl-jvm-1.12.7-SNAPSHOT-sources.jar
│   │   ├── mockk-dsl-jvm-1.12.7-SNAPSHOT.jar
│   │   ├── mockk-dsl-jvm-1.12.7-SNAPSHOT.module
│   │   └── mockk-dsl-jvm-1.12.7-SNAPSHOT.pom
│   └── maven-metadata-local.xml
└── mockk-jvm
    ├── 1.12.7-SNAPSHOT
    │   ├── maven-metadata-local.xml
    │   ├── mockk-jvm-1.12.7-SNAPSHOT-javadoc.jar
    │   ├── mockk-jvm-1.12.7-SNAPSHOT-sources.jar
    │   ├── mockk-jvm-1.12.7-SNAPSHOT.jar
    │   ├── mockk-jvm-1.12.7-SNAPSHOT.module
    │   └── mockk-jvm-1.12.7-SNAPSHOT.pom
    └── maven-metadata-local.xml

20 directories, 72 files
```

