### PR TITLE
Fix Android Instrumentation dispatcher.jar inclusion

### DIFF
--- a/modules/mockk-agent-android/build.gradle.kts
+++ b/modules/mockk-agent-android/build.gradle.kts
@@ -23,7 +23,7 @@ android {
     sourceSets {
         named("main").configure {
             resources {
-                srcDirs(dispatcherJarResPath)
+                srcDirs({ packageDispatcherJar.map { it.destinationDirectory } })
             }
         }
     }
@@ -60,13 +60,11 @@ dependencies {
     androidClassesDex(projects.modules.mockkAgentAndroidDispatcher)
 }
 
-val dispatcherJarResPath: Provider<Directory> = layout.buildDirectory.dir("generated/dispatcher-jar")
-
 val packageDispatcherJar by tasks.registering(Jar::class) {
     group = LifecycleBasePlugin.BUILD_GROUP
     from(androidClassesDex.asFileTree)
     archiveFileName.set("dispatcher.jar")
-    destinationDirectory.set(dispatcherJarResPath)
+    destinationDirectory.set(temporaryDir)
 }
 
 tasks.preBuild {


### PR DESCRIPTION
Fixes #894

My take on #895 - credit to @kubode for identifying the problem and showing how to check it.

What do you think @kubode?

It also includes using the Gradle task output - this helps with Gradle task optimisation. Wrapping the task in a lambda prevents the NPE.

The issue in this comment is also resolved https://github.com/mockk/mockk/pull/895#issuecomment-1225519166

<img width="340" alt="image" src="https://user-images.githubusercontent.com/897017/186528189-2eb12057-85a1-4b77-b5e7-226941fd116b.png">
