### PR TITLE
use the official Gradle GHA

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -83,4 +83,7 @@ jobs:
           script: echo "Generated AVD snapshot for caching."
 
       - name: run tests
-        run: ./gradlew connectedCheck
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: ${{ matrix.api-level }}
+          script: ./gradlew connectedCheck

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -32,6 +32,8 @@ jobs:
 
       - name: Setup Gradle
         uses: gradle/gradle-build-action@v2
+        with:
+          cache-read-only: false
 
       - name: Run tests with Gradle
         run: |
@@ -58,6 +60,8 @@ jobs:
 
       - name: Setup Gradle
         uses: gradle/gradle-build-action@v2
+        with:
+          cache-read-only: false
 
       - name: AVD cache
         uses: actions/cache@v3
@@ -77,7 +81,6 @@ jobs:
           emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           disable-animations: false
           script: echo "Generated AVD snapshot for caching."
-
 
       - name: run tests
         run: |

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -24,31 +24,20 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Setup Gradle Dependencies Cache
-        uses: actions/cache@v3
-        with:
-          path: ~/.gradle/caches
-          key: ${{ runner.os }}-gradle-caches-${{ hashFiles('**/*.gradle', '**/*.gradle.kts') }}
-
-      - name: Setup Gradle Wrapper Cache
-        uses: actions/cache@v3
-        with:
-          path: ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-wrapper-${{ hashFiles('**/gradle/wrapper/gradle-wrapper.properties') }}
-
       - name: Set up JDK ${{ matrix.java-version }}
         uses: actions/setup-java@v3
         with:
           distribution: temurin
           java-version: ${{ matrix.java-version }}
 
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@v2
+
       - name: Run tests with Gradle
-        uses: eskatos/gradle-command-action@v1
-        with:
-          arguments: |
-            test 
-            --stacktrace 
-            -Pkotlin.version=${{ matrix.kotlin-version }} 
+        run: |
+          ./gradlew check
+            --stacktrace
+            -Pkotlin.version=${{ matrix.kotlin-version }}
             -Pkotlin.ir.enabled=${{ matrix.kotlin-ir-enabled }}
             -PjavaToolchainTestVersion=${{ matrix.java-version }}
 
@@ -67,17 +56,8 @@ jobs:
           distribution: adopt
           java-version: 11
 
-      - name: Setup Gradle Dependencies Cache
-        uses: actions/cache@v3
-        with:
-          path: ~/.gradle/caches
-          key: ${{ runner.os }}-gradle-caches-${{ hashFiles('**/*.gradle', '**/*.gradle.kts') }}
-
-      - name: Setup Gradle Wrapper Cache
-        uses: actions/cache@v3
-        with:
-          path: ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-wrapper-${{ hashFiles('**/gradle/wrapper/gradle-wrapper.properties') }}
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@v2
 
       - name: AVD cache
         uses: actions/cache@v3
@@ -98,8 +78,11 @@ jobs:
           disable-animations: false
           script: echo "Generated AVD snapshot for caching."
 
+
       - name: run tests
-        uses: reactivecircus/android-emulator-runner@v2
-        with:
-          api-level: ${{ matrix.api-level }}
-          script: ./gradlew connectedCheck
+        run: |
+          ./gradlew connectedCheck
+            --stacktrace
+            -Pkotlin.version=${{ matrix.kotlin-version }}
+            -Pkotlin.ir.enabled=${{ matrix.kotlin-ir-enabled }}
+            -PjavaToolchainTestVersion=${{ matrix.java-version }}

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -36,7 +36,7 @@ jobs:
           cache-read-only: false
 
       - name: Run tests with Gradle
-        run: |
+        run: >
           ./gradlew check
             --stacktrace
             -Pkotlin.version=${{ matrix.kotlin-version }}
@@ -83,9 +83,4 @@ jobs:
           script: echo "Generated AVD snapshot for caching."
 
       - name: run tests
-        run: |
-          ./gradlew connectedCheck
-            --stacktrace
-            -Pkotlin.version=${{ matrix.kotlin-version }}
-            -Pkotlin.ir.enabled=${{ matrix.kotlin-ir-enabled }}
-            -PjavaToolchainTestVersion=${{ matrix.java-version }}
+        run: ./gradlew connectedCheck

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -38,10 +38,10 @@ jobs:
       - name: Run tests with Gradle
         run: >
           ./gradlew check
-            --stacktrace
-            -Pkotlin.version=${{ matrix.kotlin-version }}
-            -Pkotlin.ir.enabled=${{ matrix.kotlin-ir-enabled }}
-            -PjavaToolchainTestVersion=${{ matrix.java-version }}
+          --stacktrace
+          -Pkotlin.version=${{ matrix.kotlin-version }}
+          -Pkotlin.ir.enabled=${{ matrix.kotlin-ir-enabled }}
+          -PjavaToolchainTestVersion=${{ matrix.java-version }}
 
   android-instrumented-tests:
     runs-on: macos-latest

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -32,8 +32,6 @@ jobs:
 
       - name: Setup Gradle
         uses: gradle/gradle-build-action@v2
-        with:
-          cache-read-only: false
 
       - name: Run tests with Gradle
         run: >
@@ -60,8 +58,6 @@ jobs:
 
       - name: Setup Gradle
         uses: gradle/gradle-build-action@v2
-        with:
-          cache-read-only: false
 
       - name: AVD cache
         uses: actions/cache@v3

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,6 +11,13 @@ plugins {
 
 group = "io.mockk"
 
+apiValidation {
+    ignoredProjects += listOf(
+        projects.testModules.performanceTests.name,
+        projects.testModules.clientTests.name,
+    )
+}
+
 tasks.wrapper {
     gradleVersion = "7.5.1"
     distributionType = Wrapper.DistributionType.ALL


### PR DESCRIPTION
Use the official Gradle GitHub Action https://github.com/marketplace/actions/gradle-build-action

Two reasons: 

1. I've noticed that the GitHub actions aren't always cached, and thus they take longer than necessary
2. Less configuration is needed