### PR TITLE
add 1.7.20-RC to test matrix

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         java-version: [ 11, 17, 18 ] # test LTS versions, and the newest
-        kotlin-version: [ 1.5.31, 1.6.21, 1.7.10 ]
+        kotlin-version: [ 1.5.31, 1.6.21, 1.7.20-RC ]
         kotlin-ir-enabled: [ true, false ]
       fail-fast: false # in case one JDK fails, we still want to see results from others
     timeout-minutes: 30


### PR DESCRIPTION
Just a quick test to make sure there are no issues ahead of the release. Either this can be merged now, or later once 1.7.20 is released properly - I'm not sure which is best.