### PR TITLE
value class check - catch KotlinReflectionInternalError

### DIFF
--- a/modules/mockk-core/src/jvmMain/kotlin/io/mockk/core/ValueClassSupport.kt
+++ b/modules/mockk-core/src/jvmMain/kotlin/io/mockk/core/ValueClassSupport.kt
@@ -6,6 +6,7 @@ import kotlin.reflect.full.declaredMemberProperties
 import kotlin.reflect.full.primaryConstructor
 import kotlin.reflect.jvm.isAccessible
 import kotlin.reflect.jvm.javaField
+import kotlin.reflect.jvm.internal.KotlinReflectionInternalError
 
 
 actual object ValueClassSupport {
@@ -61,6 +62,8 @@ actual object ValueClassSupport {
     private val <T : Any> KClass<T>.isValue_safe: Boolean
         get() = try {
             this.isValue
+        } catch (_: KotlinReflectionInternalError) {
+            false
         } catch (_: UnsupportedOperationException) {
             false
         }

--- a/test-modules/client-tests/build.gradle.kts
+++ b/test-modules/client-tests/build.gradle.kts
@@ -3,7 +3,9 @@ plugins {
 }
 
 kotlin {
-    jvm()
+    jvm {
+        withJava()
+    }
 
     sourceSets {
         val commonMain by getting {

--- a/test-modules/client-tests/src/jvmTest/java/io/mockk/core/JavaEnum.java
+++ b/test-modules/client-tests/src/jvmTest/java/io/mockk/core/JavaEnum.java
@@ -1,0 +1,10 @@
+package io.mockk.core;
+
+/** @see ValueClassSupport */
+public enum JavaEnum {
+    A {
+        public String toString() {
+            return "aaa";
+        }
+    }
+}

--- a/test-modules/client-tests/src/jvmTest/kotlin/io/mockk/core/ValueClassSupportTest.kt
+++ b/test-modules/client-tests/src/jvmTest/kotlin/io/mockk/core/ValueClassSupportTest.kt
@@ -1,0 +1,24 @@
+package io.mockk.core
+
+import io.mockk.every
+import io.mockk.mockk
+import kotlin.test.Test
+
+
+class ValueClassSupportTest {
+
+    /** https://github.com/mockk/mockk/issues/868 */
+    @Test
+    fun `verify Java class does not cause KotlinReflectionInternalError`() {
+        val mock = mockk<MockTarget> {
+            every { func() } returns JavaEnum.A
+        }
+
+        mock.func() // throws KotlinReflectionInternalError
+    }
+
+}
+
+private class MockTarget {
+    fun func(): JavaEnum = JavaEnum.A
+}

--- a/test-modules/client-tests/src/jvmTest/kotlin/io/mockk/core/ValueClassSupportTest.kt
+++ b/test-modules/client-tests/src/jvmTest/kotlin/io/mockk/core/ValueClassSupportTest.kt
@@ -3,6 +3,7 @@ package io.mockk.core
 import io.mockk.every
 import io.mockk.mockk
 import kotlin.test.Test
+import kotlin.test.assertEquals
 
 
 class ValueClassSupportTest {
@@ -14,7 +15,9 @@ class ValueClassSupportTest {
             every { func() } returns JavaEnum.A
         }
 
-        mock.func() // throws KotlinReflectionInternalError
+        val result = mock.func() // check this doesn't throw KotlinReflectionInternalError
+
+        assertEquals(JavaEnum.A, result)
     }
 
 }


### PR DESCRIPTION
might fix #868 ~caused by #913?~ not caused by #913, it seems `KotlinReflectionInternalError` was never caught...

~This is a draft because I want to make a test for this to make sure it doesn't happen again. See https://youtrack.jetbrains.com/issue/KT-41373 for reproductions.~ Test added