### PR TITLE
Fix instantiation error when mocking sealed classes in JDK 17

### DIFF
--- a/modules/mockk/src/commonTest/kotlin/io/mockk/it/SealedClassTest.kt
+++ b/modules/mockk/src/commonTest/kotlin/io/mockk/it/SealedClassTest.kt
@@ -30,6 +30,28 @@ class SealedClassTest {
         assertEquals(Leaf(1), result)
     }
 
+    @Test
+    fun serviceReturnsSealedClassImplWithAnyMatcher() {
+        val factory = mockk<Factory> {
+            every { copy(any()) } returns Leaf(1)
+        }
+
+        val result = factory.create()
+
+        assertEquals(Leaf(1), result)
+    }
+
+    @Test
+    fun serviceAnswersSealedClassImplWithAnyMatcher() {
+        val factory = mockk<Factory> {
+            every { copy(any()) } answers { Leaf(1) }
+        }
+
+        val result = factory.create()
+
+        assertEquals(Leaf(1), result)
+    }
+
     companion object {
 
         sealed class Node
@@ -39,10 +61,12 @@ class SealedClassTest {
 
         interface Factory {
             fun create(): Node
+            fun copy(node: Node): Node
         }
 
         class FactoryImpl : Factory {
             override fun create(): Node = Root(0)
+            override fun copy(node: Node): Node = node
         }
 
     }


### PR DESCRIPTION
Related to #934 -

## First step, reproducing the issue:
Demonstrate the failure when using the `any()` matcher.

WIP