### PR TITLE
Add tests for issue #934

### DIFF
--- a/modules/mockk/src/commonTest/kotlin/io/mockk/it/SealedClassTest.kt
+++ b/modules/mockk/src/commonTest/kotlin/io/mockk/it/SealedClassTest.kt
@@ -2,6 +2,8 @@ package io.mockk.it
 
 import io.mockk.every
 import io.mockk.mockk
+import org.junit.jupiter.api.condition.DisabledForJreRange
+import org.junit.jupiter.api.condition.JRE
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
@@ -30,6 +32,22 @@ class SealedClassTest {
         assertEquals(Leaf(1), result)
     }
 
+    @Test
+    @DisabledForJreRange(
+        min = JRE.JAVA_17,
+        disabledReason = "https://github.com/mockk/mockk/issues/934"
+    )
+    fun serviceTakesSealedClassAsInput() {
+        val formattedNode = "Formatted node"
+        val factory = mockk<Factory> {
+            every { format(any()) } answers { formattedNode }
+        }
+
+        val result = factory.format(Root(0))
+
+        assertEquals(formattedNode, result)
+    }
+
     companion object {
 
         sealed class Node
@@ -39,10 +57,14 @@ class SealedClassTest {
 
         interface Factory {
             fun create(): Node
+
+            fun format(node: Node): String
         }
 
         class FactoryImpl : Factory {
             override fun create(): Node = Root(0)
+
+            override fun format(node: Node): String = node.toString()
         }
 
     }

--- a/modules/mockk/src/commonTest/kotlin/io/mockk/it/SealedInterfaceTest.kt
+++ b/modules/mockk/src/commonTest/kotlin/io/mockk/it/SealedInterfaceTest.kt
@@ -2,6 +2,8 @@ package io.mockk.it
 
 import io.mockk.every
 import io.mockk.mockk
+import org.junit.jupiter.api.condition.DisabledForJreRange
+import org.junit.jupiter.api.condition.JRE
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
@@ -30,6 +32,22 @@ class SealedInterfaceTest {
         assertEquals(Leaf(1), result)
     }
 
+    @Test
+    @DisabledForJreRange(
+        min = JRE.JAVA_17,
+        disabledReason = "https://github.com/mockk/mockk/issues/934"
+    )
+    fun serviceTakesSealedInterfaceAsInput() {
+        val formattedNode = "Formatted node"
+        val factory = mockk<Factory> {
+            every { format(any()) } answers { formattedNode }
+        }
+
+        val result = factory.format(Root(0))
+
+        assertEquals(formattedNode, result)
+    }
+
     companion object {
 
         sealed interface Node
@@ -39,10 +57,14 @@ class SealedInterfaceTest {
 
         interface Factory {
             fun create(): Node
+
+            fun format(node: Node): String
         }
 
         class FactoryImpl : Factory {
             override fun create(): Node = Root(0)
+
+            override fun format(node: Node): String = node.toString()
         }
 
     }


### PR DESCRIPTION
This PR adds tests to demonstrate the issue #934 
Since the problem reproduces with JVM 17+ bytecode, to reproduce the problem:
1. Remove `DisabledForJreRange` annotation from the tests
2. Set JVM target [here](https://github.com/mockk/mockk/blob/c18440f9e34020c96caa49b994c7f3efe92c7c8a/buildSrc/src/main/kotlin/buildsrc/config/Deps.kt#L10) to `JavaVersion.VERSION_17`
3. Run the tests with `-PjavaToolchainTestVersion=17`