### PR TITLE
Add missing test annotation to LambdaTest

### DIFF
--- a/modules/mockk/src/commonTest/kotlin/io/mockk/it/LambdaTest.kt
+++ b/modules/mockk/src/commonTest/kotlin/io/mockk/it/LambdaTest.kt
@@ -4,22 +4,23 @@ import io.mockk.every
 import io.mockk.invoke
 import io.mockk.mockk
 import io.mockk.verify
+import kotlin.test.Test
 import kotlin.test.assertEquals
 
 class LambdaTest {
-    val mock = mockk<MockCls>()
+    private val mock = mockk<MockCls>()
 
-    fun lambdaTest() {
+    @Test
+    fun simpleLambdaTest() {
         every {
             mock.lambdaOp(1, captureLambda())
         } answers { 1 - lambda<() -> Int>().invoke() }
 
-        assertEquals(-4, mock.lambdaOp(1, { 5 }))
+        assertEquals(-4, mock.lambdaOp(1) { 5 })
 
         verify {
             mock.lambdaOp(1, any())
         }
-
     }
 
     class MockCls {


### PR DESCRIPTION
There is no test annotation in LambdaTest. Add missing test annotation to LambdaTest.

I don't know history about this, Is there a reason why there is no test annotation?