### PR TITLE
Document InaccessibleObjectException/IllegalAccessException on JDK 16+ with solution

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ From version 1.13.0 MockK supports Kotlin 1.4 and higher
  
 * PowerMock needs a workaround to run together with MockK [#79](https://github.com/mockk/mockk/issues/79#issuecomment-437646333). (not sure after workaround if it is generally usable or not, please somebody report it)
 * Inline functions cannot be mocked: see the discussion on [this issue](https://github.com/mockk/mockk/issues/27)
+* Spies, mockkStatic may not work on JDK 16+; `InaccessibleObjectException`/`IllegalAccessException`: [read more here](doc/md/jdk16-access-exceptions.md)
 
 Table of contents:
 

--- a/doc/md/jdk16-access-exceptions.md
+++ b/doc/md/jdk16-access-exceptions.md
@@ -1,0 +1,62 @@
+# JDK 16+ access exceptions
+
+### Problem symptoms 
+On JDK 16 and above you may encounter InaccessibleObjectException or IllegalAccessException in following known cases:
+1. _Some_ usages of `mockkStatic` on java standard library classes, e.g. 
+   ```kotlin
+   mockkStatic(Instant::class)
+   every { Instant.now() } returns Instant.parse("2022-09-15T09:31:26.919Z")
+   ```
+   ```
+   java.time.format.DateTimeParseException: Text '2022-09-15T09:31:26.919Z' could not be parsed:
+     Unable to make private static java.time.Instant java.time.Instant.create(long,int) accessible: 
+     module java.base does not "opens java.time" to unnamed module @4501b7af
+   ```
+
+2. Spying on java standard library classes, e.g.
+   ```kotlin
+   val socket = Socket()
+   val spy = spyk<Socket>(socket)
+   ```
+    Note: this includes creating `@SpyKBean` on spring data repository instances, because they are instances of `java.lang.reflect.Proxy` in fact.
+   ```
+   Error creating bean with name 'featureRepository': Post-processing of FactoryBean's singleton object failed;
+    nested exception is java.lang.IllegalAccessException: class io.mockk.impl.InternalPlatform 
+    cannot access a member of class java.lang.reflect.Proxy (in module java.base) with modifiers "protected"
+   ```
+
+### Problem cause
+JDK 16 enforced strong encapsulation of standard modules. In practice this means you (and your libraries) can no more get away with call like `privateMember.setAccessible(true)` to any of JDK classes.
+
+https://blogs.oracle.com/javamagazine/post/a-peek-into-java-17-continuing-the-drive-to-encapsulate-the-java-runtime-internals
+
+### Solution / workaround
+Add JVM argument `--add-opens java.base/java.time=ALL-UNNAMED` _for each package_ you need  
+Description: https://docs.oracle.com/en/java/javase/16/migrate/migrating-jdk-8-later-jdk-releases.html
+
+For gradle users:
+```groovy
+tasks.test {
+    jvmArgs("--add-opens", "java.base/java.time=ALL-UNNAMED")
+}
+```
+
+For maven users:
+```xml
+<plugin>
+    <groupId>org.apache.maven.plugins</groupId>
+    <artifactId>maven-surefire-plugin</artifactId>
+    <configuration>
+      <argLine>
+        --add-opens java.base/java.time=ALL-UNNAMED
+      </argLine>
+    </configuration>
+</plugin>
+```
+
+### Linked issues
+* https://github.com/mockk/mockk/issues/681
+* https://github.com/Ninja-Squad/springmockk/issues/65
+* https://github.com/mockk/mockk/issues/929
+* https://github.com/mockk/mockk/issues/864
+* https://github.com/mockk/mockk/issues/834


### PR DESCRIPTION
Some users face InaccessibleObjectException/IllegalAccessException working on JDK 16+.  
As far as I'm concerned, this is not considered as a bug in mockk; or fix is just not planned yet.  
So I added separate MD file describing the problem and link to it from main README.md (section "known issues")  

I'm not sure where to put this MD file, I supposed that `doc/md` directory is fine.

### Linked issues
* https://github.com/mockk/mockk/issues/681
* https://github.com/mockk/mockk/issues/929
* https://github.com/mockk/mockk/issues/864
* https://github.com/mockk/mockk/issues/834
* https://github.com/Ninja-Squad/springmockk/issues/65