### PR TITLE
Recognize atLeast = 0 when mocked methods is never called

### DIFF
--- a/modules/mockk/src/commonMain/kotlin/io/mockk/impl/verify/UnorderedCallVerifier.kt
+++ b/modules/mockk/src/commonMain/kotlin/io/mockk/impl/verify/UnorderedCallVerifier.kt
@@ -82,7 +82,9 @@ open class UnorderedCallVerifier(
             }
         } else when (allCallsForMockMethod.size) {
             0 -> {
-                if (allCallsForMock.isEmpty()) {
+                if(min == 0) {
+                    VerificationResult.OK(listOf())
+                } else if (allCallsForMock.isEmpty()) {
                     VerificationResult.Failure("$callIdxMsg was not called")
                 } else {
                     VerificationResult.Failure(safeToString.exec {

--- a/modules/mockk/src/commonTest/kotlin/io/mockk/it/VerifyAtLeastAtMostExactlyTest.kt
+++ b/modules/mockk/src/commonTest/kotlin/io/mockk/it/VerifyAtLeastAtMostExactlyTest.kt
@@ -194,6 +194,13 @@ class VerifyAtLeastAtMostExactlyTest {
     }
 
     @Test
+    fun atLeastNeverAtAll() {
+        every { mock.op(0) } returns 1
+
+        verify(atLeast = 0) { mock.op(0) }
+    }
+
+    @Test
     fun atLeastNever() {
         every { mock.op(0) } returns 1
         mock.op(0)


### PR DESCRIPTION
Fix #969
verify atLeast = 0 only passing if the mocked function is called at least once with different parameters

The case in which the method never gets called at all probably just got forgotten in this fix #807