### PR TITLE
Prevent "MockKException: Failed matching mocking signature for" on sealed classes

### DIFF
--- a/modules/mockk/src/commonTest/kotlin/io/mockk/it/SealedClassTest.kt
+++ b/modules/mockk/src/commonTest/kotlin/io/mockk/it/SealedClassTest.kt
@@ -44,12 +44,28 @@ class SealedClassTest {
         assertEquals(formattedNode, result)
     }
 
+    @Test
+    fun mockSealedClassAbstractMethodWithMatchers() {
+        val node = mockk<Node> {
+            every { doSomething(any()) } returns 10
+        }
+
+        assertEquals(node.doSomething(20), 10)
+    }
+
     companion object {
 
-        sealed class Node
+        sealed class Node {
+            abstract fun doSomething(arg: Any?): Int
+        }
 
-        data class Root(val id: Int) : Node()
-        data class Leaf(val id: Int) : Node()
+        data class Root(val id: Int) : Node() {
+            override fun doSomething(arg: Any?) = id
+        }
+
+        data class Leaf(val id: Int) : Node() {
+            override fun doSomething(arg: Any?) = id
+        }
 
         interface Factory {
             fun create(): Node

--- a/modules/mockk/src/commonTest/kotlin/io/mockk/it/SealedInterfaceTest.kt
+++ b/modules/mockk/src/commonTest/kotlin/io/mockk/it/SealedInterfaceTest.kt
@@ -44,12 +44,28 @@ class SealedInterfaceTest {
         assertEquals(formattedNode, result)
     }
 
+    @Test
+    fun mockSealedInterfaceMethodWithMatchers() {
+        val node = mockk<Node> {
+            every { doSomething(any()) } returns 10
+        }
+
+        assertEquals(node.doSomething(20), 10)
+    }
+
     companion object {
 
-        sealed interface Node
+        sealed interface Node {
+            fun doSomething(arg: Any?): Int
+        }
 
-        data class Root(val id: Int) : Node
-        data class Leaf(val id: Int) : Node
+        data class Root(val id: Int) : Node {
+            override fun doSomething(arg: Any?) = id
+        }
+
+        data class Leaf(val id: Int) : Node {
+            override fun doSomething(arg: Any?) = id
+        }
 
         interface Factory {
             fun create(): Node


### PR DESCRIPTION
Hello, I was trying to upgrade a Kotlin project I'm working on to kotlin 1.7.21 (jdk 17) and was having the same problem as described in https://github.com/mockk/mockk/issues/978.

This PR is an attempt to fix the issue. I'll try to explain what I found out, but please keep in mind that I know very little what I'm talking about 😂 . 

The exception reported in the issue is thrown [here](https://github.com/mockk/mockk/blob/master/modules/mockk/src/commonMain/kotlin/io/mockk/impl/recording/SignatureMatcherDetector.kt#L99), because a single `CallRound` arrives in `detect(callRounds: List<CallRound>)` and: 
- has a single `SignedMatcher` (indicating that `any()` was called), 
- but has no `SignedCall`s to match with the existing `SignedMatcher`. 

From what I could understand `SignedCall`s are registered [here](https://github.com/mockk/mockk/blob/master/modules/mockk/src/commonMain/kotlin/io/mockk/impl/recording/states/RecordingState.kt#L64-L90), when the method call is intercepted in the proxy call (i.e. when a mocked method is called inside a `every { }` block). For sealed classes proxies, this "interception" is not happening.

I think this "interception" is configured by calling [inline](https://github.com/mockk/mockk/blob/master/modules/mockk-agent/src/jvmMain/kotlin/io/mockk/proxy/jvm/ProxyMaker.kt#L30) on the mock class. It happens that sealed class proxies are actually an instance of a sealed subclass (see [here](https://github.com/mockk/mockk/blob/master/modules/mockk-agent/src/jvmMain/kotlin/io/mockk/proxy/jvm/ProxyMaker.kt#L110)). So, `mockk` instantiates a sealed subclass, but calls `inline` on the sealed class (its parent). 

The change in this PR is to call `inline` on the same sealed subclass that `mockk` instantiates. This seems to correctly register the interceptors, which in turn correctly store the `SignedCall` in `RecordingState`, which prevents the exception reported in the issue.

I tested this change on a project with JDK 17 and Kotlin 1.7.21, and seems to be working. Didn't test in other JDKs/Kotlin versions.

Does any of this make sense? 😂 

