### PR TITLE
Fixes #647 by allowing `classBeingRedefined` to be `null`

### DIFF
--- a/modules/mockk-agent/src/jvmMain/kotlin/io/mockk/proxy/jvm/transformation/InliningClassTransformer.kt
+++ b/modules/mockk-agent/src/jvmMain/kotlin/io/mockk/proxy/jvm/transformation/InliningClassTransformer.kt
@@ -60,10 +60,14 @@ internal class InliningClassTransformer(
     override fun transform(
         loader: ClassLoader?,
         className: String,
-        classBeingRedefined: Class<*>,
+        classBeingRedefined: Class<*>?,
         protectionDomain: ProtectionDomain?,
-        classfileBuffer: ByteArray?
+        classfileBuffer: ByteArray
     ): ByteArray? {
+        if (classBeingRedefined == null) {
+            return classfileBuffer
+        }
+
         val spec = specMap[classBeingRedefined]
                 ?: return classfileBuffer
 
@@ -121,7 +125,7 @@ internal class InliningClassTransformer(
     private fun matchRestrictedMethods(desc: MethodDescription) =
         desc.declaringType.typeName + "." + desc.name in restrictedMethods
 
-    private fun constructorAdvice(): AsmVisitorWrapper.ForDeclaredMethods? {
+    private fun constructorAdvice(): AsmVisitorWrapper.ForDeclaredMethods {
         return Advice.withCustomMapping()
             .bind<ProxyAdviceId>(ProxyAdviceId::class.java, constructorAdvice.id)
             .to(JvmMockKConstructorProxyAdvice::class.java)


### PR DESCRIPTION
Fixes #647 by declaring `classBeingRedefined` as a nullable parameter, aligning [JVM's `InliningClassTransformer`](https://github.com/mockk/mockk/blob/master/modules/mockk-agent/src/jvmMain/kotlin/io/mockk/proxy/jvm/transformation/InliningClassTransformer.kt#L67) with [Android's one](https://github.com/mockk/mockk/blob/master/modules/mockk-agent-android/src/main/kotlin/io/mockk/proxy/android/transformation/InliningClassTransformer.kt#L30)

According the [Oracle's documentaiton](https://docs.oracle.com/javase/7/docs/api/java/lang/instrument/ClassFileTransformer.html), it's expected `classBeingRedefined` to be nullable:

> classBeingRedefined - if this is triggered by a redefine or retransform, the class being redefined or retransformed; if this is a class load, null

https://docs.oracle.com/javase/7/docs/api/java/lang/instrument/ClassFileTransformer.html

