### PR TITLE
Inline mocked subclass of sealed class along with the sealed class itself

### DIFF
--- a/modules/mockk/src/commonTest/kotlin/io/mockk/it/SealedClassMockingTest.kt
+++ b/modules/mockk/src/commonTest/kotlin/io/mockk/it/SealedClassMockingTest.kt
@@ -1,0 +1,23 @@
+package io.mockk.it
+
+import io.mockk.every
+import io.mockk.mockk
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class SealedClassMockingTest {
+
+    @Test
+    fun testSealedClassCanBeMocked() {
+        val base = mockk<Base> {
+            every { i } returns 0
+        }
+        assertEquals(0, base.i)
+    }
+
+    private sealed class Base {
+        abstract val i: Int
+    }
+
+    private data class Derived(override val i: Int) : Base()
+}


### PR DESCRIPTION
Fixes #938, fixes #978, fixes #987
