### PR TITLE
bump Kover to 0.6.1

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -41,6 +41,14 @@ jobs:
           -Pkotlin.ir.enabled=${{ matrix.kotlin-ir-enabled }}
           -PjavaToolchainTestVersion=${{ matrix.java-version }}
 
+      - name: Coverage report
+        uses: mi-kas/kover-report@v1
+        with:
+          path: "${{ github.workspace }}/build/reports/kover/merged/xml/report.xml"
+          token: ${{ secrets.GITHUB_TOKEN }}
+          title: Code Coverage
+          update-comment: true
+
   android-instrumented-tests:
     runs-on: macos-latest
     strategy:
@@ -83,3 +91,11 @@ jobs:
         with:
           api-level: ${{ matrix.api-level }}
           script: ./gradlew connectedCheck
+
+      - name: Coverage report
+        uses: mi-kas/kover-report@v1
+        with:
+          path: "${{ github.workspace }}/build/reports/kover/merged/xml/report.xml"
+          token: ${{ secrets.GITHUB_TOKEN }}
+          title: Code Coverage
+          update-comment: true

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -41,14 +41,6 @@ jobs:
           -Pkotlin.ir.enabled=${{ matrix.kotlin-ir-enabled }}
           -PjavaToolchainTestVersion=${{ matrix.java-version }}
 
-      - name: Coverage report
-        uses: mi-kas/kover-report@v1
-        with:
-          path: "${{ github.workspace }}/build/reports/kover/merged/xml/report.xml"
-          token: ${{ secrets.GITHUB_TOKEN }}
-          title: Code Coverage
-          update-comment: true
-
   android-instrumented-tests:
     runs-on: macos-latest
     strategy:
@@ -91,11 +83,3 @@ jobs:
         with:
           api-level: ${{ matrix.api-level }}
           script: ./gradlew connectedCheck
-
-      - name: Coverage report
-        uses: mi-kas/kover-report@v1
-        with:
-          path: "${{ github.workspace }}/build/reports/kover/merged/xml/report.xml"
-          token: ${{ secrets.GITHUB_TOKEN }}
-          title: Code Coverage
-          update-comment: true

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,10 +11,15 @@ plugins {
 
 group = "io.mockk"
 
+koverMerged {
+    enable()
+}
+
 apiValidation {
     ignoredProjects += listOf(
-        projects.testModules.performanceTests.name,
+        projects.testModules.loggerTests.name,
         projects.testModules.clientTests.name,
+        projects.testModules.performanceTests.name,
     )
 }
 

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -13,7 +13,7 @@ plugins {
 val kotlinPluginVersion: String = "1.7.20"
 
 val androidGradle = "7.2.1"
-val kotlinxKover = "0.5.1"
+val kotlinxKover = "0.6.1"
 val dokka = "1.7.10"
 val binaryCompatibilityValidator = "0.11.0"
 

--- a/buildSrc/src/main/kotlin/buildsrc/convention/android-application.gradle.kts
+++ b/buildSrc/src/main/kotlin/buildsrc/convention/android-application.gradle.kts
@@ -6,6 +6,7 @@ plugins {
     id("com.android.application")
 
     id("org.jetbrains.dokka")
+    id("org.jetbrains.kotlinx.kover")
 
     id("buildsrc.convention.base")
 }

--- a/buildSrc/src/main/kotlin/buildsrc/convention/android-library.gradle.kts
+++ b/buildSrc/src/main/kotlin/buildsrc/convention/android-library.gradle.kts
@@ -10,6 +10,7 @@ plugins {
     kotlin("plugin.allopen")
 
     id("org.jetbrains.dokka")
+    id("org.jetbrains.kotlinx.kover")
 
     id("buildsrc.convention.base")
 }

--- a/buildSrc/src/main/kotlin/buildsrc/convention/kotlin-jvm.gradle.kts
+++ b/buildSrc/src/main/kotlin/buildsrc/convention/kotlin-jvm.gradle.kts
@@ -7,6 +7,7 @@ plugins {
     `java-library`
     kotlin("jvm")
     id("org.jetbrains.dokka")
+    id("org.jetbrains.kotlinx.kover")
 
     id("buildsrc.convention.base")
     id("buildsrc.convention.toolchain-jvm")

--- a/buildSrc/src/main/kotlin/buildsrc/convention/kotlin-multiplatform.gradle.kts
+++ b/buildSrc/src/main/kotlin/buildsrc/convention/kotlin-multiplatform.gradle.kts
@@ -7,6 +7,7 @@ plugins {
     kotlin("multiplatform")
 
     id("org.jetbrains.dokka")
+    id("org.jetbrains.kotlinx.kover")
 
     id("buildsrc.convention.base")
     id("buildsrc.convention.toolchain-jvm")


### PR DESCRIPTION
* bump Kover to 0.6.1
* apply Kover to all subprojects via buildSrc convention plugins
* enable merged reports
* exclude 'loggerTests' from API validation (unrelated, but a small fix)