### PR TITLE
Add `fun <T> MockKMatcherScope.any(KClass<T>): T`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1209,6 +1209,24 @@ inline fun <reified T : List<E>, E : Any> MockKMatcherScope.matchListWithoutOrde
 ): T = match(ListWithoutOrderMatcher(listOf(*items), refEq))
 ```
 
+### Reflection matchers
+
+Example using reflection to mock all methods on a builder-style object
+
+```kotlin
+val builderFunctions = MyBuilder::class.memberFunctions.filter { it.returnType.classifier == MyBuilder::class }
+val builderMock = mockk<MyBuilder> {
+  builderFunctions.forEach { func ->
+    every {
+      val params = listOf<Any?>(builderMock) + func.parameters.drop(1).map { any(it.type.classifier as KClass<Any>) }
+      func.call(*params.toTypedArray())
+    } answers { 
+      this@mockk
+    }
+  }
+}
+```
+
 ## Settings file
 
 To adjust parameters globally, there are a few settings you can specify in a resource file.
@@ -1274,6 +1292,7 @@ By default, simple arguments are matched using `eq()`
 | Matcher                                                 | Description                                                                                            |
 |---------------------------------------------------------|--------------------------------------------------------------------------------------------------------|
 | `any()`                                                 | matches any argument                                                                                   |
+| `any(Class)`                                            | matches any argument of the give Class (for reflective mocking)                                        |
 | `allAny()`                                              | special matcher that uses `any()` instead of `eq()` for matchers that are provided as simple arguments |
 | `isNull()`                                              | checks if the value is null                                                                            |
 | `isNull(inverse=true)`                                  | checks if the value is not null                                                                        |

--- a/modules/mockk-dsl/api/mockk-dsl.api
+++ b/modules/mockk-dsl/api/mockk-dsl.api
@@ -820,6 +820,7 @@ public abstract interface class io/mockk/MockKGateway$Verifier {
 
 public class io/mockk/MockKMatcherScope {
 	public fun <init> (Lio/mockk/MockKGateway$CallRecorder;Lio/mockk/CapturingSlot;)V
+	public final fun any (Lkotlin/reflect/KClass;)Ljava/lang/Object;
 	public final fun anyBooleanVararg ()[Z
 	public final fun anyByteVararg ()[B
 	public final fun anyCharVararg ()[C
@@ -836,6 +837,7 @@ public class io/mockk/MockKMatcherScope {
 	public static synthetic fun hint$default (Lio/mockk/MockKMatcherScope;Ljava/lang/Object;Lkotlin/reflect/KClass;IILjava/lang/Object;)Ljava/lang/Object;
 	public final fun invoke (Ljava/lang/Object;Ljava/lang/String;)Lio/mockk/MockKMatcherScope$DynamicCallLong;
 	public final fun invokeNoArgs (Ljava/lang/Object;Ljava/lang/String;)Ljava/lang/Object;
+	public final fun match (Lio/mockk/Matcher;Lkotlin/reflect/KClass;)Ljava/lang/Object;
 	public final fun setProperty (Ljava/lang/Object;Ljava/lang/String;)Lio/mockk/MockKMatcherScope$DynamicSetProperty;
 	public final fun varargAllBoolean (Lkotlin/jvm/functions/Function2;)[Z
 	public final fun varargAllByte (Lkotlin/jvm/functions/Function2;)[B

--- a/modules/mockk-dsl/src/commonMain/kotlin/io/mockk/API.kt
+++ b/modules/mockk-dsl/src/commonMain/kotlin/io/mockk/API.kt
@@ -690,6 +690,9 @@ open class MockKMatcherScope(
     val lambda: CapturingSlot<Function<*>>
 ) {
 
+    fun <T: Any> match(matcher: Matcher<T>, kclass: KClass<T>): T {
+        return callRecorder.matcher(matcher, kclass)
+    }
     inline fun <reified T : Any> match(matcher: Matcher<T>): T {
         return callRecorder.matcher(matcher, T::class)
     }
@@ -732,6 +735,10 @@ open class MockKMatcherScope(
      */
     inline fun <reified T : Any> nrefEq(value: T) = refEq(value, true)
 
+    /**
+     * Matches any argument given a [KClass]
+     */
+    fun <T: Any> any(classifier: KClass<T>): T = match(ConstantMatcher(true), classifier)
     /**
      * Matches any argument.
      */

--- a/modules/mockk/src/commonTest/kotlin/io/mockk/ReflectiveMockTests.kt
+++ b/modules/mockk/src/commonTest/kotlin/io/mockk/ReflectiveMockTests.kt
@@ -1,0 +1,96 @@
+@file:Suppress("UNCHECKED_CAST")
+
+package io.mockk
+
+import kotlin.reflect.KClass
+import kotlin.reflect.full.callSuspend
+import kotlin.reflect.full.memberFunctions
+import kotlin.test.Test
+
+
+class ReflectiveMockTests {
+  private inline fun <reified T : Any> mockkBuilder(): T {
+    val builder: T = mockk()
+    builder.javaClass.kotlin.memberFunctions
+      .filter { it.returnType.classifier == T::class }
+      .filter { !it.isSuspend }
+      .forEach { func ->
+        every {
+          val params: List<Any?> =
+            listOf<Any?>(builder) + func.parameters.drop(1).map { any(it.type.classifier as KClass<Any>) }
+          func.call(*params.toTypedArray())
+        } answers { builder }
+      }
+    return builder
+  }
+
+  interface TestBuilder {
+    fun f1(p1: String): TestBuilder
+    fun f2(p1: String, p2: Int): TestBuilder
+    fun f3(p1: String, p2: Int, p3: Long?): TestBuilder
+  }
+
+  @Test
+  fun testAQuickMockBuilder() {
+    val builder: TestBuilder = mockkBuilder()
+
+    builder.f1("f1")
+      .f2("f2", 2)
+      .f3("f3", 3, 3)
+
+    verify {
+      builder.f1("f1")
+      builder.f2("f2", 2)
+      builder.f3("f3", 3, 3)
+    }
+  }
+
+
+  private inline fun <reified T : Any> mockkWithDefault(noinline defaultAnswer: MockKAnswerScope<Any?, Any?>.(Call) -> Any?): T {
+    val mock: T = mockk()
+    mock.javaClass.kotlin.memberFunctions
+      .filter { !it.isSuspend }
+      .forEach { func ->
+        every {
+          val params: List<Any?> =
+            listOf<Any?>(mock) + func.parameters.drop(1).map { any(it.type.classifier as KClass<Any>) }
+          func.call(*params.toTypedArray())
+        } answers {
+          this.defaultAnswer(it)
+        }
+      }
+
+    mock.javaClass.kotlin.memberFunctions
+      .filter { it.isSuspend }
+      .forEach { func ->
+        coEvery {
+          val params: List<Any?> =
+            listOf<Any?>(mock) + func.parameters.drop(1).map { any(it.type.classifier as KClass<Any>) }
+          func.callSuspend(*params.toTypedArray())
+        } answers {
+          this.defaultAnswer(it)
+        }
+      }
+    return mock
+  }
+
+  @Test fun testMockkWithDefault() {
+    val builder: TestBuilder = mockkWithDefault {
+      when (it.retType) {
+        TestBuilder::class -> it.invocation.self
+        Unit::class        -> Unit
+        else               -> null
+      }
+    }
+
+    builder.f1("f1")
+      .f2("f2", 2)
+      .f3("f3", 3, 3)
+
+    verify {
+      builder.f1("f1")
+      builder.f2("f2", 2)
+      builder.f3("f3", 3, 3)
+    }
+  }
+}


### PR DESCRIPTION
### Premise

In transitioning from mockito to mockk, the one feature I've been missing is Mockito's `defaultAnswer` concept. 

It seems like we can actually replicate this concept in mockk using reflection, however we're blocked w/o a way to define an `any()` matcher given a KClass or KType instead of a reified type.

### The Change

This PR currently adds only the needed `fun any(KClass)` and `fun match(Matcher, KClass)` functions to the api to open up the possibility of mockking via reflection, and avoids trying to define new dsl for declaring default answers. 

We also demonstrate two examples of reflective mockking. In both examples we mock a TestBuilder and tell it to always return itself. This is just to demonstrate the possibilities we'd be opening up with this change.