### PR TITLE
Return the configured answers when no answer found

### DIFF
--- a/modules/mockk/src/commonMain/kotlin/io/mockk/impl/stub/MockKStub.kt
+++ b/modules/mockk/src/commonMain/kotlin/io/mockk/impl/stub/MockKStub.kt
@@ -88,8 +88,8 @@ open class MockKStub(
                 }
             } else {
                 val configuredAnswers = answers.map { it.matcher.toString() }.joinToString(separator = "\n") { it }
-                throw MockKException("no answer found for: ${gatewayAccess.safeToString.exec { invocation.toString() }}" +
-                        " between the configured answers: ($configuredAnswers)")
+                throw MockKException("no answer found for ${gatewayAccess.safeToString.exec { invocation.toString() }}" +
+                        " among the configured answers: ($configuredAnswers)")
             }
         }
     }

--- a/modules/mockk/src/commonMain/kotlin/io/mockk/impl/stub/MockKStub.kt
+++ b/modules/mockk/src/commonMain/kotlin/io/mockk/impl/stub/MockKStub.kt
@@ -87,7 +87,9 @@ open class MockKStub(
                     childMockK(invocation.allEqMatcher(), invocation.method.returnType)
                 }
             } else {
-                throw MockKException("no answer found for: ${gatewayAccess.safeToString.exec { invocation.toString() }}")
+                val configuredAnswers = answers.map { it.matcher.toString() }.joinToString(separator = "\n") { it }
+                throw MockKException("no answer found for: ${gatewayAccess.safeToString.exec { invocation.toString() }}" +
+                        " between the configured answers: ($configuredAnswers)")
             }
         }
     }

--- a/modules/mockk/src/commonTest/kotlin/io/mockk/impl/stub/MockKStubTest.kt
+++ b/modules/mockk/src/commonTest/kotlin/io/mockk/impl/stub/MockKStubTest.kt
@@ -11,7 +11,7 @@ class MockKStubTest {
     @Test
     fun givenAMockkStubWithAnswerConfiguredWhenCallingItWithOtherParametersThenTheExceptionContainsConfiguredAnswers() {
         val mock: DummyClass = mockk()
-        val expectedMessage = "no answer found for: $mock.function(3) between the configured answers: ($mock.function(eq(2))))"
+        val expectedMessage = "no answer found for $mock.function(3) among the configured answers: ($mock.function(eq(2))))"
 
         every {
             mock.function(2)
@@ -27,7 +27,7 @@ class MockKStubTest {
     @Test
     fun givenAMockkStubWithAnswersConfiguredWhenCallingItWithOtherParametersThenTheExceptionContainsConfiguredAnswers() {
         val mock: DummyClass = mockk()
-        val expectedMessage = """no answer found for: $mock.function(3) between the configured answers: ($mock.function(eq(2)))
+        val expectedMessage = """no answer found for $mock.function(3) among the configured answers: ($mock.function(eq(2)))
 $mock.function(eq(5))))"""
 
         every {

--- a/modules/mockk/src/commonTest/kotlin/io/mockk/impl/stub/MockKStubTest.kt
+++ b/modules/mockk/src/commonTest/kotlin/io/mockk/impl/stub/MockKStubTest.kt
@@ -1,0 +1,50 @@
+package io.mockk.impl.stub
+
+import io.mockk.MockKException
+import io.mockk.every
+import io.mockk.mockk
+import kotlin.test.assertEquals
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+class MockKStubTest {
+    @Test
+    fun givenAMockkStubWithAnswerConfiguredWhenCallingItWithOtherParametersThenTheExceptionContainsConfiguredAnswers() {
+        val mock: DummyClass = mockk()
+        val expectedMessage = "no answer found for: $mock.function(3) between the configured answers: ($mock.function(eq(2))))"
+
+        every {
+            mock.function(2)
+        } returns 3
+
+        val exception = assertThrows<MockKException> {
+            mock.function(3)
+        }
+
+        assertEquals(expectedMessage, exception.message)
+    }
+
+    @Test
+    fun givenAMockkStubWithAnswersConfiguredWhenCallingItWithOtherParametersThenTheExceptionContainsConfiguredAnswers() {
+        val mock: DummyClass = mockk()
+        val expectedMessage = """no answer found for: $mock.function(3) between the configured answers: ($mock.function(eq(2)))
+$mock.function(eq(5))))"""
+
+        every {
+            mock.function(2)
+        } returns 3
+        every {
+            mock.function(5)
+        } returns 3
+
+        val exception = assertThrows<MockKException> {
+            mock.function(3)
+        }
+
+        assertEquals(expectedMessage, exception.message)
+    }
+
+    class DummyClass {
+        fun function(a: Int) = a
+    }
+}


### PR DESCRIPTION

This PR modifies the way the `MockKException` is constructed when a mock is called with a set of parameters that wasn't configured, so it also adds to the exception message all the answers configured for that mock.

The aim of this change is to help understand why is the mock's call really failing, giving some extra information to the developer.
