### PR TITLE
Issue#1037 : Don't unbox Result inline class for interceptor

### DIFF
--- a/modules/mockk-agent/src/jvmMain/kotlin/io/mockk/proxy/jvm/advice/Interceptor.kt
+++ b/modules/mockk-agent/src/jvmMain/kotlin/io/mockk/proxy/jvm/advice/Interceptor.kt
@@ -18,8 +18,11 @@ internal class Interceptor(
             self,
             method
         )
-        return handler.invocation(self, method, callOriginalMethod, arguments)
-            ?.boxedValue // unbox value class objects
+
+        return when (val result = handler.invocation(self, method, callOriginalMethod, arguments)) {
+            is Result<*> -> result
+            else -> result?.boxedValue
+        }
     }
 
 }

--- a/test-modules/client-tests/src/jvmTest/kotlin/io/mockk/test/Issue1037Test.kt
+++ b/test-modules/client-tests/src/jvmTest/kotlin/io/mockk/test/Issue1037Test.kt
@@ -1,0 +1,19 @@
+package io.mockk.test
+
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+
+class Issue1037Test {
+    interface Api {
+        fun foo() : Any
+    }
+
+    @Test
+    fun `mock Any return type should not unbox Result class`() {
+        val mockApi : Api = mockk()
+        every { mockApi.foo() } returns Result.success(1)
+        assertEquals(Result.success(1), mockApi.foo())
+    }
+}


### PR DESCRIPTION
In issue #1037 , there appears to be an issue with unbox Result class, causing the return value type of Result class, being unboxed into underlying value type.

This was a bit confusing and break existing old tests on my side.