### PR TITLE
replace "no answer found for" by "no mock found for"

### DIFF
--- a/modules/mockk/src/commonMain/kotlin/io/mockk/impl/stub/MockKStub.kt
+++ b/modules/mockk/src/commonMain/kotlin/io/mockk/impl/stub/MockKStub.kt
@@ -87,7 +87,7 @@ open class MockKStub(
                     childMockK(invocation.allEqMatcher(), invocation.method.returnType)
                 }
             } else {
-                throw MockKException("no answer found for: ${gatewayAccess.safeToString.exec { invocation.toString() }}")
+                throw MockKException("no mock found for: ${gatewayAccess.safeToString.exec { invocation.toString() }}")
             }
         }
     }


### PR DESCRIPTION
replace "no answer found for" with "no mock found for", Because it's a misleading error for beginners.