### PR TITLE
Issue #997 - Simulate garbage collected proxy

### DIFF
--- a/modules/mockk-agent-api/src/jvmMain/kotlin/io/mockk/proxy/common/ProxyMaker.kt
+++ b/modules/mockk-agent-api/src/jvmMain/kotlin/io/mockk/proxy/common/ProxyMaker.kt
@@ -20,7 +20,6 @@ import io.mockk.proxy.common.transformation.InlineInstrumentation
 import io.mockk.proxy.common.transformation.TransformationRequest
 import io.mockk.proxy.common.transformation.SubclassInstrumentation
 import io.mockk.proxy.common.transformation.TransformationType
-import java.lang.ref.WeakReference
 import java.lang.reflect.Method
 import java.lang.reflect.Modifier
 
@@ -61,13 +60,10 @@ class ProxyMaker(
             val proxy = instantiate(actualClass, proxyClass, useDefaultConstructor, instance)
 
             handlers[proxy] = handler
-            val callbackRef = WeakReference(proxy)
             return result
                 .withValue(proxy)
                 .alsoOnCancel {
-                    callbackRef.get()?.let {
-                        handlers.remove(it)
-                    }
+                    handlers.remove(proxy)
                 }
         } catch (e: Exception) {
             result.cancel()

--- a/modules/mockk-agent/src/jvmTest/java/io/mockk/proxy/JvmMockKProxyMakerTest.java
+++ b/modules/mockk-agent/src/jvmTest/java/io/mockk/proxy/JvmMockKProxyMakerTest.java
@@ -49,6 +49,10 @@ public class JvmMockKProxyMakerTest {
         return maker.proxy(cls, new Class[0], handler, false, null).get();
     }
 
+    private <T> Cancelable<T> makeCancelableProxy(Class<T> cls) {
+        return maker.proxy(cls, new Class[0], handler, false, null);
+    }
+
     @Test
     public void openClassProxy() {
         A proxy = makeProxy(A.class);
@@ -68,6 +72,19 @@ public class JvmMockKProxyMakerTest {
 
         assertTrue(executed[0]);
         checkProxyHandlerCalled(1, proxy, "a");
+    }
+
+    @Test
+    public void garbageCollectedProxy() {
+        handler.callOriginal = true;
+        Cancelable<A> cancelableProxy = makeCancelableProxy(A.class);
+        System.gc();
+
+        cancelableProxy.get().a();
+
+        assertTrue(executed[0]);
+        checkProxyHandlerCalled(1, cancelableProxy, "a");
+
     }
 
     static final class B {

--- a/modules/mockk-agent/src/jvmTest/java/io/mockk/proxy/JvmMockKProxyMakerTest.java
+++ b/modules/mockk-agent/src/jvmTest/java/io/mockk/proxy/JvmMockKProxyMakerTest.java
@@ -78,6 +78,8 @@ public class JvmMockKProxyMakerTest {
     public void garbageCollectedProxy() {
         handler.callOriginal = true;
         Cancelable<A> cancelableProxy = makeCancelableProxy(A.class);
+
+        // Make sure that calling GC before `.get` does not cause an exception
         System.gc();
 
         A proxy = cancelableProxy.get();

--- a/modules/mockk-agent/src/jvmTest/java/io/mockk/proxy/JvmMockKProxyMakerTest.java
+++ b/modules/mockk-agent/src/jvmTest/java/io/mockk/proxy/JvmMockKProxyMakerTest.java
@@ -80,10 +80,11 @@ public class JvmMockKProxyMakerTest {
         Cancelable<A> cancelableProxy = makeCancelableProxy(A.class);
         System.gc();
 
-        cancelableProxy.get().a();
+        A proxy = cancelableProxy.get();
+        proxy.a();
 
         assertTrue(executed[0]);
-        checkProxyHandlerCalled(1, cancelableProxy, "a");
+        checkProxyHandlerCalled(1, proxy, "a");
 
     }
 


### PR DESCRIPTION
Fix for issue #997 - WeakReference fails when GC is called between `proxy` and `get`, resulting in flaky tests. This PR simulates & solves the issue.