### PR TITLE
update Kotlin and Java Toolchain properties, and setting them in CI

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -34,11 +34,12 @@ jobs:
         uses: gradle/gradle-build-action@v2.4.2
 
       - name: Run tests with Gradle
+        env:
+          ORG_GRADLE_PROJECT_io_mockk_kotlin_version: ${{ matrix.kotlin-version }}
+          ORG_GRADLE_PROJECT_io_mockk_java_toolchain_test_version: ${{ matrix.java-version }}
         run: >
           ./gradlew check
           --stacktrace
-          -Pkotlin.version=${{ matrix.kotlin-version }}
-          -PjavaToolchainTestVersion=${{ matrix.java-version }}
 
   android-instrumented-tests:
     runs-on: macos-latest

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -34,12 +34,11 @@ jobs:
         uses: gradle/gradle-build-action@v2.4.2
 
       - name: Run tests with Gradle
-        env:
-          ORG_GRADLE_PROJECT_io_mockk_kotlin_version: ${{ matrix.kotlin-version }}
-          ORG_GRADLE_PROJECT_io_mockk_java_toolchain_test_version: ${{ matrix.java-version }}
         run: >
           ./gradlew check
           --stacktrace
+          -Pio_mockk_kotlin_version=${{ matrix.kotlin-version }}
+          -Pio_mockk_java_toolchain_test_version=${{ matrix.java-version }}
 
   android-instrumented-tests:
     runs-on: macos-latest

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 }
 
 // set the versions of Gradle plugins that the subprojects will use here
-val kotlinPluginVersion: String = "1.9.10"
+val kotlinPluginVersion: String = providers.gradleProperty("io_mockk_kotlin_version").getOrElse("1.9.10")
 
 val androidGradle = "8.1.1"
 val kotlinxKover = "0.7.3"

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 }
 
 // set the versions of Gradle plugins that the subprojects will use here
-val kotlinVersion: String = providers.gradleProperty("io_mockk_kotlin_version").getOrElse("1.9.10")
+val kotlinPluginVersion: String = "1.9.10"
 
 val androidGradle = "8.1.1"
 val kotlinxKover = "0.7.3"
@@ -13,10 +13,10 @@ val dokka = "1.9.0"
 val binaryCompatibilityValidator = "0.13.2"
 
 dependencies {
-    implementation(platform("org.jetbrains.kotlin:kotlin-bom:$kotlinVersion"))
-    implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion")
-    implementation("org.jetbrains.kotlin:kotlin-reflect:$kotlinVersion")
-    implementation("org.jetbrains.kotlin:kotlin-allopen:$kotlinVersion")
+    implementation(platform("org.jetbrains.kotlin:kotlin-bom:$kotlinPluginVersion"))
+    implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinPluginVersion")
+    implementation("org.jetbrains.kotlin:kotlin-reflect:$kotlinPluginVersion")
+    implementation("org.jetbrains.kotlin:kotlin-allopen:$kotlinPluginVersion")
 
     implementation("org.jetbrains.kotlinx.kover:org.jetbrains.kotlinx.kover.gradle.plugin:$kotlinxKover")
 

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -1,5 +1,3 @@
-import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
-
 plugins {
     `kotlin-dsl`
 }
@@ -24,20 +22,4 @@ dependencies {
     implementation("org.jetbrains.dokka:dokka-gradle-plugin:$dokka")
 
     implementation("org.jetbrains.kotlinx:binary-compatibility-validator:$binaryCompatibilityValidator")
-}
-
-tasks.withType<KotlinCompile>().configureEach {
-    kotlinOptions {
-        jvmTarget = "11"
-    }
-}
-
-kotlin {
-    jvmToolchain {
-        languageVersion.set(JavaLanguageVersion.of(11))
-    }
-}
-
-kotlinDslPluginOptions {
-    jvmTarget.set("11")
 }

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 }
 
 // set the versions of Gradle plugins that the subprojects will use here
-val kotlinPluginVersion: String = providers.gradleProperty("io_mockk_kotlin_version").getOrElse("1.9.10")
+val kotlinVersion: String = providers.gradleProperty("io_mockk_kotlin_version").getOrElse("1.9.10")
 
 val androidGradle = "8.1.1"
 val kotlinxKover = "0.7.3"
@@ -13,10 +13,10 @@ val dokka = "1.9.0"
 val binaryCompatibilityValidator = "0.13.2"
 
 dependencies {
-    implementation(platform("org.jetbrains.kotlin:kotlin-bom:$kotlinPluginVersion"))
-    implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinPluginVersion")
-    implementation("org.jetbrains.kotlin:kotlin-reflect:$kotlinPluginVersion")
-    implementation("org.jetbrains.kotlin:kotlin-allopen:$kotlinPluginVersion")
+    implementation(platform("org.jetbrains.kotlin:kotlin-bom:$kotlinVersion"))
+    implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion")
+    implementation("org.jetbrains.kotlin:kotlin-reflect:$kotlinVersion")
+    implementation("org.jetbrains.kotlin:kotlin-allopen:$kotlinVersion")
 
     implementation("org.jetbrains.kotlinx.kover:org.jetbrains.kotlinx.kover.gradle.plugin:$kotlinxKover")
 

--- a/buildSrc/src/main/kotlin/buildsrc/config/Deps.kt
+++ b/buildSrc/src/main/kotlin/buildsrc/config/Deps.kt
@@ -3,6 +3,10 @@ package buildsrc.config
 import org.gradle.api.JavaVersion
 import org.gradle.api.Project
 
+fun Project.kotlinVersion(): String =
+    providers.gradleProperty("io_mockk_kotlin_version")
+        .getOrElse(Deps.Versions.kotlinDefault)
+
 object Deps {
     object Versions {
         val jvmTarget = JavaVersion.VERSION_11

--- a/buildSrc/src/main/kotlin/buildsrc/config/Deps.kt
+++ b/buildSrc/src/main/kotlin/buildsrc/config/Deps.kt
@@ -3,8 +3,6 @@ package buildsrc.config
 import org.gradle.api.JavaVersion
 import org.gradle.api.Project
 
-fun Project.kotlinVersion() = findProperty("kotlin.version")?.toString() ?: Deps.Versions.kotlinDefault
-
 object Deps {
     object Versions {
         val jvmTarget = JavaVersion.VERSION_11

--- a/buildSrc/src/main/kotlin/buildsrc/convention/toolchain-jvm.gradle.kts
+++ b/buildSrc/src/main/kotlin/buildsrc/convention/toolchain-jvm.gradle.kts
@@ -25,8 +25,8 @@ tasks.withType<KotlinCompile>().configureEach {
 val javaToolchains: JavaToolchainService = extensions.getByType()
 
 
-val javaToolchainMainVersion = javaLanguageVersion("javaToolchainMainVersion")
-val javaToolchainTestVersion = javaLanguageVersion("javaToolchainTestVersion")
+val javaToolchainMainVersion = javaLanguageVersion("io_mockk_java_toolchain_main_version")
+val javaToolchainTestVersion = javaLanguageVersion("io_mockk_java_toolchain_test_version")
 
 
 // The Java Toolchains that will compile/launch *main* code

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,8 +8,12 @@ org.gradle.welcome=never
 org.gradle.jvmargs=-XX:MaxMetaspaceSize=768m
 kotlin.mpp.stability.nowarn=true
 localrepo=build/maven-local-repo
-android.useAndroidX=true
+########################
 # version of Java that will be used to build the project
-javaToolchainMainVersion=11
+io_mockk_java_toolchain_main_version=11
 # the Java version tests will run against - this is overridden in the GitHub actions
-javaToolchainTestVersion=11
+io_mockk_java_toolchain_test_version=11
+########################
+# Android properties:
+android.useAndroidX=true
+########################


### PR DESCRIPTION
Fix #1048 

* prefix the Java and Kotlin versions with `io_mockk`, which can help in some situations (e.g. if an individual wants to set them specifically on their machine they can add them in `$GRADLE_USER_HOME/gradle.properties` and not risk clashing with other properties)
* standardise the naming for the Kotlin and Java versions (I chose snake_case, but camelCase would work as well - up to you)
* remove Java version/target/toolchain from `buildSrc/build.gradle.kts` - it should be inherited from the root project