### PR TITLE
Make slf4j an optional dependency

### DIFF
--- a/modules/mockk/build.gradle.kts
+++ b/modules/mockk/build.gradle.kts
@@ -38,7 +38,7 @@ kotlin {
         }
         val jvmMain by getting {
             dependencies {
-                implementation(Deps.Libs.slfj)
+                compileOnly(Deps.Libs.slfj)
 
                 implementation(Deps.Libs.junit4)
                 implementation(Deps.Libs.junitJupiter)


### PR DESCRIPTION
Currently, mockk pulls in SL4J even though it's an optional dependency. This causes a warning as detailed in https://github.com/mockk/mockk/issues/243

With this change, SL4J is changed to a compileOnly dependency which truly makes it optional without having any additional work needed.