### PR TITLE
Issue 293: support capture nullable with slot

### DIFF
--- a/modules/mockk-dsl/api/mockk-dsl.api
+++ b/modules/mockk-dsl/api/mockk-dsl.api
@@ -133,16 +133,31 @@ public abstract interface class io/mockk/CapturingMatcher {
 	public abstract fun capture (Ljava/lang/Object;)V
 }
 
+public final class io/mockk/CapturingNullableSlotMatcher : io/mockk/CapturingMatcher, io/mockk/EquivalentMatcher, io/mockk/Matcher, io/mockk/TypedMatcher {
+	public fun <init> (Lio/mockk/CapturingSlot;Lkotlin/reflect/KClass;)V
+	public fun capture (Ljava/lang/Object;)V
+	public fun checkType (Ljava/lang/Object;)Z
+	public final fun component1 ()Lio/mockk/CapturingSlot;
+	public final fun component2 ()Lkotlin/reflect/KClass;
+	public final fun copy (Lio/mockk/CapturingSlot;Lkotlin/reflect/KClass;)Lio/mockk/CapturingNullableSlotMatcher;
+	public static synthetic fun copy$default (Lio/mockk/CapturingNullableSlotMatcher;Lio/mockk/CapturingSlot;Lkotlin/reflect/KClass;ILjava/lang/Object;)Lio/mockk/CapturingNullableSlotMatcher;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun equivalent ()Lio/mockk/Matcher;
+	public fun getArgumentType ()Lkotlin/reflect/KClass;
+	public final fun getCaptureSlot ()Lio/mockk/CapturingSlot;
+	public fun hashCode ()I
+	public fun match (Ljava/lang/Object;)Z
+	public fun substitute (Ljava/util/Map;)Lio/mockk/Matcher;
+	public fun toString ()Ljava/lang/String;
+}
+
 public final class io/mockk/CapturingSlot {
-	public field captured Ljava/lang/Object;
 	public fun <init> ()V
 	public final fun clear ()V
 	public final fun getCaptured ()Ljava/lang/Object;
 	public final fun isCaptured ()Z
 	public final fun isNull ()Z
 	public final fun setCaptured (Ljava/lang/Object;)V
-	public final fun setCaptured (Z)V
-	public final fun setNull (Z)V
 	public fun toString ()Ljava/lang/String;
 }
 

--- a/modules/mockk-dsl/src/commonMain/kotlin/io/mockk/Matchers.kt
+++ b/modules/mockk-dsl/src/commonMain/kotlin/io/mockk/Matchers.kt
@@ -136,7 +136,7 @@ data class CaptureNullableMatcher<T : Any>(
 }
 
 /**
- * Matcher capturing one last value to the CapturingSlot
+ * Matcher capturing one last NON nullable value to the [CapturingSlot]
  */
 data class CapturingSlotMatcher<T : Any>(
     val captureSlot: CapturingSlot<T>,
@@ -145,16 +145,43 @@ data class CapturingSlotMatcher<T : Any>(
     override fun equivalent(): Matcher<Any> = ConstantMatcher(true)
 
     override fun capture(arg: Any?) {
-        if (arg == null) {
-            captureSlot.isNull = true
-        } else {
-            captureSlot.isNull = false
+        // does not capture null values
+        if (arg != null) {
             captureSlot.captured = InternalPlatformDsl.boxCast(argumentType, arg)
         }
-        captureSlot.isCaptured = true
     }
 
     override fun match(arg: T?): Boolean = true
+
+    override fun toString(): String = "slotCapture<${argumentType.simpleName}>()"
+}
+
+/**
+ * Matcher capturing one last nullable value to the [CapturingSlot]
+ */
+data class CapturingNullableSlotMatcher<T : Any>(
+    val captureSlot: CapturingSlot<T?>,
+    override val argumentType: KClass<*>,
+) : Matcher<T>, CapturingMatcher, TypedMatcher, EquivalentMatcher {
+    override fun equivalent(): Matcher<Any> = ConstantMatcher(true)
+
+    override fun capture(arg: Any?) {
+        if (arg == null) {
+            captureSlot.captured = null
+        } else {
+            captureSlot.captured = InternalPlatformDsl.boxCast(argumentType, arg)
+        }
+    }
+
+    override fun match(arg: T?): Boolean = true
+
+    override fun checkType(arg: Any?): Boolean {
+        if (arg == null) {
+            return true
+        }
+
+        return super.checkType(arg)
+    }
 
     override fun toString(): String = "slotCapture<${argumentType.simpleName}>()"
 }

--- a/modules/mockk/src/commonMain/kotlin/io/mockk/MockK.kt
+++ b/modules/mockk/src/commonMain/kotlin/io/mockk/MockK.kt
@@ -119,7 +119,7 @@ inline fun <reified T : Any> spyk(
  * network.download("testfile")
  * // slot.captured is now "testfile"
  */
-inline fun <reified T : Any> slot() = MockK.useImpl {
+inline fun <reified T : Any?> slot() = MockK.useImpl {
     MockKDsl.internalSlot<T>()
 }
 

--- a/modules/mockk/src/commonTest/kotlin/io/mockk/it/CapturingTest.kt
+++ b/modules/mockk/src/commonTest/kotlin/io/mockk/it/CapturingTest.kt
@@ -6,6 +6,7 @@ import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
+import kotlin.test.assertNull
 
 class CapturingTest {
 
@@ -28,6 +29,32 @@ class CapturingTest {
         assertEquals(55, slot.captured.value)
 
         verify { mock.op(1, 2, any()) }
+    }
+
+    @Test
+    fun `CapturingSlot can capture nullable value`() {
+        val mock = mockk<MockCls>()
+
+        val slot = CapturingSlot<Cls?>()
+        every { mock.nullableOp(1, 2, captureNullable(slot)) } returns 22
+
+        assertEquals(22, mock.nullableOp(1, 2, null))
+        assertNull(slot.captured?.value)
+
+        verify { mock.nullableOp(1, 2, null) }
+    }
+
+    @Test
+    fun `slot can capture nullable value`() {
+        val mock = mockk<MockCls>()
+
+        val slot = slot<Cls?>()
+        every { mock.nullableOp(1, 2, captureNullable(slot)) } returns 22
+
+        assertEquals(22, mock.nullableOp(1, 2, null))
+        assertNull(slot.captured?.value)
+
+        verify { mock.nullableOp(1, 2, null) }
     }
 
     @Test
@@ -190,6 +217,9 @@ class CapturingTest {
 
     class MockCls {
         fun op(a: Int, b: Int, c: Cls) = a + b + c.value
+        fun nullableOp(a: Int, b: Int, c: Cls?): Int {
+            return a + b + (c?.value ?: 9)
+        }
     }
 
     class CoMockCls {

--- a/modules/mockk/src/commonTest/kotlin/io/mockk/it/CapturingTest.kt
+++ b/modules/mockk/src/commonTest/kotlin/io/mockk/it/CapturingTest.kt
@@ -58,6 +58,19 @@ class CapturingTest {
     }
 
     @Test
+    fun `captureNullable can capture non null value`() {
+        val mock = mockk<MockCls>()
+
+        val slot = slot<Cls?>()
+        every { mock.nullableOp(1, 2, captureNullable(slot)) } returns 22
+        val toBeCaptured = Cls()
+        assertEquals(22, mock.nullableOp(1, 2, toBeCaptured))
+        assertEquals(slot.captured?.value, toBeCaptured.value)
+
+        verify { mock.nullableOp(1, 2, toBeCaptured) }
+    }
+
+    @Test
     fun captureListSlot() {
         val mock = mockk<MockCls>()
 

--- a/modules/mockk/src/jvmTest/kotlin/io/mockk/CapturingSlotTest.kt
+++ b/modules/mockk/src/jvmTest/kotlin/io/mockk/CapturingSlotTest.kt
@@ -1,0 +1,42 @@
+package io.mockk
+
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class CapturingSlotTest {
+
+    @Test
+    fun `capturing slot behave as expected`() {
+        val slot = CapturingSlot<String?>()
+        // init state - exception is thrown if value is not yet captured
+        val initStateMessage = assertThrows<IllegalStateException> { slot.captured }.message
+        assertEquals(initStateMessage, "Value not yet captured.")
+        assertFalse(slot.isCaptured)
+        assertFalse(slot.isNull)
+        // capture non null value
+        slot.captured = "value"
+        assertEquals(slot.captured, "value")
+        assertTrue(slot.isCaptured)
+        assertFalse(slot.isNull)
+        // clear captured
+        slot.clear()
+        val afterNonNullClearMessage = assertThrows<IllegalStateException> { slot.captured }.message
+        assertEquals(afterNonNullClearMessage, "Value not yet captured.")
+        assertFalse(slot.isCaptured)
+        assertFalse(slot.isNull)
+        // capture null value
+        slot.captured = null
+        assertEquals(slot.captured, null)
+        assertTrue(slot.isCaptured)
+        assertTrue(slot.isNull)
+        //clear captured
+        slot.clear()
+        val afterNullableClearMessage = assertThrows<IllegalStateException> { slot.captured }.message
+        assertEquals(afterNullableClearMessage, "Value not yet captured.")
+        assertFalse(slot.isCaptured)
+        assertFalse(slot.isNull)
+    }
+}


### PR DESCRIPTION
Hello,

This is PR for Allow to Capture nullable values with `CapturingSlot` see [293](https://github.com/mockk/mockk/issues/293). Seems it works according to tests.

Changes on  `CapturingSlot` API are big, I can make them less invasive, but currently I don`t know how much problem it is. I mean removal of 
```
public field captured Ljava/lang/Object; //is not field only get/set now
public final fun setCaptured (Z)V // only getter now
public final fun setNull (Z)V // only getter now
```