### PR TITLE
1122(docs): fix header for `clearStaticMockk`

### DIFF
--- a/modules/mockk/src/commonMain/kotlin/io/mockk/MockK.kt
+++ b/modules/mockk/src/commonMain/kotlin/io/mockk/MockK.kt
@@ -520,7 +520,7 @@ inline fun mockkStatic(vararg classes: String) = MockK.useImpl {
 }
 
 /**
- * Cancel static mocks.
+ * Clears static mocks.
  */
 inline fun clearStaticMockk(
     vararg classes: KClass<*>,


### PR DESCRIPTION
# Summary

Changes `"Cancel"` to `"Clears"` for the `clearStaticMockk` header.

# Related Issues/PRs

Fixes #1122.