### PR TITLE
Fix `IncompatibleClassChangeError` in Android instrumentation test

### DIFF
--- a/buildSrc/src/main/kotlin/buildsrc/config/Deps.kt
+++ b/buildSrc/src/main/kotlin/buildsrc/config/Deps.kt
@@ -26,6 +26,7 @@ object Deps {
         const val androidxTestRules = "1.4.0"
         const val androidxTestRunner = "1.4.0"
         const val androidxTestExtJunit = "1.1.3"
+        const val androidxTestOrchestrator = "1.4.2"
     }
 
     object Libs {

--- a/buildSrc/src/main/kotlin/buildsrc/convention/android-library.gradle.kts
+++ b/buildSrc/src/main/kotlin/buildsrc/convention/android-library.gradle.kts
@@ -59,6 +59,7 @@ dependencies {
     androidTestImplementation("androidx.test:rules:${Deps.Versions.androidxTestRules}")
     androidTestImplementation("androidx.test:runner:${Deps.Versions.androidxTestRunner}")
     androidTestImplementation("androidx.test.ext:junit-ktx:${Deps.Versions.androidxTestExtJunit}")
+    androidTestUtil("androidx.test:orchestrator:${Deps.Versions.androidxTestOrchestrator}")
 
     androidTestImplementation(kotlin("test"))
     androidTestImplementation(kotlin("test-junit"))


### PR DESCRIPTION
Fixes https://github.com/mockk/mockk/issues/1035

When eliminating duplicate `ProxyMaker` in d9ceddcbdd1d7f6e6cad291bb1a3d7bdb512ab68, the logic for `isInterface` was missing.
This caused an `IncompatibleClassChangeError` in Android instrumentation test.

Also, the Test Orchestrator is not working, and `. /gradlew connectedAndroidTest` always returned zero results, which has been fixed.