### PR TITLE
Update Android test targets

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -46,7 +46,7 @@ jobs:
     runs-on: macos-latest
     strategy:
       matrix:
-        api-level: [ 21, 29 ] # The minSdk and targetSdk versions set for MockK Android projects
+        api-level: [ 29, 31 ] # The minSdk and targetSdk versions set for MockK Android projects
       fail-fast: false # in case one API-level fails, we still want to see results from others
     name: "[api-level=${{ matrix.api-level }}]"
     timeout-minutes: 30


### PR DESCRIPTION
## Summary

As suggested [here](https://github.com/mockk/mockk/pull/1145#issuecomment-1713924755), this updates MockK's Android test targets to be API 29 and 31 (removing 21 and adding 31). The older target is broken and no longer mainstream, while the newer is relatively common.

## Verification

- [X] Tests pass locally against an API 29 emulator (when [orchestrator fix](https://github.com/mockk/mockk/pull/1145/commits/1a1e71772f5077a68a28307c47be190c216ca03e) is applied)
- [X] Tests pass locally against an API 31 emulator (when [orchestrator fix](https://github.com/mockk/mockk/pull/1145/commits/1a1e71772f5077a68a28307c47be190c216ca03e) is applied)