### PR TITLE
Remove Kotlin-IR from CI matrix

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -18,9 +18,8 @@ jobs:
       matrix:
         java-version: [ 17, 19 ] # test LTS versions, and the newest
         kotlin-version: [ 1.5.31, 1.6.21, 1.7.22, 1.8.20 ]
-        kotlin-ir-enabled: [ true, false ]
       fail-fast: false # in case one JDK fails, we still want to see results from others
-    name: "[java=${{ matrix.java-version }}, kotlin=${{ matrix.kotlin-version }}, IR=${{ matrix.kotlin-ir-enabled }}]"
+    name: "[java=${{ matrix.java-version }}, kotlin=${{ matrix.kotlin-version }}]"
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v3
@@ -39,7 +38,6 @@ jobs:
           ./gradlew check
           --stacktrace
           -Pkotlin.version=${{ matrix.kotlin-version }}
-          -Pkotlin.ir.enabled=${{ matrix.kotlin-ir-enabled }}
           -PjavaToolchainTestVersion=${{ matrix.java-version }}
 
   android-instrumented-tests:


### PR DESCRIPTION
The last usage was removed in https://github.com/mockk/mockk/commit/ada19d57d42aac1e69007cfbef14f8c5294e0ef8#diff-49a96e7eea8a94af862798a45174e6ac43eb4f8b4bd40759b5da63ba31ec3ef7