### PR TITLE
Fix `dokkaJavadoc` publishing task

### DIFF
--- a/buildSrc/src/main/kotlin/buildsrc/convention/android-library.gradle.kts
+++ b/buildSrc/src/main/kotlin/buildsrc/convention/android-library.gradle.kts
@@ -68,6 +68,12 @@ dependencies {
     androidTestUtil("androidx.test:orchestrator:${Deps.Versions.androidxOrchestrator}")
 }
 
+// Fix: Task 'dokkaJavadoc' uses this output of task 'kaptReleaseKotlin' without declaring an explicit or implicit dependency.
+tasks.dokkaJavadoc.configure {
+    mustRunAfter(tasks.named("kaptDebugKotlin"))
+    mustRunAfter(tasks.named("kaptReleaseKotlin"))
+}
+
 val javadocJar by tasks.registering(Jar::class) {
     from(tasks.dokkaJavadoc)
     archiveClassifier.set("javadoc")


### PR DESCRIPTION
`dokkaJavadoc` relies implicitly on `kaptDebugKotlin` and `kaptReleaseKotlin` leading to Gradle failing the build. Adding explicit dependency as the message suggest fixes the issue.