### PR TITLE
JVM 1.8 source compatibility

### DIFF
--- a/buildSrc/src/main/kotlin/buildsrc/config/Deps.kt
+++ b/buildSrc/src/main/kotlin/buildsrc/config/Deps.kt
@@ -9,7 +9,7 @@ fun Project.kotlinVersion(): String =
 
 object Deps {
     object Versions {
-        val jvmTarget = JavaVersion.VERSION_11
+        val jvmTarget = JavaVersion.VERSION_1_8
 
         const val dokka = "1.9.0"
         const val kotlinDefault = "1.9.10"


### PR DESCRIPTION
[This commit](https://github.com/mockk/mockk/commit/b6cf9551da37b17f718f44677107ea23ec616982) changed JVM source compatibility to JVM 11, but this doesn't seem to be required. Reverting to 1.8 compatibility supports more apps and libraries that target JVM <11.