### PR TITLE
Fix unit tests errors by using `slf4jOrJulLogging()`

### DIFF
--- a/modules/mockk/src/jvmTest/kotlin/io/mockk/it/ParallelTest.kt
+++ b/modules/mockk/src/jvmTest/kotlin/io/mockk/it/ParallelTest.kt
@@ -4,8 +4,8 @@ import io.mockk.MockKAnnotations
 import io.mockk.every
 import io.mockk.impl.annotations.MockK
 import io.mockk.verify
-import org.slf4j.Logger
-import org.slf4j.LoggerFactory
+import io.mockk.impl.log.JvmLogging
+import io.mockk.impl.log.Logger
 import java.util.Collections.synchronizedList
 import java.util.Random
 import kotlin.test.Test
@@ -63,15 +63,15 @@ class ParallelTest {
                         mock.op(a, b)
                         ops.add(Op(mock, a, b))
                     }
-                    log.info("Done operations for thread {}", n)
+                    log.info { "Done operations for thread $n" }
 
                     repeat(500) {
                         val op = ops[rnd.nextInt(ops.size)]
                         verify { op.mock.op(op.a, op.b) }
                     }
-                    log.info("Done verification block for thread {}", n)
+                    log.info { "Done verification block for thread $n" }
                 } catch (ex: Exception) {
-                    log.warn("Exception for thread {}", n, ex)
+                    log.warn(ex) { "Exception for thread $n" }
                     exceptions.add(ex)
                 }
             }
@@ -85,6 +85,6 @@ class ParallelTest {
     }
 
     companion object {
-        val log: Logger = LoggerFactory.getLogger(ParallelTest::class.java)
+        val log: Logger = JvmLogging.slf4jOrJulLogging()(ParallelTest::class)
     }
 }


### PR DESCRIPTION
Closes #1165

This could also be solved by adding the slf4j/logback dependency to the jvmTest configutation.
Tell me what's the best approach.