### PR TITLE
Fixes infinite recursion when stubbing a fun that returns value class

### DIFF
--- a/modules/mockk-agent/src/jvmMain/kotlin/io/mockk/proxy/jvm/transformation/InliningClassTransformer.kt
+++ b/modules/mockk-agent/src/jvmMain/kotlin/io/mockk/proxy/jvm/transformation/InliningClassTransformer.kt
@@ -108,6 +108,7 @@ internal class InliningClassTransformer(
                 isMethod<MethodDescription>()
                     .and(not<OfByteCodeElement>(isStatic<OfByteCodeElement>()))
                     .and(not<MethodDescription>(isDefaultFinalizer<MethodDescription>()))
+                    .and(not<MethodDescription>(this::matchValueClassGetValueMethod))
             )
 
     @Suppress("RemoveExplicitTypeArguments")
@@ -124,6 +125,15 @@ internal class InliningClassTransformer(
 
     private fun matchRestrictedMethods(desc: MethodDescription) =
         desc.declaringType.typeName + "." + desc.name in restrictedMethods
+
+    private fun matchValueClassGetValueMethod(desc: MethodDescription): Boolean {
+        return isFinal<MethodDescription>()
+            .and(isDeclaredBy(isAnnotatedWith(JvmInline::class.java)))
+            .and(named("getValue"))
+            .and(isPublic())
+            .and(takesNoArguments())
+            .matches(desc)
+    }
 
     @Suppress("RemoveExplicitTypeArguments")
     private fun constructorAdvice(): AsmVisitorWrapper.ForDeclaredMethods {

--- a/modules/mockk/src/commonTest/kotlin/io/mockk/it/ValueClassTest.kt
+++ b/modules/mockk/src/commonTest/kotlin/io/mockk/it/ValueClassTest.kt
@@ -1,6 +1,8 @@
 package io.mockk.it
 
 import io.mockk.*
+import org.junit.jupiter.api.assertTimeoutPreemptively
+import java.time.Duration
 import kotlin.jvm.JvmInline
 import kotlin.test.Ignore
 import kotlin.test.Test
@@ -488,6 +490,17 @@ class ValueClassTest {
         val result = mock.returnValueClass()
 
         assertEquals(givenResult, result)
+    }
+
+    @Test
+    fun `ensure no infinite recursion when mocking fun that returns value class`() {
+        val f: () -> DummyValue = mockk()
+
+        assertTimeoutPreemptively(Duration.ofMillis(500L)) {
+            runCatching {
+                every { f.invoke() } returns DummyValue(42)
+            }
+        }
     }
 
     companion object {


### PR DESCRIPTION
(issue #977)

Adds exclusion rule to prevent interception of the value class getValue method