### PR TITLE
Specify unique `android.namespace` to resolve warnings

### DIFF
--- a/buildSrc/src/main/kotlin/buildsrc/convention/android-application.gradle.kts
+++ b/buildSrc/src/main/kotlin/buildsrc/convention/android-application.gradle.kts
@@ -13,7 +13,6 @@ plugins {
 }
 
 android {
-    namespace = "io.mockk"
     compileSdk = Deps.Versions.compileSdk
 
     lint {

--- a/buildSrc/src/main/kotlin/buildsrc/convention/android-library.gradle.kts
+++ b/buildSrc/src/main/kotlin/buildsrc/convention/android-library.gradle.kts
@@ -15,7 +15,6 @@ plugins {
 }
 
 android {
-    namespace = "io.mockk"
     compileSdk = Deps.Versions.compileSdk
 
     lint {

--- a/modules/mockk-agent-android/build.gradle.kts
+++ b/modules/mockk-agent-android/build.gradle.kts
@@ -14,6 +14,7 @@ val mavenDescription: String by extra("${project.description}")
 
 @Suppress("UnstableApiUsage")
 android {
+    namespace = "io.mockk.proxy.android"
     externalNativeBuild {
         cmake {
             path = file("CMakeLists.txt")

--- a/modules/mockk-android/build.gradle.kts
+++ b/modules/mockk-android/build.gradle.kts
@@ -10,6 +10,7 @@ val mavenName: String by extra("MockK Android")
 val mavenDescription: String by extra("${project.description}")
 
 android {
+    namespace = "io.mockk.android"
     packaging {
         resources {
             excludes += "META-INF/LICENSE.md"


### PR DESCRIPTION
To fix https://github.com/mockk/mockk/issues/1180

The breaking change would not occur because MockK does not use `R` files.

If you have an appropriate namespace specification, please comment.
