### PR TITLE
fix atMost + timeout verify

### DIFF
--- a/modules/mockk/src/commonMain/kotlin/io/mockk/impl/verify/TimeoutVerifier.kt
+++ b/modules/mockk/src/commonMain/kotlin/io/mockk/impl/verify/TimeoutVerifier.kt
@@ -17,10 +17,14 @@ class TimeoutVerifier(
         val stubs = verificationSequence.allStubs(stubRepo)
 
         val session = stubRepo.openRecordCallAwaitSession(stubs, params.timeout)
+        val startTime = System.currentTimeMillis()
         try {
             while (true) {
                 val result = verifierChain.verify(verificationSequence, params)
-                if (params.inverse != result.matches) {
+                // With atMost set the reaching expected result does not mean test passed
+                //  - it can fail till the end of the timeout
+                if (params.inverse != result.matches && 
+                        (params.max != Int.MAX_VALUE && (System.currentTimeMillis() - startTime < params.timeout))) {
                     return result // passed
                 }
                 if (!session.wait()) {


### PR DESCRIPTION
This is addressed to fix https://github.com/mockk/mockk/issues/1169

In the current implementation the `TimeoutVerifier.verify` exits as soon as it reached the first success condition, but having the upper limit set with `atMost` we can not be sure this condition won't fail in the rest of timeout.

In order to wait until the timeout i propose this quick fix which prevents `TimeoutVerifier.verify` to exit too early.

This PoC draft PR and need to be tested.