### PR TITLE
Prevent kover setup failure without Android SDK

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -36,8 +36,13 @@ idea {
 dependencies {
     kover(projects.modules.mockk)
     kover(projects.modules.mockkAgent)
-    kover(projects.modules.mockkAndroid)
-    kover(projects.modules.mockkAgentAndroid)
+    // if the android SDK is not available trying to resolve the module names will fail
+    listOf("android", "agent-android").forEach { module ->
+        rootProject.subprojects.find { it.name == "mockk-$module" }?.let {
+            kover(it)
+        }
+    }
+
     kover(projects.testModules.loggerTests)
     kover(projects.testModules.clientTests)
     kover(projects.testModules.performanceTests)


### PR DESCRIPTION
Fixes #1191 

Not a particularly nice solution but unfortunately type safe project access doesn't like mentioning non-existing projects at all - which is okay since that's what it was built for.

Afaik there isn't any check whether a constant is defined in Kotlin script, so I had to resort to a more traditional approach... :grimacing: 