### PR TITLE
Fix StackOverflowError calling method on spy of class with generic base class

### DIFF
--- a/modules/mockk-agent/src/jvmMain/kotlin/io/mockk/proxy/jvm/advice/SelfCallEliminator.kt
+++ b/modules/mockk-agent/src/jvmMain/kotlin/io/mockk/proxy/jvm/advice/SelfCallEliminator.kt
@@ -1,6 +1,8 @@
 package io.mockk.proxy.jvm.advice
 
 import java.lang.reflect.Method
+import java.lang.reflect.ParameterizedType
+import java.lang.reflect.Type
 import java.util.Arrays
 
 internal object SelfCallEliminator {
@@ -12,7 +14,15 @@ internal object SelfCallEliminator {
     }
 
     private fun checkOverride(method1: Method, method2: Method): Boolean {
-        return method1.name == method2.name && Arrays.equals(method1.parameterTypes, method2.parameterTypes)
+        val namesMatch = method1.name == method2.name
+
+        val parameterTypesMatch = method1.parameterTypes.contentEquals(method2.parameterTypes) ||
+            (method1.parameterTypes.size == method2.parameterTypes.size &&
+                method1.parameterTypes.zip(method2.parameterTypes).all { (type1, type2) ->
+                    type1.isAssignableFrom(type2) || type2.isAssignableFrom(type1)
+                })
+
+        return namesMatch && parameterTypesMatch
     }
 
     inline fun <T> apply(self: Any, method: Method, block: () -> T): T {

--- a/modules/mockk-agent/src/jvmTest/java/io/mockk/proxy/advice/SelfCallEliminatorTest.kt
+++ b/modules/mockk-agent/src/jvmTest/java/io/mockk/proxy/advice/SelfCallEliminatorTest.kt
@@ -1,0 +1,65 @@
+package io.mockk.proxy.advice
+
+import io.mockk.proxy.jvm.advice.SelfCallEliminator
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.lang.reflect.Method
+
+class SelfCallEliminatorTest {
+
+    @Test
+    fun `isSelf returns true when ChildClass overrides BaseClass method with type parameter`() {
+        val childMethod = getMethod("method", ChildClass::class.java, String::class.java) // ChildClass: override fun method(t: String)
+        val baseMethod = getMethod("method", BaseClass::class.java, Any::class.java) // BaseClass: open fun method(t: T)
+
+        SelfCallEliminator.apply(ChildClass::class.java, childMethod) {
+            assertTrue(SelfCallEliminator.isSelf(ChildClass::class.java, baseMethod))
+        }
+
+        SelfCallEliminator.apply(BaseClass::class.java, baseMethod) {
+            assertTrue(SelfCallEliminator.isSelf(BaseClass::class.java, childMethod))
+        }
+    }
+
+    @Test
+    fun `isSelf returns false when methods are not self`() {
+        val childMethod = getMethod("method", ChildClass::class.java, Int::class.java) // ChildClass: fun method(t: Int)
+        val baseMethod = getMethod("method", BaseClass::class.java, Any::class.java)  // BaseClass: open fun method(t: T)
+
+        SelfCallEliminator.apply(ChildClass::class.java, childMethod) {
+            assertFalse(SelfCallEliminator.isSelf(ChildClass::class.java, baseMethod))
+        }
+
+        val otherMethod = getMethod("someOtherMethod", ChildClass::class.java, String::class.java) // ChildClass: fun someOtherMethod(t: String)
+
+        SelfCallEliminator.apply(ChildClass::class.java, otherMethod) {
+            assertFalse(SelfCallEliminator.isSelf(ChildClass::class.java, baseMethod))
+        }
+    }
+
+    private fun getMethod(name: String, clazz: Class<*>, parameterType: Class<*>): Method {
+        return clazz.getDeclaredMethod(name, parameterType)
+    }
+
+    abstract class BaseClass<T> {
+        open fun method(t: T) {
+            println("BaseClass method with type parameter: $t")
+        }
+    }
+
+    class ChildClass : BaseClass<String>() {
+        override fun method(t: String) {
+            super.method(t)
+            println("ChildClass method with parameter String: $t")
+        }
+
+        fun method(t: Int) {
+            println("ChildClass method with parameter Int: $t")
+        }
+
+        fun someOtherMethod(t: String) {
+            println("ChildClass someOtherMethod with parameter String: $t")
+        }
+    }
+}


### PR DESCRIPTION
Issue #366 

Modified the `checkOverride` function to include a check for parameter type assignability, preventing infinite recursion and resolving the stack overflow issue.

