### PR TITLE
Fix callOriginal on default interface method

### DIFF
--- a/modules/mockk-agent/api/mockk-agent.api
+++ b/modules/mockk-agent/api/mockk-agent.api
@@ -137,3 +137,11 @@ public class io/mockk/proxy/jvm/dispatcher/JvmMockKWeakMap : java/util/Map {
 	public fun values ()Ljava/util/Collection;
 }
 
+public final class io/mockk/proxy/jvm/util/DefaultInterfaceMethodResolver {
+	public static final field Companion Lio/mockk/proxy/jvm/util/DefaultInterfaceMethodResolver$Companion;
+	public fun <init> ()V
+}
+
+public final class io/mockk/proxy/jvm/util/DefaultInterfaceMethodResolver$Companion {
+}
+

--- a/modules/mockk-agent/src/jvmMain/java/io/mockk/proxy/jvm/advice/jvm/JvmMockKProxyInterceptor.java
+++ b/modules/mockk-agent/src/jvmMain/java/io/mockk/proxy/jvm/advice/jvm/JvmMockKProxyInterceptor.java
@@ -1,13 +1,12 @@
 package io.mockk.proxy.jvm.advice.jvm;
 
-import io.mockk.proxy.MockKInvocationHandler;
 import io.mockk.proxy.jvm.advice.BaseAdvice;
 import io.mockk.proxy.jvm.advice.ProxyAdviceId;
 import io.mockk.proxy.jvm.dispatcher.JvmMockKDispatcher;
+import io.mockk.proxy.jvm.util.DefaultInterfaceMethodResolver;
 import net.bytebuddy.implementation.bind.annotation.*;
 
 import java.lang.reflect.Method;
-import java.util.Map;
 import java.util.concurrent.Callable;
 
 public class JvmMockKProxyInterceptor extends BaseAdvice {
@@ -42,7 +41,8 @@ public class JvmMockKProxyInterceptor extends BaseAdvice {
             return null;
         }
 
-        return dispatcher.handle(self, method, args, null);
+        return dispatcher.handle(self, method, args, DefaultInterfaceMethodResolver.Companion.getDefaultImplementationOrNull$mockk_agent(self, method, args));
+
     }
 
 }

--- a/modules/mockk-agent/src/jvmMain/kotlin/io/mockk/proxy/jvm/util/DefaultInterfaceMethodResolver.kt
+++ b/modules/mockk-agent/src/jvmMain/kotlin/io/mockk/proxy/jvm/util/DefaultInterfaceMethodResolver.kt
@@ -1,0 +1,39 @@
+package io.mockk.proxy.jvm.util
+
+import io.mockk.proxy.jvm.advice.MethodCall
+import java.lang.reflect.Method
+import java.lang.reflect.Modifier
+
+class DefaultInterfaceMethodResolver {
+
+    companion object {
+
+        internal fun getDefaultImplementationOrNull(mock: Any, method: Method, arguments: Array<Any?>): MethodCall? =
+            findDefaultImplMethod(method)
+                ?.let {
+                    val defaultImplMethodArguments = arrayOf(mock, *arguments)
+                    MethodCall(mock, it, defaultImplMethodArguments)
+                }
+
+        private fun findDefaultImplMethod(method: Method): Method? =
+            method.takeIf { Modifier.isAbstract(it.modifiers) }
+                ?.declaringClass
+                ?.let { declaringClass ->
+                    findDefaultImplsClass(declaringClass)
+                        ?.runCatching {
+                            getMethod(method.name, declaringClass, *method.parameterTypes.requireNoNulls())
+                        }
+                        ?.getOrNull()
+                        ?.takeIf { Modifier.isStatic(it.modifiers) }
+                }
+
+        private fun findDefaultImplsClass(clazz: Class<*>): Class<*>? =
+            clazz.takeIf { it.isInterface && isKotlinClass(it) }
+                ?.classes?.firstOrNull { it.simpleName == "DefaultImpls" && Modifier.isStatic(it.modifiers) }
+
+        private fun isKotlinClass(clazz: Class<*>): Boolean {
+            return clazz.isAnnotationPresent(Metadata::class.java)
+        }
+    }
+
+}

--- a/modules/mockk-agent/src/jvmTest/java/io/mockk/proxy/util/DefaultInterfaceMethodResolverTest.kt
+++ b/modules/mockk-agent/src/jvmTest/java/io/mockk/proxy/util/DefaultInterfaceMethodResolverTest.kt
@@ -1,0 +1,69 @@
+package io.mockk.proxy.util
+
+import io.mockk.proxy.jvm.util.DefaultInterfaceMethodResolver
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import kotlin.test.Test
+
+
+class DefaultInterfaceMethodResolverTest {
+
+  interface A {
+    fun method()
+    fun defaultMethod(arg: String): String {
+      return "Arg: $arg"
+    }
+  }
+
+  class B : A {
+    fun subclassMethod(arg: String) {}
+    override fun method() {
+    }
+  }
+
+  @Test
+  fun `should return MethodCall when default implementation exists`() {
+    val subclass = B()
+    val method = A::class.java.getMethod("defaultMethod", String::class.java)
+    val arguments = arrayOfNulls<Any>(1).also { it[0] = "arg" }
+
+    val result = DefaultInterfaceMethodResolver.getDefaultImplementationOrNull(subclass, method, arguments)
+
+    assertNotNull(result)
+
+  }
+
+  @Test
+  fun `should return null when is concrete class method`() {
+    val subclass = B()
+    val method = B::class.java.getMethod("subclassMethod", String::class.java)
+    val arguments = arrayOfNulls<Any>(1).also { it[0] = "arg" }
+
+    val result = DefaultInterfaceMethodResolver.getDefaultImplementationOrNull(subclass, method, arguments)
+
+    assertNull(result)
+  }
+
+  @Test
+  fun `should return null when method is overwritten`() {
+    val subclass = B()
+    val method = A::class.java.getDeclaredMethod("method")
+    val arguments = arrayOfNulls<Any>(0)
+
+    val result = DefaultInterfaceMethodResolver.getDefaultImplementationOrNull(subclass, method, arguments)
+
+    assertNull(result)
+  }
+
+  @Test
+  fun `should return null when method is not a Kotlin class`() {
+    val subclass = ArrayList<Any>()
+    val method = ArrayList::class.java.getDeclaredMethod("add", Any::class.java)
+    val arguments = arrayOfNulls<Any>(1).also { it[0] = "element" }
+
+    val result = DefaultInterfaceMethodResolver.getDefaultImplementationOrNull(subclass, method, arguments)
+
+    assertNull(result)
+  }
+
+}

--- a/modules/mockk/src/jvmTest/kotlin/io/mockk/it/CallOriginalOnDefaultInterfaceMethodTest.kt
+++ b/modules/mockk/src/jvmTest/kotlin/io/mockk/it/CallOriginalOnDefaultInterfaceMethodTest.kt
@@ -1,0 +1,42 @@
+package io.mockk.it
+
+import io.mockk.*
+import kotlin.test.Test
+
+class CallOriginalOnDefaultInterfaceMethodTest {
+
+  interface A {
+    fun method1(items: List<Int>)
+    fun method2(items: List<Int>)
+    fun defaultMethod(callMethod2: Boolean) {
+      method1(listOf(1, 2, 3))
+      if (callMethod2)
+        method2(listOf(4, 5, 6))
+    }
+  }
+
+  @Test
+  fun `should call the original default method when spy the class`() {
+    val spy = spyk<A>()
+    every { spy.defaultMethod(any()) } answers { callOriginal() }
+
+    spy.defaultMethod(callMethod2 = true)
+
+    verify { spy.method1(listOf(1, 2, 3)) }
+    verify { spy.method2(listOf(4, 5, 6)) }
+  }
+
+  @Test
+  fun `should call the original default method when mock the class`() {
+    val mock = mockk<A>()
+    every { mock.defaultMethod(any()) } answers { callOriginal() }
+    every { mock.method1(any()) } just runs
+    every { mock.method2(any()) } just runs
+
+    mock.defaultMethod(callMethod2 = true)
+
+    verify { mock.method1(listOf(1, 2, 3)) }
+    verify { mock.method2(listOf(4, 5, 6)) }
+  }
+
+}


### PR DESCRIPTION
Issue: #64

The Kotlin compiler generates an additional class that contains an implementation of a default method as a static member. This method will always be intercepted by InterceptNoSuper since it doesn't have a `@SuperCall`.

Reference: 
https://github.com/mockk/mockk/blob/ef56926bbbc740cb0a5ae87a56726c3ca175713e/modules/mockk-agent/src/jvmMain/java/io/mockk/proxy/jvm/advice/jvm/JvmMockKProxyInterceptor.java#L34-L38

To determine whether the method is a default interface method or not, I have implemented a new utility class named DefaultInterfaceMethodResolver. 
This class attempts to find the DefaultImpls class and then the default method.