### PR TITLE
Only unbox value class answers when appropriate

### DIFF
--- a/modules/mockk-agent/src/jvmMain/kotlin/io/mockk/proxy/jvm/advice/Interceptor.kt
+++ b/modules/mockk-agent/src/jvmMain/kotlin/io/mockk/proxy/jvm/advice/Interceptor.kt
@@ -1,6 +1,6 @@
 package io.mockk.proxy.jvm.advice
 
-import io.mockk.core.ValueClassSupport.boxedValue
+import io.mockk.core.ValueClassSupport.maybeUnboxValueForMethodReturn
 import io.mockk.proxy.MockKInvocationHandler
 import java.lang.reflect.Method
 import java.util.concurrent.Callable
@@ -19,7 +19,7 @@ internal class Interceptor(
             method
         )
         return handler.invocation(self, method, callOriginalMethod, arguments)
-            ?.boxedValue // unbox value class objects
+                ?.maybeUnboxValueForMethodReturn(method)
     }
 
 }

--- a/modules/mockk-core/api/mockk-core.api
+++ b/modules/mockk-core/api/mockk-core.api
@@ -2,5 +2,6 @@ public final class io/mockk/core/ValueClassSupport {
 	public static final field INSTANCE Lio/mockk/core/ValueClassSupport;
 	public final fun getBoxedClass (Lkotlin/reflect/KClass;)Lkotlin/reflect/KClass;
 	public final fun getBoxedValue (Ljava/lang/Object;)Ljava/lang/Object;
+	public final fun maybeUnboxValueForMethodReturn (Ljava/lang/Object;Ljava/lang/reflect/Method;)Ljava/lang/Object;
 }
 

--- a/modules/mockk-core/src/commonMain/kotlin/io/mockk/core/ValueClassSupport.kt
+++ b/modules/mockk-core/src/commonMain/kotlin/io/mockk/core/ValueClassSupport.kt
@@ -1,9 +1,18 @@
 package io.mockk.core
 
+import java.lang.reflect.Method
 import kotlin.reflect.KClass
 
 
 expect object ValueClassSupport {
+
+    /**
+     * Unboxes the underlying property value of a **`value class`** or self, as long the unboxed value is appropriate
+     * for the given method's return type.
+     *
+     * @see boxedValue
+     */
+    fun <T : Any> T.maybeUnboxValueForMethodReturn(method: Method): Any?
 
     /**
      * Underlying property value of a **`value class`** or self.

--- a/modules/mockk-core/src/jvmMain/kotlin/io/mockk/core/ValueClassSupport.kt
+++ b/modules/mockk-core/src/jvmMain/kotlin/io/mockk/core/ValueClassSupport.kt
@@ -1,14 +1,41 @@
 package io.mockk.core
 
+import java.lang.reflect.Method
 import kotlin.reflect.KClass
 import kotlin.reflect.KProperty1
 import kotlin.reflect.full.declaredMemberProperties
 import kotlin.reflect.jvm.isAccessible
 import kotlin.reflect.jvm.javaField
 import kotlin.reflect.jvm.internal.KotlinReflectionInternalError
+import kotlin.reflect.jvm.kotlinFunction
 
 
 actual object ValueClassSupport {
+
+    /**
+     * Unboxes the underlying property value of a **`value class`** or self, as long the unboxed value is appropriate
+     * for the given method's return type.
+     *
+     * @see boxedValue
+     */
+    actual fun <T : Any> T.maybeUnboxValueForMethodReturn(method: Method): Any? {
+        val resultType = this::class
+        if (!resultType.isValue_safe) {
+            return this
+        }
+        val kFunction = method.kotlinFunction ?: return this
+
+        // Only unbox a value class if the method's return type is actually the type of the inlined property.
+        // For example, in a normal case where a value class `Foo` with underlying `Int` property is inlined:
+        //   method.returnType == int (the actual representation of inlined property on JVM)
+        //   method.kotlinFunction.returnType.classifier == Foo
+        val expectedReturnType = kFunction.returnType.classifier
+        return if (resultType == expectedReturnType) {
+            this.boxedValue
+        } else {
+            this
+        }
+    }
 
     /**
      * Underlying property value of a **`value class`** or self.

--- a/modules/mockk/src/commonTest/kotlin/io/mockk/it/ValueClassTest.kt
+++ b/modules/mockk/src/commonTest/kotlin/io/mockk/it/ValueClassTest.kt
@@ -585,6 +585,23 @@ class ValueClassTest {
         }
     }
 
+    @Test
+    fun `spy class returning value class not boxed due to cast to another type`() {
+        val f = spyk<DummyService>()
+        val result = f.returnValueClassNotInlined() as DummyValue
+
+        assertEquals(DummyValue(0), result)
+    }
+
+    @Test
+    fun `mock class returning value class not boxed due to cast to another type`() {
+        val f = mockk<DummyService>()
+        every { f.returnValueClassNotInlined() } returns DummyValue(3)
+        val result = f.returnValueClassNotInlined() as DummyValue
+
+        assertEquals(DummyValue(3), result)
+    }
+
     companion object {
 
         @JvmInline
@@ -621,6 +638,9 @@ class ValueClassTest {
 
             fun returnValueClass(): DummyValue =
                 DummyValue(0)
+
+            // Note the value class is not inlined in this case due to being cast to another type
+            fun returnValueClassNotInlined(): Any = DummyValue(0)
 
             fun argNoneReturnsUInt(): UInt = 123u
         }


### PR DESCRIPTION
Fixes issue: https://github.com/mockk/mockk/issues/1037

Without this change, the two new test cases fail with:
```
java.lang.ClassCastException: class java.lang.Integer cannot be cast to class io.mockk.it.ValueClassTest$Companion$DummyValue (java.lang.Integer is in module java.base of loader 'bootstrap'; io.mockk.it.ValueClassTest$Companion$DummyValue is in unnamed module of loader 'app')
```