### PR TITLE
Fix capture using mutable list of value class

### DIFF
--- a/modules/mockk-dsl/src/commonMain/kotlin/io/mockk/Matchers.kt
+++ b/modules/mockk-dsl/src/commonMain/kotlin/io/mockk/Matchers.kt
@@ -98,9 +98,10 @@ data class CaptureMatcher<T : Any>(
 ) : Matcher<T>, CapturingMatcher, TypedMatcher, EquivalentMatcher {
     override fun equivalent(): Matcher<Any> = ConstantMatcher(true)
 
-    @Suppress("UNCHECKED_CAST")
     override fun capture(arg: Any?) {
-        captureList.add(arg as T)
+        if (arg != null) {
+            captureList.add(InternalPlatformDsl.boxCast(argumentType, arg))
+        }
     }
 
     override fun match(arg: T?): Boolean = true

--- a/modules/mockk/src/commonTest/kotlin/io/mockk/it/ValueClassTest.kt
+++ b/modules/mockk/src/commonTest/kotlin/io/mockk/it/ValueClassTest.kt
@@ -59,6 +59,22 @@ class ValueClassTest {
     }
 
     @Test
+    fun `arg is MutableList(ValueClass), returns ValueClass`() {
+        val slot = mutableListOf<DummyValue>()
+        val mock = mockk<DummyService> {
+            every { argValueClassReturnValueClass(capture(slot)) } returns dummyValueClassReturn
+        }
+
+        val result = mock.argValueClassReturnValueClass(dummyValueClassArg)
+
+        assertEquals(dummyValueClassReturn, result)
+
+        assertEquals(dummyValueClassArg, slot.single())
+
+        verify { mock.argValueClassReturnValueClass(dummyValueClassArg) }
+    }
+
+    @Test
     fun `arg is ValueClass, answers ValueClass`() {
         val mock = mockk<DummyService> {
             every { argValueClassReturnValueClass(dummyValueClassArg) } answers { dummyValueClassReturn }


### PR DESCRIPTION
### The Problem
When using `capture` with a mutable list of a value type (i.e. using `CaptureMatcher`), the wrapped value is captured rather than the value type:
```
expected: <DummyValue(value=101)> but was: <101>
```

_When using `capture` with a `slot` (i.e. using `CapturingSlotMatcher`) this is handled by calling the internal `boxCast` helper function._


### The Solution
Use `boxCast` in `CaptureMatcher `, in the same way as `CapturingSlotMatcher` does.