### PR TITLE
Updates documentation to include example access error workaround for Android users

### DIFF
--- a/doc/md/jdk16-access-exceptions.md
+++ b/doc/md/jdk16-access-exceptions.md
@@ -44,6 +44,20 @@ tasks.test {
 }
 ```
 
+Example for Gradle users within an Android module:
+```groovy
+android {
+    testOptions {
+        unitTests.all {
+            jvmArgs(
+                "--add-opens", "java.base/java.time=ALL-UNNAMED",
+                "--add-opens", "java.base/java.lang.reflect=ALL-UNNAMED"
+            )
+        }
+    }
+}
+```
+
 Example for Maven users:
 ```xml
 <plugin>


### PR DESCRIPTION
Whilst the documentation added in #965 is excellent, developers using Gradle within an Android project require a standard template that differs from the Gradle example provided.

I recently solved this issue within my own project and struggled to find a "copypastable" solution. Adding this example will make the guide much more useful for other Android developers!