### PR TITLE
Fix cannot mock value class for class property in 1.13.10

### DIFF
--- a/modules/mockk-core/src/jvmMain/kotlin/io/mockk/core/ValueClassSupport.kt
+++ b/modules/mockk-core/src/jvmMain/kotlin/io/mockk/core/ValueClassSupport.kt
@@ -111,7 +111,7 @@ actual object ValueClassSupport {
             false
         } catch (_: UnsupportedOperationException) {
             false
-        } catch (e: AbstractMethodError) {
+        } catch (_: AbstractMethodError) {
             false
         }
 }

--- a/modules/mockk-core/src/jvmMain/kotlin/io/mockk/core/ValueClassSupport.kt
+++ b/modules/mockk-core/src/jvmMain/kotlin/io/mockk/core/ValueClassSupport.kt
@@ -2,13 +2,14 @@ package io.mockk.core
 
 import java.lang.reflect.Method
 import kotlin.reflect.KClass
+import kotlin.reflect.KProperty
 import kotlin.reflect.KProperty1
 import kotlin.reflect.full.declaredMemberProperties
+import kotlin.reflect.jvm.internal.KotlinReflectionInternalError
 import kotlin.reflect.jvm.isAccessible
 import kotlin.reflect.jvm.javaField
-import kotlin.reflect.jvm.internal.KotlinReflectionInternalError
+import kotlin.reflect.jvm.javaGetter
 import kotlin.reflect.jvm.kotlinFunction
-
 
 actual object ValueClassSupport {
 
@@ -23,18 +24,36 @@ actual object ValueClassSupport {
         if (!resultType.isValue_safe) {
             return this
         }
-        val kFunction = method.kotlinFunction ?: return this
-
-        // Only unbox a value class if the method's return type is actually the type of the inlined property.
-        // For example, in a normal case where a value class `Foo` with underlying `Int` property is inlined:
-        //   method.returnType == int (the actual representation of inlined property on JVM)
-        //   method.kotlinFunction.returnType.classifier == Foo
-        val expectedReturnType = kFunction.returnType.classifier
-        return if (resultType == expectedReturnType) {
-            this.boxedValue
-        } else {
-            this
+        val kFunction = method.kotlinFunction
+        if (kFunction != null) {
+            // Only unbox a value class if the method's return type is actually the type of the inlined property.
+            // For example, in a normal case where a value class `Foo` with underlying `Int` property is inlined:
+            //   method.returnType == int (the actual representation of inlined property on JVM)
+            //   method.kotlinFunction.returnType.classifier == Foo
+            val expectedReturnType = kFunction.returnType.classifier
+            return if (resultType == expectedReturnType) {
+                this.boxedValue
+            } else {
+                this
+            }
         }
+        // It is possible that the method is a getter for a property, in which case we can check the property's return
+        // type in kotlin.
+        val kProperty = findMatchingPropertyWithJavaGetter(method)
+        if (kProperty == null) {
+            return this
+        } else {
+            val expectedReturnType = kProperty.returnType.classifier
+            return if (resultType == expectedReturnType) {
+                this.boxedValue
+            } else {
+                this
+            }
+        }
+    }
+
+    private fun findMatchingPropertyWithJavaGetter(method: Method): KProperty<*>? {
+        return method.declaringClass.kotlin.declaredMemberProperties.find { it.javaGetter == method }
     }
 
     /**
@@ -92,8 +111,7 @@ actual object ValueClassSupport {
             false
         } catch (_: UnsupportedOperationException) {
             false
-        } catch (_: AbstractMethodError) {
+        } catch (e: AbstractMethodError) {
             false
         }
-
 }

--- a/modules/mockk/src/commonTest/kotlin/io/mockk/it/ValueClassTest.kt
+++ b/modules/mockk/src/commonTest/kotlin/io/mockk/it/ValueClassTest.kt
@@ -1,10 +1,13 @@
 package io.mockk.it
 
-import io.mockk.*
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.spyk
+import io.mockk.verify
 import org.junit.jupiter.api.assertTimeoutPreemptively
 import java.time.Duration
 import java.util.UUID
-import kotlin.jvm.JvmInline
 import kotlin.test.Ignore
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -29,6 +32,17 @@ class ValueClassTest {
         assertEquals(dummyValueClassReturn, mock.argValueClassReturnValueClass(dummyValueClassArg))
 
         verify { mock.argValueClassReturnValueClass(dummyValueClassArg) }
+    }
+
+    @Test
+    fun `field is ValueClass, returns ValueClass`() {
+        val mock = mockk<DummyService> {
+            every { valueClassField } returns dummyValueClassReturn
+        }
+
+        assertEquals(dummyValueClassReturn, mock.valueClassField)
+
+        verify { mock.valueClassField }
     }
 
     @Test
@@ -121,7 +135,10 @@ class ValueClassTest {
             every { argComplexValueClassReturnComplexValueClass(dummyComplexValueClassArg) } returns dummyComplexValueClassReturn
         }
 
-        assertEquals(dummyComplexValueClassReturn, mock.argComplexValueClassReturnComplexValueClass(dummyComplexValueClassArg))
+        assertEquals(
+            dummyComplexValueClassReturn,
+            mock.argComplexValueClassReturnComplexValueClass(dummyComplexValueClassArg)
+        )
 
         verify { mock.argComplexValueClassReturnComplexValueClass(dummyComplexValueClassArg) }
     }
@@ -132,7 +149,10 @@ class ValueClassTest {
             every { argComplexValueClassReturnComplexValueClass(any()) } returns dummyComplexValueClassReturn
         }
 
-        assertEquals(dummyComplexValueClassReturn, mock.argComplexValueClassReturnComplexValueClass(dummyComplexValueClassArg))
+        assertEquals(
+            dummyComplexValueClassReturn,
+            mock.argComplexValueClassReturnComplexValueClass(dummyComplexValueClassArg)
+        )
 
         verify { mock.argComplexValueClassReturnComplexValueClass(dummyComplexValueClassArg) }
     }
@@ -159,7 +179,10 @@ class ValueClassTest {
             every { argComplexValueClassReturnComplexValueClass(dummyComplexValueClassArg) } answers { dummyComplexValueClassReturn }
         }
 
-        assertEquals(dummyComplexValueClassReturn, mock.argComplexValueClassReturnComplexValueClass(dummyComplexValueClassArg))
+        assertEquals(
+            dummyComplexValueClassReturn,
+            mock.argComplexValueClassReturnComplexValueClass(dummyComplexValueClassArg)
+        )
 
         verify { mock.argComplexValueClassReturnComplexValueClass(dummyComplexValueClassArg) }
     }
@@ -170,7 +193,10 @@ class ValueClassTest {
             every { argComplexValueClassReturnComplexValueClass(any()) } answers { dummyComplexValueClassReturn }
         }
 
-        assertEquals(dummyComplexValueClassReturn, mock.argComplexValueClassReturnComplexValueClass(dummyComplexValueClassArg))
+        assertEquals(
+            dummyComplexValueClassReturn,
+            mock.argComplexValueClassReturnComplexValueClass(dummyComplexValueClassArg)
+        )
 
         verify { mock.argComplexValueClassReturnComplexValueClass(dummyComplexValueClassArg) }
     }
@@ -625,6 +651,7 @@ class ValueClassTest {
 
         @Suppress("UNUSED_PARAMETER")
         class DummyService {
+            val valueClassField = DummyValue(0)
 
             fun argWrapperReturnWrapper(wrapper: DummyValueWrapper): DummyValueWrapper =
                 DummyValueWrapper(DummyValue(0))

--- a/modules/mockk/src/commonTest/kotlin/io/mockk/it/ValueClassTest.kt
+++ b/modules/mockk/src/commonTest/kotlin/io/mockk/it/ValueClassTest.kt
@@ -135,10 +135,7 @@ class ValueClassTest {
             every { argComplexValueClassReturnComplexValueClass(dummyComplexValueClassArg) } returns dummyComplexValueClassReturn
         }
 
-        assertEquals(
-            dummyComplexValueClassReturn,
-            mock.argComplexValueClassReturnComplexValueClass(dummyComplexValueClassArg)
-        )
+        assertEquals(dummyComplexValueClassReturn, mock.argComplexValueClassReturnComplexValueClass(dummyComplexValueClassArg))
 
         verify { mock.argComplexValueClassReturnComplexValueClass(dummyComplexValueClassArg) }
     }
@@ -149,10 +146,7 @@ class ValueClassTest {
             every { argComplexValueClassReturnComplexValueClass(any()) } returns dummyComplexValueClassReturn
         }
 
-        assertEquals(
-            dummyComplexValueClassReturn,
-            mock.argComplexValueClassReturnComplexValueClass(dummyComplexValueClassArg)
-        )
+        assertEquals(dummyComplexValueClassReturn, mock.argComplexValueClassReturnComplexValueClass(dummyComplexValueClassArg))
 
         verify { mock.argComplexValueClassReturnComplexValueClass(dummyComplexValueClassArg) }
     }
@@ -179,10 +173,7 @@ class ValueClassTest {
             every { argComplexValueClassReturnComplexValueClass(dummyComplexValueClassArg) } answers { dummyComplexValueClassReturn }
         }
 
-        assertEquals(
-            dummyComplexValueClassReturn,
-            mock.argComplexValueClassReturnComplexValueClass(dummyComplexValueClassArg)
-        )
+        assertEquals(dummyComplexValueClassReturn, mock.argComplexValueClassReturnComplexValueClass(dummyComplexValueClassArg))
 
         verify { mock.argComplexValueClassReturnComplexValueClass(dummyComplexValueClassArg) }
     }
@@ -193,10 +184,7 @@ class ValueClassTest {
             every { argComplexValueClassReturnComplexValueClass(any()) } answers { dummyComplexValueClassReturn }
         }
 
-        assertEquals(
-            dummyComplexValueClassReturn,
-            mock.argComplexValueClassReturnComplexValueClass(dummyComplexValueClassArg)
-        )
+        assertEquals(dummyComplexValueClassReturn, mock.argComplexValueClassReturnComplexValueClass(dummyComplexValueClassArg))
 
         verify { mock.argComplexValueClassReturnComplexValueClass(dummyComplexValueClassArg) }
     }


### PR DESCRIPTION
### The Problem
I notice that after bumping the version to 1.13.10, mockk cannot mock a value class type property in a class. 
This can be reproduced by my newly added test case in `modules/mockk/src/commonTest/kotlin/io/mockk/it/ValueClassTest.kt` below. 
stacktrace:
```

java.lang.ClassCastException: class io.mockk.it.ValueClassTest$Companion$DummyValue cannot be cast to class java.lang.Integer (io.mockk.it.ValueClassTest$Companion$DummyValue is in unnamed module of loader 'app'; java.lang.Integer is in module java.base of loader 'bootstrap')
	at io.mockk.it.ValueClassTest$Companion$DummyService.getValueClassField-_Hougu0(ValueClassTest.kt:642)
	at io.mockk.it.ValueClassTest.field is ValueClass, returns ValueClass(ValueClassTest.kt:43)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(Unknown Source)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(Unknown Source)
	at java.base/java.lang.reflect.Method.invoke(Unknown Source)
	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:725)
	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$ValidatingInvocation.proceed(InvocationInterceptorChain.java:131)
	at org.junit.jupiter.engine.extension.TimeoutExtension.intercept(TimeoutExtension.java:149)
	at org.junit.jupiter.engine.extension.TimeoutExtension.interceptTestableMethod(TimeoutExtension.java:140)
	at org.junit.jupiter.engine.extension.TimeoutExtension.interceptTestMethod(TimeoutExtension.java:84)
	at org.junit.jupiter.engine.execution.ExecutableInvoker$ReflectiveInterceptorCall.lambda$ofVoidMethod$0(ExecutableInvoker.java:115)
	at org.junit.jupiter.engine.execution.ExecutableInvoker.lambda$invoke$0(ExecutableInvoker.java:105)
	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$InterceptedInvocation.proceed(InvocationInterceptorChain.java:106)
	at org.junit.jupiter.engine.execution.InvocationInterceptorChain.proceed(InvocationInterceptorChain.java:64)
	at org.junit.jupiter.engine.execution.InvocationInterceptorChain.chainAndInvoke(InvocationInterceptorChain.java:45)
	at org.junit.jupiter.engine.execution.InvocationInterceptorChain.invoke(InvocationInterceptorChain.java:37)
	at org.junit.jupiter.engine.execution.ExecutableInvoker.invoke(ExecutableInvoker.java:104)
	at org.junit.jupiter.engine.execution.ExecutableInvoker.invoke(ExecutableInvoker.java:98)
	at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.lambda$invokeTestMethod$7(TestMethodTestDescriptor.java:214)
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
	at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.invokeTestMethod(TestMethodTestDescriptor.java:210)
	at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.execute(TestMethodTestDescriptor.java:135)
	at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.execute(TestMethodTestDescriptor.java:66)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$6(NodeTestTask.java:151)
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$8(NodeTestTask.java:141)
	at org.junit.platform.engine.support.hierarchical.Node.around(Node.java:137)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$9(NodeTestTask.java:139)
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively(NodeTestTask.java:138)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:95)
	at java.base/java.util.ArrayList.forEach(Unknown Source)
	at org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService.invokeAll(SameThreadHierarchicalTestExecutorService.java:41)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$6(NodeTestTask.java:155)
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$8(NodeTestTask.java:141)
	at org.junit.platform.engine.support.hierarchical.Node.around(Node.java:137)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$9(NodeTestTask.java:139)
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively(NodeTestTask.java:138)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:95)
	at java.base/java.util.ArrayList.forEach(Unknown Source)
	at org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService.invokeAll(SameThreadHierarchicalTestExecutorService.java:41)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$6(NodeTestTask.java:155)
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$8(NodeTestTask.java:141)
	at org.junit.platform.engine.support.hierarchical.Node.around(Node.java:137)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$9(NodeTestTask.java:139)
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively(NodeTestTask.java:138)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:95)
	at org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService.submit(SameThreadHierarchicalTestExecutorService.java:35)
	at org.junit.platform.engine.support.hierarchical.HierarchicalTestExecutor.execute(HierarchicalTestExecutor.java:57)
	at org.junit.platform.engine.support.hierarchical.HierarchicalTestEngine.execute(HierarchicalTestEngine.java:54)
	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:107)
	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:88)
	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.lambda$execute$0(EngineExecutionOrchestrator.java:54)
	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.withInterceptedStreams(EngineExecutionOrchestrator.java:67)
	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:52)
	at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:114)
	at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:86)
	at org.junit.platform.launcher.core.DefaultLauncherSession$DelegatingLauncher.execute(DefaultLauncherSession.java:86)
	at org.gradle.api.internal.tasks.testing.junitplatform.JUnitPlatformTestClassProcessor$CollectAllTestClassesExecutor.processAllTestClasses(JUnitPlatformTestClassProcessor.java:119)
	at org.gradle.api.internal.tasks.testing.junitplatform.JUnitPlatformTestClassProcessor$CollectAllTestClassesExecutor.access$000(JUnitPlatformTestClassProcessor.java:94)
	at org.gradle.api.internal.tasks.testing.junitplatform.JUnitPlatformTestClassProcessor.stop(JUnitPlatformTestClassProcessor.java:89)
	at org.gradle.api.internal.tasks.testing.SuiteTestClassProcessor.stop(SuiteTestClassProcessor.java:62)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(Unknown Source)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(Unknown Source)
	at java.base/java.lang.reflect.Method.invoke(Unknown Source)
	at org.gradle.internal.dispatch.ReflectionDispatch.dispatch(ReflectionDispatch.java:36)
	at org.gradle.internal.dispatch.ReflectionDispatch.dispatch(ReflectionDispatch.java:24)
	at org.gradle.internal.dispatch.ContextClassLoaderDispatch.dispatch(ContextClassLoaderDispatch.java:33)
	at org.gradle.internal.dispatch.ProxyDispatchAdapter$DispatchingInvocationHandler.invoke(ProxyDispatchAdapter.java:94)
	at jdk.proxy1/jdk.proxy1.$Proxy2.stop(Unknown Source)
	at org.gradle.api.internal.tasks.testing.worker.TestWorker$3.run(TestWorker.java:193)
	at org.gradle.api.internal.tasks.testing.worker.TestWorker.executeAndMaintainThreadName(TestWorker.java:129)
	at org.gradle.api.internal.tasks.testing.worker.TestWorker.execute(TestWorker.java:100)
	at org.gradle.api.internal.tasks.testing.worker.TestWorker.execute(TestWorker.java:60)
	at org.gradle.process.internal.worker.child.ActionExecutionWorker.execute(ActionExecutionWorker.java:56)
	at org.gradle.process.internal.worker.child.SystemApplicationClassLoaderWorker.call(SystemApplicationClassLoaderWorker.java:113)
	at org.gradle.process.internal.worker.child.SystemApplicationClassLoaderWorker.call(SystemApplicationClassLoaderWorker.java:65)
	at worker.org.gradle.process.internal.worker.GradleWorkerMain.run(GradleWorkerMain.java:69)
	at worker.org.gradle.process.internal.worker.GradleWorkerMain.main(GradleWorkerMain.java:74)
```

### The Solution
I found that this is because in this case `method.kotlinFunction` would return null and fail the check. 

I added additional handling below that if `method.kotlinFunction` returns null, we would try checking if the class has a property that its java getter method is equal to this `method`, and use it to get the expected return type instead. 
