### PR TITLE
Introduce `verifyCount` DSL

### DIFF
--- a/README.md
+++ b/README.md
@@ -674,6 +674,26 @@ verify(exactly = 0) { car.accelerate(fromSpeed = 30, toSpeed = 10) } // means no
 confirmVerified(car)
 ```
 
+Or you can use `verifyCount`:
+
+```kotlin
+
+val car = mockk<Car>(relaxed = true)
+
+car.accelerate(fromSpeed = 10, toSpeed = 20)
+car.accelerate(fromSpeed = 10, toSpeed = 30)
+car.accelerate(fromSpeed = 20, toSpeed = 30)
+
+// all pass
+verifyCount { 
+    (3..5) * { car.accelerate(allAny(), allAny()) } // same as verify(atLeast = 3, atMost = 5) { car.accelerate(allAny(), allAny()) }
+    1 * { car.accelerate(fromSpeed = 10, toSpeed = 20) } // same as verify(exactly = 1) { car.accelerate(fromSpeed = 10, toSpeed = 20) }
+    0 * { car.accelerate(fromSpeed = 30, toSpeed = 10) } // same as verify(exactly = 0) { car.accelerate(fromSpeed = 30, toSpeed = 10) }
+}
+
+confirmVerified(car)
+```
+
 ### Verification order
 
 * `verifyAll` verifies that all calls happened without checking their order.

--- a/modules/mockk-dsl/api/mockk-dsl.api
+++ b/modules/mockk-dsl/api/mockk-dsl.api
@@ -531,6 +531,18 @@ public final class io/mockk/MockKAssertScope {
 	public final fun getActual ()Ljava/lang/Object;
 }
 
+public final class io/mockk/MockKCallCountCoVerificationScope {
+	public fun <init> ()V
+	public final fun times (ILkotlin/jvm/functions/Function2;)V
+	public final fun times (Lkotlin/ranges/IntRange;Lkotlin/jvm/functions/Function2;)V
+}
+
+public final class io/mockk/MockKCallCountVerificationScope {
+	public fun <init> ()V
+	public final fun times (ILkotlin/jvm/functions/Function1;)V
+	public final fun times (Lkotlin/ranges/IntRange;Lkotlin/jvm/functions/Function1;)V
+}
+
 public final class io/mockk/MockKCancellationRegistry {
 	public static final field INSTANCE Lio/mockk/MockKCancellationRegistry;
 	public final fun cancelAll ()V

--- a/modules/mockk-dsl/src/commonMain/kotlin/io/mockk/API.kt
+++ b/modules/mockk-dsl/src/commonMain/kotlin/io/mockk/API.kt
@@ -690,9 +690,10 @@ open class MockKMatcherScope(
     val lambda: CapturingSlot<Function<*>>
 ) {
 
-    fun <T: Any> match(matcher: Matcher<T>, kclass: KClass<T>): T {
+    fun <T : Any> match(matcher: Matcher<T>, kclass: KClass<T>): T {
         return callRecorder.matcher(matcher, kclass)
     }
+
     inline fun <reified T : Any> match(matcher: Matcher<T>): T {
         return callRecorder.matcher(matcher, T::class)
     }
@@ -720,6 +721,7 @@ open class MockKMatcherScope(
      */
     inline fun <reified T : Any> eq(value: T, inverse: Boolean = false): T =
         match(EqMatcher(value, inverse = inverse))
+
     /**
      * Matches if the value is not equal to the provided [value] via the `deepEquals` function.
      */
@@ -730,6 +732,7 @@ open class MockKMatcherScope(
      */
     inline fun <reified T : Any> refEq(value: T, inverse: Boolean = false): T =
         match(EqMatcher(value, ref = true, inverse = inverse))
+
     /**
      * Matches if the value is not equal to the provided [value] via reference comparison.
      */
@@ -738,13 +741,15 @@ open class MockKMatcherScope(
     /**
      * Matches any argument given a [KClass]
      */
-    fun <T: Any> any(classifier: KClass<T>): T = match(ConstantMatcher(true), classifier)
+    fun <T : Any> any(classifier: KClass<T>): T = match(ConstantMatcher(true), classifier)
+
     /**
      * Matches any argument.
      */
     inline fun <reified T : Any> any(): T = match(ConstantMatcher(true))
 
     inline fun <reified T : Any> capture(lst: MutableList<T>): T = match(CaptureMatcher(lst, T::class))
+
     /**
      * Captures a non-nullable value to a [CapturingSlot].
      *
@@ -782,7 +787,8 @@ open class MockKMatcherScope(
      * network.download("testfile")
      * // slot.captured is now "testfile"
      */
-    inline fun <reified T : Any> captureNullable(lst: CapturingSlot<T?>): T? = match(CapturingNullableSlotMatcher(lst, T::class))
+    inline fun <reified T : Any> captureNullable(lst: CapturingSlot<T?>): T? =
+        match(CapturingNullableSlotMatcher(lst, T::class))
 
     /**
      * Captures a nullable value to a [MutableList].
@@ -797,12 +803,14 @@ open class MockKMatcherScope(
      * Matches if the value is equal to the provided [value] via the `compareTo` function.
      */
     inline fun <reified T : Comparable<T>> cmpEq(value: T): T = match(ComparingMatcher(value, 0, T::class))
+
     /**
      * Matches if the value is more than the provided [value] via the `compareTo` function.
      * @param andEquals matches more than or equal to
      */
     inline fun <reified T : Comparable<T>> more(value: T, andEquals: Boolean = false): T =
         match(ComparingMatcher(value, if (andEquals) 2 else 1, T::class))
+
     /**
      * Matches if the value is less than the provided [value] via the `compareTo` function.
      * @param andEquals matches less than or equal to
@@ -824,10 +832,12 @@ open class MockKMatcherScope(
      * Combines two matchers via a logical and.
      */
     inline fun <reified T : Any> and(left: T, right: T): T = match(AndOrMatcher<T>(true, left, right))
+
     /**
      * Combines two matchers via a logical or.
      */
     inline fun <reified T : Any> or(left: T, right: T): T = match(AndOrMatcher<T>(false, left, right))
+
     /**
      * Negates the matcher.
      */
@@ -840,6 +850,7 @@ open class MockKMatcherScope(
      */
     inline fun <reified T : Any> isNull(inverse: Boolean = false): T = match(NullCheckMatcher<T>(inverse))
     inline fun <reified T : Any, R : T> ofType(cls: KClass<R>): T = match(OfTypeMatcher<T>(cls))
+
     /**
      * Checks if the value belongs to the type.
      */
@@ -2204,6 +2215,27 @@ class MockKCallCountVerificationScope {
 }
 
 /**
+ * Part of DSL. Additional operations for coroutine call count verification scope.
+ */
+class MockKCallCountCoVerificationScope {
+    operator fun Int.times(verifyBlock: suspend MockKVerificationScope.() -> Unit) {
+        MockKGateway.implementation().verifier.verify(
+            VerificationParameters(Ordering.UNORDERED, min = this, max = this, inverse = false, timeout = 0),
+            null,
+            verifyBlock
+        )
+    }
+
+    operator fun IntRange.times(verifyBlock: suspend MockKVerificationScope.() -> Unit) {
+        MockKGateway.implementation().verifier.verify(
+            VerificationParameters(Ordering.UNORDERED, min = this.first, max = this.last, inverse = false, timeout = 0),
+            null,
+            verifyBlock
+        )
+    }
+}
+
+/**
  * Part of DSL. Object to represent phrase "wasNot Called"
  */
 object Called
@@ -2696,7 +2728,7 @@ class CapturingSlot<T : Any?> {
      * For init state (not yet captured) returns false.
      */
     val isNull
-        get() = when(val value = capturedValue) {
+        get() = when (val value = capturedValue) {
             is CapturedValue.Value -> value.value == null
             is CapturedValue.NotYetCaptured -> false
         }

--- a/modules/mockk-dsl/src/commonMain/kotlin/io/mockk/API.kt
+++ b/modules/mockk-dsl/src/commonMain/kotlin/io/mockk/API.kt
@@ -2183,6 +2183,27 @@ class MockKVerificationScope(
 }
 
 /**
+ * Part of DSL. Additional operations for call count verification scope.
+ */
+class MockKCallCountVerificationScope {
+    operator fun Int.times(verifyBlock: MockKVerificationScope.() -> Unit) {
+        MockKGateway.implementation().verifier.verify(
+            VerificationParameters(Ordering.UNORDERED, min = this, max = this, inverse = false, timeout = 0),
+            verifyBlock,
+            null
+        )
+    }
+
+    operator fun IntRange.times(verifyBlock: MockKVerificationScope.() -> Unit) {
+        MockKGateway.implementation().verifier.verify(
+            VerificationParameters(Ordering.UNORDERED, min = this.first, max = this.last, inverse = false, timeout = 0),
+            verifyBlock,
+            null
+        )
+    }
+}
+
+/**
  * Part of DSL. Object to represent phrase "wasNot Called"
  */
 object Called

--- a/modules/mockk/api/mockk.api
+++ b/modules/mockk/api/mockk.api
@@ -38,6 +38,7 @@ public final class io/mockk/MockKKt {
 	public static synthetic fun coVerify$default (Lio/mockk/Ordering;ZIIIJLkotlin/jvm/functions/Function2;ILjava/lang/Object;)V
 	public static final fun coVerifyAll (ZLkotlin/jvm/functions/Function2;)V
 	public static synthetic fun coVerifyAll$default (ZLkotlin/jvm/functions/Function2;ILjava/lang/Object;)V
+	public static final fun coVerifyCount (Lkotlin/jvm/functions/Function1;)V
 	public static final fun coVerifyOrder (ZLkotlin/jvm/functions/Function2;)V
 	public static synthetic fun coVerifyOrder$default (ZLkotlin/jvm/functions/Function2;ILjava/lang/Object;)V
 	public static final fun coVerifySequence (ZLkotlin/jvm/functions/Function2;)V
@@ -72,6 +73,7 @@ public final class io/mockk/MockKKt {
 	public static synthetic fun verify$default (Lio/mockk/Ordering;ZIIIJLkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
 	public static final fun verifyAll (ZLkotlin/jvm/functions/Function1;)V
 	public static synthetic fun verifyAll$default (ZLkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+	public static final fun verifyCount (Lkotlin/jvm/functions/Function1;)V
 	public static final fun verifyOrder (ZLkotlin/jvm/functions/Function1;)V
 	public static synthetic fun verifyOrder$default (ZLkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
 	public static final fun verifySequence (ZLkotlin/jvm/functions/Function1;)V

--- a/modules/mockk/src/commonMain/kotlin/io/mockk/MockK.kt
+++ b/modules/mockk/src/commonMain/kotlin/io/mockk/MockK.kt
@@ -261,6 +261,7 @@ fun coVerify(
  * @see verify
  * @see verifyOrder
  * @see verifySequence
+ * @see verifyCount
  *
  * @param inverse when true, the verification will check that the behaviour specified did **not** happen
  */
@@ -278,6 +279,7 @@ fun verifyAll(
  * @see verify
  * @see verifyAll
  * @see verifySequence
+ * @see verifyCount
  *
  * @param inverse when true, the verification will check that the behaviour specified did **not** happen
  */
@@ -295,6 +297,7 @@ fun verifyOrder(
  * @see verify
  * @see verifyOrder
  * @see verifyAll
+ * @see verifyCount
  *
  * @param inverse when true, the verification will check that the behaviour specified did **not** happen
  */
@@ -303,6 +306,20 @@ fun verifySequence(
     verifyBlock: MockKVerificationScope.() -> Unit
 ) = MockK.useImpl {
     MockKDsl.internalVerifySequence(inverse, verifyBlock)
+}
+
+/**
+ * Verifies that calls and their count
+ *
+ * @see coVerifyCount Coroutine version
+ * @see verify
+ * @see verifyOrder
+ * @see verifyAll
+ * @see verifySequence
+ *
+ */
+fun verifyCount(verifyBlock: MockKCallCountVerificationScope.() -> Unit) = MockK.useImpl {
+    MockKCallCountVerificationScope().verifyBlock()
 }
 
 /**

--- a/modules/mockk/src/commonMain/kotlin/io/mockk/MockK.kt
+++ b/modules/mockk/src/commonMain/kotlin/io/mockk/MockK.kt
@@ -378,6 +378,20 @@ fun coVerifySequence(
 }
 
 /**
+ * Verifies that calls and their count. Coroutine version
+ *
+ * @see verifyCount
+ * @see coVerify
+ * @see coVerifyOrder
+ * @see coVerifyAll
+ * @see coVerifySequence
+ *
+ */
+fun coVerifyCount(verifyBlock: MockKCallCountCoVerificationScope.() -> Unit) = MockK.useImpl {
+    MockKCallCountCoVerificationScope().verifyBlock()
+}
+
+/**
  * Exclude calls from recording
  *
  * @param current if current recorded calls should be filtered out

--- a/modules/mockk/src/commonMain/kotlin/io/mockk/MockK.kt
+++ b/modules/mockk/src/commonMain/kotlin/io/mockk/MockK.kt
@@ -331,6 +331,7 @@ fun verifyCount(verifyBlock: MockKCallCountVerificationScope.() -> Unit) = MockK
  * @see coVerify
  * @see coVerifyOrder
  * @see coVerifySequence
+ * @see coVerifyCount
  *
  * @param inverse when true, the verification will check that the behaviour specified did **not** happen
  */
@@ -349,6 +350,7 @@ fun coVerifyAll(
  * @see coVerify
  * @see coVerifyAll
  * @see coVerifySequence
+ * @see coVerifyCount
  *
  * @param inverse when true, the verification will check that the behaviour specified did **not** happen
  */
@@ -367,6 +369,7 @@ fun coVerifyOrder(
  * @see coVerify
  * @see coVerifyOrder
  * @see coVerifyAll
+ * @see coVerifyCount
  *
  * @param inverse when true, the verification will check that the behaviour specified did **not** happen
  */

--- a/modules/mockk/src/commonTest/kotlin/io/mockk/it/CaptureSubclassVerificationTest.kt
+++ b/modules/mockk/src/commonTest/kotlin/io/mockk/it/CaptureSubclassVerificationTest.kt
@@ -6,6 +6,7 @@ import io.mockk.just
 import io.mockk.mockk
 import io.mockk.slot
 import io.mockk.verify
+import io.mockk.verifyCount
 import io.mockk.verifyOrder
 import io.mockk.verifySequence
 import kotlin.test.Test
@@ -73,6 +74,24 @@ class CaptureSubclassVerificationTest {
         verifySequence {
             service.method(any())
             service.method(capture(slot))
+        }
+        assertTrue(slot.isCaptured)
+        assertIs<Subclass2>(slot.captured)
+    }
+
+    @Test
+    fun `test count`() {
+        val service = mockk<Service> {
+            every { method(any()) } just Runs
+        }
+
+        service.method(Subclass1())
+        service.method(Subclass2())
+
+        val slot = slot<Subclass2>()
+        verifyCount {
+            2 * { service.method(any()) }
+            1 * { service.method(capture(slot)) }
         }
         assertTrue(slot.isCaptured)
         assertIs<Subclass2>(slot.captured)

--- a/modules/mockk/src/commonTest/kotlin/io/mockk/it/CoVerifyTest.kt
+++ b/modules/mockk/src/commonTest/kotlin/io/mockk/it/CoVerifyTest.kt
@@ -1,9 +1,15 @@
 package io.mockk.it
 
-import io.mockk.*
-import kotlinx.coroutines.coroutineScope
+import io.mockk.InternalPlatformDsl
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.coVerifyCount
+import io.mockk.coVerifyOrder
+import io.mockk.coVerifySequence
+import io.mockk.mockk
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlinx.coroutines.coroutineScope
 
 class CoVerifyTest {
     class MockCls {
@@ -12,7 +18,7 @@ class CoVerifyTest {
 
     val mock = mockk<MockCls>()
 
-    fun doCalls() {
+    private fun doCalls() {
         coEvery { mock.op(5) } returns 1
         coEvery { mock.op(6) } returns 2
         coEvery { mock.op(7) } returns 3
@@ -154,6 +160,20 @@ class CoVerifyTest {
             mock.op(6)
             mock.op(5)
             mock.op(7)
+        }
+    }
+
+    @Test
+    fun verifyCount() {
+        doCalls()
+
+        coVerifyCount {
+            0 * { mock.op(4) } // not called
+            1 * { mock.op(5) } // called
+            (0..Int.MAX_VALUE) * { mock.op(6) } // called
+            (1..1) * { mock.op(7) } // called
+            (0..0) * { mock.op(8) } // not called
+            (0..1) * { mock.op(9) } // not called
         }
     }
 }

--- a/modules/mockk/src/commonTest/kotlin/io/mockk/it/VerificationErrorsTest.kt
+++ b/modules/mockk/src/commonTest/kotlin/io/mockk/it/VerificationErrorsTest.kt
@@ -135,7 +135,7 @@ class VerificationErrorsTest {
     }
 
     @Test
-    fun callsNotMatchinVerificationSequence() {
+    fun callsNotMatchingVerificationSequence() {
         expectVerificationError("calls are not exactly matching verification sequence", "MockCls.otherOp") {
             every { mock.otherOp(1, any()) } answers { 2 + firstArg<Int>() }
 

--- a/modules/mockk/src/commonTest/kotlin/io/mockk/it/VerifyAtLeastAtMostExactlyTest.kt
+++ b/modules/mockk/src/commonTest/kotlin/io/mockk/it/VerifyAtLeastAtMostExactlyTest.kt
@@ -5,6 +5,7 @@ import io.mockk.clearAllMocks
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
+import io.mockk.verifyCount
 import io.mockk.verifyOrder
 import io.mockk.verifySequence
 import kotlin.test.Test
@@ -194,6 +195,17 @@ class VerifyAtLeastAtMostExactlyTest {
     }
 
     @Test
+    fun count() {
+        doCalls()
+
+        verifyCount {
+            1 * { mock.op(0) }
+            4 * { mock.op(1) }
+            0 * { mock.op(2) }
+        }
+    }
+
+    @Test
     fun atLeastNeverAtAll() {
         every { mock.op(0) } returns 1
 
@@ -225,7 +237,7 @@ class VerifyAtLeastAtMostExactlyTest {
         }
     }
 
-    fun doCalls() {
+    private fun doCalls() {
         every { mock.op(0) } throws RuntimeException("test")
         every { mock.op(1) } returnsMany listOf(1, 2, 3)
 
@@ -239,7 +251,7 @@ class VerifyAtLeastAtMostExactlyTest {
         assertEquals(3, mock.op(1))
     }
 
-    fun doCalls2() {
+    private fun doCalls2() {
         every { mock.op(0) } throws RuntimeException("test")
         every { mock.op(1) } returnsMany listOf(1, 2, 3) andThen 5
         every { mock.op2(2, 1) } returns 3
@@ -255,17 +267,14 @@ class VerifyAtLeastAtMostExactlyTest {
         assertEquals(3, mock.op2(2, 1))
     }
 
-    fun doCalls3() {
+    private fun doCalls3() {
         if (doCalls4()) {
-            mock.op2(3,4)
+            mock.op2(3, 4)
         }
     }
 
-    fun doCalls4(): Boolean {
-        if (mock.op(0) == 0 || mock.op(1) == 1) {
-            return true
-        }
-        return false
+    private fun doCalls4(): Boolean {
+        return mock.op(0) == 0 || mock.op(1) == 1
     }
 
     class MockCls {

--- a/modules/mockk/src/commonTest/kotlin/io/mockk/it/VerifyTest.kt
+++ b/modules/mockk/src/commonTest/kotlin/io/mockk/it/VerifyTest.kt
@@ -5,6 +5,7 @@ import io.mockk.just
 import io.mockk.mockk
 import io.mockk.runs
 import io.mockk.verify
+import io.mockk.verifyCount
 import io.mockk.verifyOrder
 import io.mockk.verifySequence
 import kotlin.test.Test
@@ -14,7 +15,7 @@ class VerifyTest {
 
     val mock = mockk<MockCls>()
 
-    fun doCalls() {
+    private fun doCalls() {
         every { mock.op(5) } returns 1
         every { mock.op(6) } returns 2
         every { mock.op(7) } returns 3
@@ -154,6 +155,20 @@ class VerifyTest {
             mock.op(6)
             mock.op(5)
             mock.op(7)
+        }
+    }
+
+    @Test
+    fun verifyCount() {
+        doCalls()
+
+        verifyCount {
+            0 * { mock.op(4) } // not called
+            1 * { mock.op(5) } // called
+            (0..Int.MAX_VALUE) * { mock.op(6) } // called
+            (1..1) * { mock.op(7) } // called
+            (0..0) * { mock.op(8) } // not called
+            (0..1) * { mock.op(9) } // not called
         }
     }
 

--- a/modules/mockk/src/jvmTest/kotlin/io/mockk/it/VerificationAcknowledgeTest.kt
+++ b/modules/mockk/src/jvmTest/kotlin/io/mockk/it/VerificationAcknowledgeTest.kt
@@ -1,12 +1,23 @@
 package io.mockk.it
 
-import io.mockk.*
-import org.hamcrest.CoreMatchers.equalTo
-import org.hamcrest.MatcherAssert.assertThat
-import org.junit.jupiter.api.Test
+import io.mockk.Called
+import io.mockk.checkUnnecessaryStub
+import io.mockk.clearAllMocks
+import io.mockk.clearMocks
+import io.mockk.confirmVerified
+import io.mockk.every
+import io.mockk.excludeRecords
+import io.mockk.mockk
+import io.mockk.verify
+import io.mockk.verifyCount
+import io.mockk.verifyOrder
+import io.mockk.verifySequence
 import kotlin.test.assertEquals
 import kotlin.test.assertFails
 import kotlin.test.assertFailsWith
+import org.hamcrest.CoreMatchers.equalTo
+import org.hamcrest.MatcherAssert.assertThat
+import org.junit.jupiter.api.Test
 
 class VerificationAcknowledgeTest {
     class MockCls {
@@ -15,7 +26,7 @@ class VerificationAcknowledgeTest {
 
     val mock = mockk<MockCls>()
 
-    fun doCalls1() {
+    private fun doCalls1() {
         every { mock.op(5) } returns 1
         every { mock.op(6) } returns 2
         every { mock.op(7) } returns 3
@@ -26,7 +37,7 @@ class VerificationAcknowledgeTest {
     }
 
 
-    fun doCalls2() {
+    private fun doCalls2() {
         every { mock.op(0) } throws RuntimeException("test")
         every { mock.op(1) } returnsMany listOf(1, 2, 3)
 
@@ -312,6 +323,33 @@ class VerificationAcknowledgeTest {
             mock.op(6)
             mock.op(5)
             mock.op(7)
+        }
+
+        assertFails {
+            confirmVerified(mock)
+        }
+    }
+
+    @Test
+    fun verifyCount() {
+        doCalls1()
+
+        verifyCount {
+            1 * { mock.op(6) }
+            1 * { mock.op(5) }
+            1 * { mock.op(7) }
+        }
+
+        confirmVerified(mock)
+    }
+
+    @Test
+    fun verifyCount2() {
+        doCalls1()
+
+        verifyCount {
+            1 * { mock.op(6) }
+            1 * { mock.op(5) }
         }
 
         assertFails {


### PR DESCRIPTION
**this is draft implementation**
i'd like maintainers to check such points
- `API.kt` and `MockK.kt` are implemented appropriately
- tests are enough
- some changes i added as refactoring are acceptable

thank you

___

## Overview
based on [this discussion](https://github.com/mockk/mockk/discussions/1227), i added `verifyCount` DSL to make verifying call count easy

## Syntax
```
val mock = mockk<ClassUnderTest>()

...

verifyCount {
  1 * { mock.method() } // this is same as verify(exactly = 1) { mock.method() }
  0 * { mock.method() } // this is same as verify(exactly = 0) { mock.method() }
  (0..5) * { mock.method() } // this is same as verify(atLeast = 0, atMost = 5) { mock.method() }
}
```

this is inspired by [Spock](https://spockframework.org/spock/docs/2.3/spock_primer.html#_interactions) and [Mockito-Kotlin](https://github.com/mockito/mockito-kotlin/blob/main/mockito-kotlin/src/main/kotlin/org/mockito/kotlin/VerifyScope.kt#L44)