### PR TITLE
Implement `clearStaticMockk` for KFunction and KProperty

### DIFF
--- a/modules/mockk/api/mockk.api
+++ b/modules/mockk/api/mockk.api
@@ -1,4 +1,6 @@
 public final class io/mockk/JVMMockKKt {
+	public static final fun clearStaticMockk ([Lkotlin/reflect/KFunction;)V
+	public static final fun clearStaticMockk ([Lkotlin/reflect/KProperty;)V
 	public static final fun getDeclaringKotlinFile (Lkotlin/reflect/KFunction;)Lkotlin/reflect/KClass;
 	public static final fun mockkStatic ([Lkotlin/reflect/KFunction;)V
 	public static final fun mockkStatic ([Lkotlin/reflect/KFunction;Lkotlin/jvm/functions/Function0;)V

--- a/modules/mockk/src/jvmMain/kotlin/io/mockk/MockK.kt
+++ b/modules/mockk/src/jvmMain/kotlin/io/mockk/MockK.kt
@@ -45,6 +45,18 @@ fun unmockkStatic(vararg functions: KProperty<*>) =
     unmockkStatic(*functions.map(KProperty<*>::getter).toTypedArray())
 
 /**
+ * Clear static mocks.
+ */
+fun clearStaticMockk(vararg functions: KFunction<*>) =
+    clearStaticMockk(*functions.map { it.declaringKotlinFile }.toTypedArray())
+
+/**
+ * Clear static mocks.
+ */
+fun clearStaticMockk(vararg functions: KProperty<*>) =
+    clearStaticMockk(*functions.map(KProperty<*>::getter).toTypedArray())
+
+/**
  * Builds a static mock and unmocks it after the block has been executed.
  */
 inline fun mockkStatic(vararg functions: KFunction<*>, block: () -> Unit) =

--- a/modules/mockk/src/jvmTest/kotlin/io/mockk/it/StaticMockkTest.kt
+++ b/modules/mockk/src/jvmTest/kotlin/io/mockk/it/StaticMockkTest.kt
@@ -1,5 +1,6 @@
 package io.mockk.it
 
+import io.mockk.clearStaticMockk
 import io.mockk.every
 import io.mockk.mockkStatic
 import io.mockk.unmockkStatic
@@ -74,6 +75,19 @@ class StaticMockkTest {
     }
 
     @Test
+    fun extensionFunctionClearStaticMock() {
+        mockkStatic(Int::op)
+
+        every { 5 op 6 } returns 2
+
+        assertEquals(2, 5 op 6)
+
+        clearStaticMockk(Int::op)
+
+        verify(exactly = 0) { 5 op 6 }
+    }
+
+    @Test
     fun extensionPropertyStaticMock() {
         mockkStatic(Int::selfOp)
 
@@ -105,5 +119,18 @@ class StaticMockkTest {
         assertEquals(3, 5.selfOp)
 
         verify { 5.selfOp }
+    }
+
+    @Test
+    fun extensionPropertyClearStaticMock() {
+        mockkStatic(Int::selfOp)
+
+        every { 5.selfOp } returns 2
+
+        assertEquals(2, 5.selfOp)
+
+        clearStaticMockk(Int::selfOp)
+
+        verify(exactly = 0) { 5.selfOp }
     }
 }


### PR DESCRIPTION
For a class, Mockk allows to:
- `mockkStatic(klass)`
- `unmockkStatic(klass)`
- `clearStaticMock(klass)`

But for static properties and functions, since #518, only the first 2 are supported:
- `mockkStatic(::staticMethod)`
- `unmockkStatic(::staticMethod)`
- `clearStaticMock(::staticMethod)` // Doesn't compile

The helper functions were missing.