### PR TITLE
[CONTRIBUTING.md] Suggest running `gradle check` before opening a PR

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,7 @@ Please note we have a code of conduct, please follow it in all your interactions
 
 ## Pull Request Process
 
-1. Make sure all tests pass and you have a passing build for the whole project.
+1. Make sure all tests pass and you have a passing build for the whole project (run `./gradlew check`).
 2. Whether you are fixing a bug or introducing a new feature, please add the necessary tests.
    It's fine to create a test named "Issue`number`Test", where `number` is the number of the GitHub issue your test 
    is reproducing, but if you can make the extra effort to add your test coverage in an existing test group that would be great <3


### PR DESCRIPTION
I opened a PR that didn't pass the CI (#1239) even after reading CONTRIBUTING.md:
> Make sure all tests pass and you have a passing build for the whole project.

I did run `./gradlew test` but the CI runs the superset `./gradlew check`.

How about referencing the exact command to run before submitting the PR at the end of that line:
~~~diff
- 1. Make sure all tests pass and you have a passing build for the whole project.
+ 1. Make sure all tests pass and you have a passing build for the whole project (run `./gradlew check`).
~~~

~It would also be nice to document `./gradlew apiDump` (only found it after manually fixing the API file), but keeping the instructions short is probably better. What do you think?~ It's referenced in the `./gradlew check` error message.