### PR TITLE
Add DSL keyword "repeatedly" which enables repeated answer

### DIFF
--- a/modules/mockk-dsl/api/mockk-dsl.api
+++ b/modules/mockk-dsl/api/mockk-dsl.api
@@ -5,6 +5,8 @@ public final class io/mockk/APIKt {
 	public static final fun checkEquals (Lio/mockk/MockKAssertScope;Ljava/lang/String;Ljava/lang/Object;)V
 	public static final fun internalSubstitute (Ljava/lang/Object;Ljava/util/Map;)Ljava/lang/Object;
 	public static final fun internalSubstitute (Ljava/util/List;Ljava/util/Map;)Ljava/util/List;
+	public static final fun just (Lio/mockk/MockKRepeatedAnswerScope;Lio/mockk/Awaits;)Lio/mockk/MockKAdditionalAnswerScope;
+	public static final fun just (Lio/mockk/MockKRepeatedAnswerScope;Lio/mockk/Runs;)Lio/mockk/MockKAdditionalAnswerScope;
 	public static final fun just (Lio/mockk/MockKStubScope;Lio/mockk/Awaits;)Lio/mockk/MockKAdditionalAnswerScope;
 	public static final fun just (Lio/mockk/MockKStubScope;Lio/mockk/Runs;)Lio/mockk/MockKAdditionalAnswerScope;
 	public static final fun use (Lio/mockk/Deregisterable;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
@@ -922,6 +924,15 @@ public final class io/mockk/MockKObjectScope : io/mockk/MockKUnmockKScope {
 	public final fun getRecordPrivateCalls ()Z
 }
 
+public final class io/mockk/MockKRepeatedAnswerScope {
+	public fun <init> (Lio/mockk/MockKGateway$AnswerOpportunity;Lio/mockk/MockKGateway$CallRecorder;Lio/mockk/CapturingSlot;I)V
+	public final fun answers (Lio/mockk/Answer;)Lio/mockk/MockKAdditionalAnswerScope;
+	public final fun answers (Lkotlin/jvm/functions/Function2;)Lio/mockk/MockKAdditionalAnswerScope;
+	public final fun coAnswers (Lkotlin/jvm/functions/Function3;)Lio/mockk/MockKAdditionalAnswerScope;
+	public final fun returns (Ljava/lang/Object;)Lio/mockk/MockKAdditionalAnswerScope;
+	public final fun throws (Ljava/lang/Throwable;)Lio/mockk/MockKAdditionalAnswerScope;
+}
+
 public final class io/mockk/MockKSettings {
 	public static final field INSTANCE Lio/mockk/MockKSettings;
 	public final fun getRecordPrivateCalls ()Z
@@ -952,6 +963,7 @@ public final class io/mockk/MockKStubScope {
 	public final fun coAnswers (Lkotlin/jvm/functions/Function3;)Lio/mockk/MockKAdditionalAnswerScope;
 	public final fun nullablePropertyType (Lkotlin/reflect/KClass;)Lio/mockk/MockKStubScope;
 	public final fun propertyType (Lkotlin/reflect/KClass;)Lio/mockk/MockKStubScope;
+	public final fun repeatedly (I)Lio/mockk/MockKRepeatedAnswerScope;
 	public final fun returns (Ljava/lang/Object;)Lio/mockk/MockKAdditionalAnswerScope;
 	public final fun returnsArgument (I)Lio/mockk/MockKAdditionalAnswerScope;
 	public final fun returnsMany (Ljava/util/List;)Lio/mockk/MockKAdditionalAnswerScope;

--- a/modules/mockk/src/commonTest/kotlin/io/mockk/it/RepeatedlyAnswersTest.kt
+++ b/modules/mockk/src/commonTest/kotlin/io/mockk/it/RepeatedlyAnswersTest.kt
@@ -1,0 +1,90 @@
+package io.mockk.it
+
+import io.mockk.*
+import kotlinx.coroutines.coroutineScope
+import org.junit.jupiter.api.assertDoesNotThrow
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+class RepeatedlyAnswersTest {
+    private val mock = mockk<MockClass>()
+
+    @ParameterizedTest
+    @ValueSource(ints = [0, 1, 2, 3])
+    fun repeatedlyAnswers(times: Int) {
+        every { mock.op() } repeatedly times answers ConstantAnswer("repeating") andThen "final"
+
+        repeat(times) {
+            assertEquals("repeating", mock.op())
+        }
+        assertEquals("final", mock.op())
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = [0, 1, 2, 3])
+    fun repeatedlyAnswersLambda(times: Int) {
+        every { mock.op() } repeatedly times answers { "repeating" } andThen "final"
+
+        repeat(times) {
+            assertEquals("repeating", mock.op())
+        }
+        assertEquals("final", mock.op())
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = [0, 1, 2, 3])
+    fun repeatedlyReturns(times: Int) {
+        every { mock.op() } repeatedly times returns "repeating" andThen "final"
+
+        repeat(times) {
+            assertEquals("repeating", mock.op())
+        }
+        assertEquals("final", mock.op())
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = [0, 1, 2, 3])
+    fun repeatedlyThrows(times: Int) {
+        every { mock.op() } repeatedly times throws  RuntimeException("repeating") andThen "final"
+
+        repeat(times) {
+            assertFailsWith(RuntimeException::class, message = "repeating") {
+                mock.op()
+            }
+        }
+        assertEquals("final", mock.op())
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = [0, 1, 2, 3])
+    fun repeatedlyCoAnswers(times: Int) {
+        every { mock.op() } repeatedly times coAnswers { coroutineScope { "repeating" } } andThen "final"
+
+        repeat(times) {
+            assertEquals("repeating", mock.op())
+        }
+        assertEquals("final", mock.op())
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = [0, 1, 2, 3])
+    fun repeatedlyJustRuns(times: Int) {
+        every { mock.unitOp() } repeatedly times just Runs andThenThrows RuntimeException("final")
+
+        repeat(times) {
+            assertDoesNotThrow {
+                mock.unitOp()
+            }
+        }
+        assertFailsWith(RuntimeException::class, message = "final") {
+            mock.unitOp()
+        }
+    }
+
+    private interface MockClass {
+        fun op(): String
+        fun unitOp()
+    }
+}


### PR DESCRIPTION
## Summary

I'd like to add a new DSL keyword "repeatedly" which makes a mock to repeat a certain answer the specified number of times.

The usage is like the following.
```
every { mock.op() } repeatedly 3 answers { "repeating" } andThenAnswer { "final" }
```
The mock repeatedly replies "repeating" 3 times, and then replies "final".

## Background

The reason why I'd like this feature is that I actually needed it when I made unit tests of a retry operation.

Let's say there are classes like the following.
```
class FailableOperation {
    fun runFailable(): Int
}

class RetryableOperation(
    private val failableOperation: FailableOperation,
    private val maxAttempts: Int,
) {
    fun runRetryable(): Int {
        // Call failableOperation.runFailable() with retry
    }
}
```

Then we want to make a test of `RetryableOperation` with the RetryableOperation where:
1. `failableOperation.runFailable()` throws an exception several times less than `maxAttempts`.
2. Then finally `failableOperation.runFailable()` returns an expected value.

We can make this test using existing features like the following, but the code not only doesn't look smart but also is not readable. (It takes an effort to know how many times the mock throws exception. 9 times? 10 times?)
```
@Test
fun runRetryable() {
    val failableOperation = mockK<FailableOperation>()
    val retryableOperation = RetryableOperation(failableOperation, maxAttempst = 10)

    var attempts = 0
    every { failableOperation.runFailable() } answers {
        attemps++
        if (attemps < 10) throws Exception()
        else 123
    }

    assertEquals(123, retryableOperation.runRetryable()

    verify(exactly = 10) { failableOperation.runFailable() }
}
```

Using the new keyword `repeatedly`, the test can look smart and be readable like the following. (Now it's easy to know that the mock throws an exception 9 times.)
```
fun runRetryable() {
    val failableOperation = mockK<FailableOperation>()
    val retryableOperation = RetryableOperation(failableOperation, 10)

    every { failableOperation.runFailable() } repeatedly 9 throws Exception() andThen 123

    assertEquals(123, retryableOperation.runRetryable()

    verify(exactly = 10) { failableOperation.runFailable() }
}
```