### PR TITLE
Fix RequireParallelTesting Annotation

### DIFF
--- a/modules/mockk/src/jvmMain/kotlin/io/mockk/junit5/MockKExtension.kt
+++ b/modules/mockk/src/jvmMain/kotlin/io/mockk/junit5/MockKExtension.kt
@@ -155,7 +155,8 @@ class MockKExtension : TestInstancePostProcessor, ParameterResolver, AfterAllCal
             .orElse(false)
 
     private val ExtensionContext.requireParallelTesting: Boolean
-        get() = getConfigurationParameter(REQUIRE_PARALLEL_TESTING).map { it.toBoolean() }.orElse(false)
+        get() = testClass.requireParallelTesting ||
+                getConfigurationParameter(REQUIRE_PARALLEL_TESTING).map { it.toBoolean() }.orElse(false)
 
     private val Optional<out AnnotatedElement>.requireParallelTesting
         get() = map { it.getAnnotation(RequireParallelTesting::class.java) != null }


### PR DESCRIPTION
## Description
In MockKExtension, the README.md currently states that if a test is wanted to run in parallel we are able to attach the @RequireParallelTesting annotation. However, that is currently not the case. Looking deeper in MockKExtension, one of the ExtensionContext's is not like the others.

Closes #1261 