### PR TITLE
fix(813): Handle nullable value classes

### DIFF
--- a/modules/mockk-core/src/jvmMain/kotlin/io/mockk/core/ValueClassSupport.kt
+++ b/modules/mockk-core/src/jvmMain/kotlin/io/mockk/core/ValueClassSupport.kt
@@ -31,8 +31,13 @@ actual object ValueClassSupport {
             //   method.returnType == int (the actual representation of inlined property on JVM)
             //   method.kotlinFunction.returnType.classifier == Foo
             val expectedReturnType = kFunction.returnType.classifier
+            val isReturnNullable = kFunction.returnType.isMarkedNullable
             val isPrimitive = resultType.boxedClass.java.isPrimitive
-            return if (!(kFunction.isSuspend && isPrimitive) && resultType == expectedReturnType) {
+            return if (
+                !(kFunction.isSuspend && isPrimitive) &&
+                resultType == expectedReturnType &&
+                !isReturnNullable
+            ) {
                 this.boxedValue
             } else {
                 this
@@ -45,7 +50,8 @@ actual object ValueClassSupport {
             return this
         } else {
             val expectedReturnType = kProperty.returnType.classifier
-            return if (resultType == expectedReturnType) {
+            val isReturnNullable = kProperty.returnType.isMarkedNullable
+            return if (resultType == expectedReturnType && !isReturnNullable) {
                 this.boxedValue
             } else {
                 this

--- a/modules/mockk/src/commonTest/kotlin/io/mockk/it/ValueClassTest.kt
+++ b/modules/mockk/src/commonTest/kotlin/io/mockk/it/ValueClassTest.kt
@@ -572,6 +572,24 @@ class ValueClassTest {
     }
 
     @Test
+    fun `function returning nullable value class not boxed due to cast to another type`() {
+        val mock = mockk<DummyService> {
+            every { nullableValueClass() } returns DummyValue(2)
+        }
+
+        assertEquals(DummyValue(2), mock.nullableValueClass())
+    }
+
+    @Test
+    fun `nullable value class field is not boxed due to cast to another type`() {
+        val mock = mockk<DummyService> {
+            every { nullableValueClassField } returns DummyValue(2)
+        }
+
+        assertEquals(DummyValue(2), mock.nullableValueClassField)
+    }
+
+    @Test
     fun `receiver is ValueClass, return is String`() {
         val fn = mockk<DummyValue.() -> String>()
 
@@ -676,6 +694,7 @@ class ValueClassTest {
         @Suppress("UNUSED_PARAMETER")
         class DummyService {
             val valueClassField = DummyValue(0)
+            val nullableValueClassField : DummyValue? = null
 
             fun argWrapperReturnWrapper(wrapper: DummyValueWrapper): DummyValueWrapper =
                 DummyValueWrapper(DummyValue(0))
@@ -706,6 +725,8 @@ class ValueClassTest {
                 ComplexValue(UUID.fromString("c5744ead-302f-4e29-9f82-d10eb2a85ea3"))
 
             fun argNoneReturnsUInt(): UInt = 123u
+
+            fun nullableValueClass(): DummyValue? = null
         }
     }
 }


### PR DESCRIPTION
Fix https://github.com/mockk/mockk/issues/813

Problem:
When trying to mock a function that returns a nullable value class, a ClassCastException was thrown. Thats because  mockk is using the boxedClass. Nullable value classes should be handled differently because they are not inlined.

For example
`Caused by: java.lang.ClassCastException: class java.lang.Integer cannot be cast to class io.mockk.it.ValueClassTest$Companion$DummyValue (java.lang.Integer is in module java.base of loader 'bootstrap'; io.mockk.it.ValueClassTest$Companion$DummyValue is in unnamed module of loader 'app')`

Implementation:
When the return type of the function or a member property is nullable do not use the boxedClass but use the value class itself