### PR TITLE
Improve error message on unexpected calls count

### DIFF
--- a/modules/mockk/src/commonMain/kotlin/io/mockk/impl/verify/UnorderedCallVerifier.kt
+++ b/modules/mockk/src/commonMain/kotlin/io/mockk/impl/verify/UnorderedCallVerifier.kt
@@ -58,7 +58,7 @@ open class UnorderedCallVerifier(
 
         val matchedCalls = allCallsForMockMethod.filter(matcher::match)
 
-        if(matchedCalls.size > 1 && matcher.args.any { it is CapturingSlotMatcher<*> }) {
+        if (matchedCalls.size > 1 && matcher.args.any { it is CapturingSlotMatcher<*> }) {
             val msg = "$matcher execution is being verified more than once and its arguments are being captured with a slot.\n" +
                 "This will store only the argument of the last invocation in the slot.\n" +
                 "If you want to store all the arguments, use a mutableList to capture arguments."
@@ -82,7 +82,7 @@ open class UnorderedCallVerifier(
             }
         } else when (allCallsForMockMethod.size) {
             0 -> {
-                if(min == 0) {
+                if (min == 0) {
                     VerificationResult.OK(listOf())
                 } else if (allCallsForMock.isEmpty()) {
                     VerificationResult.Failure("$callIdxMsg was not called")
@@ -106,7 +106,7 @@ open class UnorderedCallVerifier(
                         VerificationResult.OK(listOf(onlyCall))
                     } else {
                         VerificationResult.Failure(
-                            "$callIdxMsg. One matching call found, but needs at least $min${atMostMsg(max)} calls" +
+                            "$callIdxMsg. One matching call found, but needs ${callsBoundsMsg(min, max)}" +
                                     "\nCall: " + allCallsForMock.first() +
                                     if (MockKSettings.stackTracesOnVerify)
                                         "\nStack trace:\n" + stackTrace(0, allCallsForMock.first().callStack())
@@ -148,8 +148,7 @@ open class UnorderedCallVerifier(
                             })
                     } else {
                         VerificationResult.Failure(
-                            "$callIdxMsg. $n matching calls found, " +
-                                    "but needs at least $min${atMostMsg(max)} calls" +
+                            "$callIdxMsg. $n matching calls found, but needs ${callsBoundsMsg(min, max)}" +
                                     "\nCalls:\n" +
                                     formatCalls(allCallsForMock) +
                                     "\n" +
@@ -174,7 +173,13 @@ open class UnorderedCallVerifier(
 
     override fun captureArguments() = captureBlocks.forEach { it() }
 
-    private fun atMostMsg(max: Int) = if (max == Int.MAX_VALUE) "" else " and at most $max"
+    private fun callsBoundsMsg(min: Int, max: Int): String {
+        return when {
+            max == Int.MAX_VALUE -> "at least $min calls"
+            min == max -> "exactly $min calls"
+            else -> "at least $min and at most $max calls"
+        }
+    }
 
     private fun describeArgumentDifference(
         matcher: InvocationMatcher,

--- a/modules/mockk/src/commonTest/kotlin/io/mockk/it/VerificationErrorsTest.kt
+++ b/modules/mockk/src/commonTest/kotlin/io/mockk/it/VerificationErrorsTest.kt
@@ -89,6 +89,54 @@ class VerificationErrorsTest {
     }
 
     @Test
+    fun someMatchingCallsFoundButTooMuch() {
+        expectVerificationError("4 matching calls found, but needs at least 2 and at most 3 calls", "MockCls.otherOp") {
+            every { mock.otherOp(1, any()) } answers { 2 + firstArg<Int>() }
+
+            mock.otherOp(1, 2)
+            mock.otherOp(1, 2)
+            mock.otherOp(1, 2)
+            mock.otherOp(1, 2)
+
+            verify(atLeast = 2, atMost = 3) { mock.otherOp(1, 2) }
+        }
+    }
+
+    @Test
+    fun oneMatchingCallFoundButNeedMoreInRange() {
+        expectVerificationError("One matching call found, but needs at least 2 and at most 3 calls", "MockCls.otherOp") {
+            every { mock.otherOp(1, any()) } answers { 2 + firstArg<Int>() }
+
+            mock.otherOp(1, 2)
+
+            verify(atLeast = 2, atMost = 3) { mock.otherOp(1, 2) }
+        }
+    }
+
+    @Test
+    fun someMatchingCallsFoundButNeedExactMatch() {
+        expectVerificationError("2 matching calls found, but needs exactly 3 calls", "MockCls.otherOp") {
+            every { mock.otherOp(1, any()) } answers { 2 + firstArg<Int>() }
+
+            mock.otherOp(1, 2)
+            mock.otherOp(1, 2)
+
+            verify(exactly = 3) { mock.otherOp(1, 2) }
+        }
+    }
+
+    @Test
+    fun oneMatchingCallFoundButNeedExactMatch() {
+        expectVerificationError("One matching call found, but needs exactly 2 calls", "MockCls.otherOp") {
+            every { mock.otherOp(1, any()) } answers { 2 + firstArg<Int>() }
+
+            mock.otherOp(1, 2)
+
+            verify(exactly = 2) { mock.otherOp(1, 2) }
+        }
+    }
+
+    @Test
     fun callsAreNotInVerificationOrder() {
         expectVerificationError("calls are not in verification order", "MockCls.otherOp") {
             every { mock.otherOp(1, any()) } answers { 2 + firstArg<Int>() }


### PR DESCRIPTION
This PR adds support for the case where `min` and `max` calls counts are the same. Instead of saying `at least <x> and at most <x> calls`, it now displays `exactly <x> calls`.