### PR TITLE
fix(1308): Handle nullable complex and nested value classes

### DIFF
--- a/modules/mockk/src/commonTest/kotlin/io/mockk/it/ValueClassTest.kt
+++ b/modules/mockk/src/commonTest/kotlin/io/mockk/it/ValueClassTest.kt
@@ -581,6 +581,65 @@ class ValueClassTest {
     }
 
     @Test
+    fun `function returning nullable complex value class, returns value class`() {
+        val expected = ComplexValue(UUID.fromString("c5744ead-302f-4e29-9f82-d10eb2a85ea3"))
+        val mock = mockk<DummyService> {
+            every { nullableComplexValueClass() } returns expected
+        }
+
+        assertEquals(expected, mock.nullableComplexValueClass())
+    }
+
+    @Test
+    fun `function returning nullable nested value class, returns value class`() {
+        val mock = mockk<DummyService> {
+            every { nullableNestedValueClass() } returns DummyValueWrapper(DummyValue(10))
+        }
+
+        assertEquals(DummyValueWrapper(DummyValue(10)), mock.nullableNestedValueClass())
+    }
+
+    @Test
+    fun `function returning nullable nested complex value class, returns value class`() {
+        val expected = ComplexValue(UUID.fromString("c5744ead-302f-4e29-9f82-d10eb2a85ea3"))
+
+        val mock = mockk<DummyService> {
+            every { nullableNestedComplexValueClass() } returns DummyComplexValueWrapper(expected)
+        }
+
+        assertEquals(DummyComplexValueWrapper(expected), mock.nullableNestedComplexValueClass())
+    }
+
+    @Test
+    fun `nullable complex value class field, returns value class`() {
+        val expected = ComplexValue(UUID.fromString("c5744ead-302f-4e29-9f82-d10eb2a85ea3"))
+        val mock = mockk<DummyService> {
+            every { nullableComplexValueClassField } returns expected
+        }
+
+        assertEquals(expected, mock.nullableComplexValueClassField)
+    }
+
+    @Test
+    fun `nullable nested value class field, returns value class`() {
+        val mock = mockk<DummyService> {
+            every { nullableNestedValueClassField } returns DummyValueWrapper(DummyValue(10))
+        }
+
+        assertEquals(DummyValueWrapper(DummyValue(10)), mock.nullableNestedValueClassField)
+    }
+
+    @Test
+    fun `nullable nested complex value class field, returns value class`() {
+        val expected = ComplexValue(UUID.fromString("c5744ead-302f-4e29-9f82-d10eb2a85ea3"))
+        val mock = mockk<DummyService> {
+            every { nullableNestedComplexValueClassField } returns DummyComplexValueWrapper(expected)
+        }
+
+        assertEquals(DummyComplexValueWrapper(expected), mock.nullableNestedComplexValueClassField)
+    }
+
+    @Test
     fun `nullable value class field is not boxed due to cast to another type`() {
         val mock = mockk<DummyService> {
             every { nullableValueClassField } returns DummyValue(2)
@@ -667,6 +726,27 @@ class ValueClassTest {
     }
 
     @Test
+    fun `mock class returning nested value class boxed due to suspend function`() {
+        val expected = DummyValueWrapper(DummyValue(3))
+        val f = mockk<DummyService>()
+        coEvery { f.returnNestedValueClassSuspendNotInlined() } returns expected
+        val result = runBlocking { f.returnNestedValueClassSuspendNotInlined() }
+
+        assertEquals(expected, result)
+    }
+
+    @Test
+    fun `mock class returning nested complex value class not boxed due to suspend function`() {
+        val expected =
+            DummyComplexValueWrapper(ComplexValue(UUID.fromString("bca61f8d-ba4d-475f-8dc6-08b943836998")))
+        val f = mockk<DummyService>()
+        coEvery { f.returnNestedComplexValueClassSuspendNotInlined() } returns expected
+        val result = runBlocking { f.returnNestedComplexValueClassSuspendNotInlined() }
+
+        assertEquals(expected, result)
+    }
+
+    @Test
     fun `mock class returning complex value class not boxed due to suspend function`() {
         val f = mockk<DummyService>()
         coEvery { f.returnComplexValueClassSuspendInlined() } returns ComplexValue(UUID.fromString("bca61f8d-ba4d-475f-8dc6-08b943836998"))
@@ -691,10 +771,16 @@ class ValueClassTest {
         @JvmInline
         value class DummyValueWrapper(val value: DummyValue)
 
+        @JvmInline
+        value class DummyComplexValueWrapper(val value: ComplexValue)
+
         @Suppress("UNUSED_PARAMETER")
         class DummyService {
             val valueClassField = DummyValue(0)
-            val nullableValueClassField : DummyValue? = null
+            val nullableValueClassField: DummyValue? = null
+            val nullableComplexValueClassField: ComplexValue? = null
+            val nullableNestedValueClassField: DummyValueWrapper? = null
+            val nullableNestedComplexValueClassField: DummyComplexValueWrapper? = null
 
             fun argWrapperReturnWrapper(wrapper: DummyValueWrapper): DummyValueWrapper =
                 DummyValueWrapper(DummyValue(0))
@@ -724,9 +810,23 @@ class ValueClassTest {
             suspend fun returnComplexValueClassSuspendInlined(): ComplexValue =
                 ComplexValue(UUID.fromString("c5744ead-302f-4e29-9f82-d10eb2a85ea3"))
 
+            @Suppress("RedundantSuspendModifier")
+            suspend fun returnNestedValueClassSuspendNotInlined(): DummyValueWrapper =
+                DummyValueWrapper(DummyValue(0))
+
+            @Suppress("RedundantSuspendModifier")
+            suspend fun returnNestedComplexValueClassSuspendNotInlined(): DummyComplexValueWrapper =
+                DummyComplexValueWrapper(ComplexValue(UUID.fromString("c5744ead-302f-4e29-9f82-d10eb2a85ea3")))
+
             fun argNoneReturnsUInt(): UInt = 123u
 
             fun nullableValueClass(): DummyValue? = null
+
+            fun nullableComplexValueClass(): ComplexValue? = null
+
+            fun nullableNestedValueClass(): DummyValueWrapper? = null
+
+            fun nullableNestedComplexValueClass(): DummyComplexValueWrapper? = null
         }
     }
 }

--- a/modules/mockk/src/jvmMain/kotlin/io/mockk/impl/instantiation/JvmMockFactoryHelper.kt
+++ b/modules/mockk/src/jvmMain/kotlin/io/mockk/impl/instantiation/JvmMockFactoryHelper.kt
@@ -4,7 +4,6 @@ import io.mockk.*
 import io.mockk.impl.InternalPlatform
 import io.mockk.impl.stub.Stub
 import io.mockk.core.ValueClassSupport.boxedClass
-import io.mockk.core.ValueClassSupport.maybeUnboxValueForMethodReturn
 import io.mockk.proxy.MockKInvocationHandler
 import java.lang.reflect.InvocationTargetException
 import java.lang.reflect.Method
@@ -150,20 +149,18 @@ object JvmMockFactoryHelper {
 
         val kotlinReturnType = kotlinFunc?.returnType
             ?: findBackingField(declaringClass.kotlin, this)?.returnType
-        val returnTypeNullable = kotlinReturnType?.isMarkedNullable ?: false
-        val returnTypeClass: KClass<*> = when (kotlinReturnType) {
+        val returnType: KClass<*> = when (kotlinReturnType) {
             is KType -> kotlinReturnType.classifier as? KClass<*> ?: returnType.kotlin
             is KClass<*> -> kotlinReturnType
             else -> returnType.kotlin
-        }
-
-        val returnType = if (!returnTypeNullable) returnTypeClass.boxedClass else returnTypeClass
+        }.boxedClass
 
         val androidCompatibleReturnType = if (returnType.qualifiedName in androidUnsupportedTypes) {
             this@toDescription.returnType.kotlin
         } else {
             returnType
         }
+        val returnTypeNullable = kotlinReturnType?.isMarkedNullable ?: false
 
         val result = MethodDescription(
             name,


### PR DESCRIPTION
Fix https://github.com/mockk/mockk/issues/1308

Problem:
The [PR](https://github.com/mockk/mockk/pull/1295) introduced a regression when a function is returning a nullable value class with a property that is not primitive and also in cases of a nested value class where the innermost property is not a primitive. In these cases we should be using the boxed value instead of the unboxed value.

Implementation:
The implementation was adjusted based on the following.
- When the innermost property of the value class is primitive then use the unboxed value
- When the innermost property of the value class is NOT primitive then use the boxed value. 
- Added some tests for nested value class as a return type of a suspending functions.
- Revert the change in JvmMockFactoryHelper.kt as it's not necessary 