### PR TITLE
Fix(Issue no. 1330) for Relaxed Mocking Value When Property is Nested Value Class

### DIFF
--- a/modules/mockk-core/src/jvmMain/kotlin/io/mockk/core/ValueClassSupport.kt
+++ b/modules/mockk-core/src/jvmMain/kotlin/io/mockk/core/ValueClassSupport.kt
@@ -55,7 +55,7 @@ actual object ValueClassSupport {
             return if (resultType == expectedReturnType && !(isReturnNullable && isPrimitive)) {
                 this.boxedValue
             } else {
-                this
+                this.boxedValue ?: this
             }
         }
     }

--- a/test-modules/client-tests/src/jvmTest/kotlin/io/mockk/core/DefaultValueInMockedValueClassTest.kt
+++ b/test-modules/client-tests/src/jvmTest/kotlin/io/mockk/core/DefaultValueInMockedValueClassTest.kt
@@ -1,0 +1,47 @@
+package io.mockk.core
+
+import io.mockk.every
+import io.mockk.mockk
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+@JvmInline
+value class InnerClass(val innerValue: Long)
+
+@JvmInline
+value class OuterClass(val outerValue: InnerClass)
+
+class ContainerOfInnerClass(val innerClass: InnerClass)
+
+class ContainerOfOuterClass(val outerClass: OuterClass)
+
+class DefaultValueInMockedValueClassTest {
+
+    @Test
+    fun `given nested value class when relaxed mocking is enabled then value successfully verified`() {
+        // pass
+        val containerOfInnerClass = mockk<ContainerOfInnerClass>(relaxed = true)
+        assertEquals(0L, containerOfInnerClass.innerClass.innerValue)
+
+        // pass
+        val outerClass = mockk<OuterClass>(relaxed = true)
+        assertEquals(0L, outerClass.outerValue.innerValue)
+
+        // fails with class "InnerClass cannot be cast to class java.lang.Long" - fixed
+        val mockedClass = mockk<ContainerOfOuterClass>(relaxed = true)
+        assertEquals(0L, mockedClass.outerClass.outerValue.innerValue)
+    }
+
+    @Test
+    fun `given nested value class when relaxed mocking is disabled then value successfully verified`() {
+        val containerOfInnerClass = mockk<ContainerOfInnerClass> {
+            every { innerClass } returns InnerClass(innerValue = 0L)
+        }
+        assertEquals(0L, containerOfInnerClass.innerClass.innerValue)
+
+        val mockedClass = mockk<ContainerOfOuterClass> {
+            every { outerClass } returns OuterClass(outerValue = InnerClass(innerValue = 0L))
+        }
+        assertEquals(0L, mockedClass.outerClass.outerValue.innerValue)
+    }
+}

--- a/test-modules/client-tests/src/jvmTest/kotlin/io/mockk/core/DefaultValueInMockedValueClassTest.kt
+++ b/test-modules/client-tests/src/jvmTest/kotlin/io/mockk/core/DefaultValueInMockedValueClassTest.kt
@@ -17,6 +17,7 @@ class ContainerOfOuterClass(val outerClass: OuterClass)
 
 class DefaultValueInMockedValueClassTest {
 
+    // https://github.com/mockk/mockk/issues/1330
     @Test
     fun `given nested value class when relaxed mocking is enabled then value successfully verified`() {
         // pass


### PR DESCRIPTION
Fix for the Issue: https://github.com/mockk/mockk/issues/1330 

Fixed for given nested value classes when relaxed mocking is enabled then value successfully verified.
Added couple of test(s) so that it will be verified in every PR.

**Root Cause**
Because of this PR's: https://github.com/mockk/mockk/pull/1314/files change in the below code in the else part, this issue was broken. Instead of returning this in the else block which returns the value class, instead check if there is any boxedValue and return the same if exists else return the same value class.

**Earlier**
```
return if (resultType == expectedReturnType && !(isReturnNullable && isPrimitive)) {
    this.boxedValue
} else {
    this
}
```

**Now**
```
return if (resultType == expectedReturnType && !(isReturnNullable && isPrimitive)) {
    this.boxedValue
 } else {
    this.boxedValue ?: this
 }
```
