### PR TITLE
Fix( Issue #1073): Bug fix for the issue with mocking value classes with coEvery

### DIFF
--- a/modules/mockk-core/src/jvmMain/kotlin/io/mockk/core/ValueClassSupport.kt
+++ b/modules/mockk-core/src/jvmMain/kotlin/io/mockk/core/ValueClassSupport.kt
@@ -44,7 +44,7 @@ actual object ValueClassSupport {
             } else if (
                 (kFunction.isSuspend
                  && !(isReturnNullable || isPrimitive))
-                && (this.javaClass.toString() == expectedReturnType.toString()
+                && (this.javaClass.kotlin == expectedReturnType
                     && !unboxValueReturnTypes.contains(expectedReturnType.toString()))
             ) {
                 this.boxedValue

--- a/modules/mockk-core/src/jvmMain/kotlin/io/mockk/core/ValueClassSupport.kt
+++ b/modules/mockk-core/src/jvmMain/kotlin/io/mockk/core/ValueClassSupport.kt
@@ -13,7 +13,7 @@ import kotlin.reflect.jvm.kotlinFunction
 
 actual object ValueClassSupport {
 
-    private val unboxValueReturnTypes = setOf("class kotlin.Result")
+    private val unboxValueReturnTypes = setOf(Result.success("").javaClass.kotlin)
 
     /**
      * Unboxes the underlying property value of a **`value class`** or self, as long the unboxed value is appropriate
@@ -45,7 +45,7 @@ actual object ValueClassSupport {
                 (kFunction.isSuspend
                  && !(isReturnNullable || isPrimitive))
                 && (this.javaClass.kotlin == expectedReturnType
-                    && !unboxValueReturnTypes.contains(expectedReturnType.toString()))
+                    && !unboxValueReturnTypes.contains(expectedReturnType))
             ) {
                 this.boxedValue
             } else {


### PR DESCRIPTION
Fix( Issue #[1073](https://github.com/mockk/mockk/issues/1073)): Bug fix for the issue with mocking value classes with coEvery.
Enable few disabled tests for support nested value classes (issue: [859](https://github.com/mockk/mockk/issues/859))