### PR TITLE
Fix(Issue #1333): Bug fix for the issue with MockK 1.13.16 Wraps Results Objects Twice

### DIFF
--- a/modules/mockk-core/src/jvmMain/kotlin/io/mockk/core/ValueClassSupport.kt
+++ b/modules/mockk-core/src/jvmMain/kotlin/io/mockk/core/ValueClassSupport.kt
@@ -36,16 +36,9 @@ actual object ValueClassSupport {
             val isReturnNullable = kFunction.returnType.isMarkedNullable
             val isPrimitive = resultType.innermostBoxedClass.java.isPrimitive
             return if (
-                !kFunction.isSuspend &&
+                !(kFunction.isSuspend && isPrimitive) &&
                 resultType == expectedReturnType &&
                 !(isReturnNullable && isPrimitive)
-            ) {
-                this.boxedValue
-            } else if (
-                (kFunction.isSuspend
-                 && !(isReturnNullable || isPrimitive))
-                && (this.javaClass.kotlin == expectedReturnType
-                    && !unboxValueReturnTypes.contains(expectedReturnType))
             ) {
                 this.boxedValue
             } else {

--- a/modules/mockk/src/commonTest/kotlin/io/mockk/it/ValueClassTest.kt
+++ b/modules/mockk/src/commonTest/kotlin/io/mockk/it/ValueClassTest.kt
@@ -7,15 +7,12 @@ import io.mockk.slot
 import io.mockk.spyk
 import io.mockk.verify
 import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.test.runTest
-import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.assertTimeoutPreemptively
 import java.time.Duration
 import java.util.UUID
 import kotlin.test.Ignore
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertTrue
 
 class ValueClassTest {
 
@@ -26,29 +23,6 @@ class ValueClassTest {
     private val dummyComplexValueClassArg get() = ComplexValue(UUID.fromString("4d19b22c-7754-4c55-ba4d-f80109708a1f"))
     private val dummyValueClassReturn get() = DummyValue(202)
     private val dummyComplexValueClassReturn get() = ComplexValue(UUID.fromString("25581db2-4cdb-48cd-a6c9-e087aee31f0b"))
-
-    private interface Action<Params, ReturnType> {
-        suspend fun execute(params: Params): ReturnType
-    }
-
-    private class ResultTest : Action<Unit, Result<String>> {
-        override suspend fun execute(params: Unit): Result<String> {
-            return Result.success("some result")
-        }
-    }
-
-    @Nested
-    inner class TestWithCoEvery {
-        private val resultTest = mockk<ResultTest> {
-            coEvery { execute(Unit) } coAnswers { Result.success("abc") }
-        }
-
-        @Test
-        fun `given a test when mocking value classes with coEvery Result returns then success`() = runTest {
-            val result = resultTest.execute(Unit)
-            assertTrue(result.isSuccess)
-        }
-    }
 
     //<editor-fold desc="arg=Value Class, return=ValueClass">
     @Test


### PR DESCRIPTION
Fix( Issue #https://github.com/mockk/mockk/issues/1333): Bug fix for the issue with MockK 1.13.16 Wraps Results Objects Twice.