### PR TITLE
Fix (issue# 1329) parallel testing for unmockkAll

### DIFF
--- a/modules/mockk/src/jvmMain/kotlin/io/mockk/junit5/MockKExtension.kt
+++ b/modules/mockk/src/jvmMain/kotlin/io/mockk/junit5/MockKExtension.kt
@@ -127,7 +127,7 @@ class MockKExtension : TestInstancePostProcessor, ParameterResolver, AfterEachCa
     }
 
     private fun finish(context: ExtensionContext) {
-        if (!context.keepMocks) {
+        if (!context.keepMocks && !context.requireParallelTesting) {
             unmockkAll()
         }
 

--- a/modules/mockk/src/jvmTest/kotlin/io/mockk/junit5/MockKExtensionRequireParallelTestingTest.kt
+++ b/modules/mockk/src/jvmTest/kotlin/io/mockk/junit5/MockKExtensionRequireParallelTestingTest.kt
@@ -1,0 +1,57 @@
+package io.mockk.junit5
+
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import io.mockk.verify
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+
+@ExtendWith(MockKExtension::class)
+@MockKExtension.RequireParallelTesting
+class MockKExtensionRequireParallelTestingTest {
+    @MockK
+    private lateinit var car: Car
+
+    @BeforeEach
+    fun setUp() {
+        Dispatchers.setMain(Dispatchers.Unconfined)
+    }
+
+    @AfterEach
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    companion object {
+        @JvmStatic
+        @AfterAll
+        fun afterAll() {
+            Dispatchers.shutdown()
+        }
+    }
+
+    @Test
+    fun `given car when test with require parallel testing execution returns successfully`() = runTest {
+        // Given
+        every { car.drive() } returns "driving"
+
+        // When
+        val result = car.drive()
+
+        // Then
+        verify { car.drive() }
+        assert(result == "driving")
+    }
+}
+
+internal interface Car {
+    fun drive(): String
+}

--- a/modules/mockk/src/jvmTest/kotlin/io/mockk/junit5/MockKExtensionWithoutRequireParallelTestingTest.kt
+++ b/modules/mockk/src/jvmTest/kotlin/io/mockk/junit5/MockKExtensionWithoutRequireParallelTestingTest.kt
@@ -1,0 +1,52 @@
+package io.mockk.junit5
+
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import io.mockk.verify
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+
+@ExtendWith(MockKExtension::class)
+class MockKExtensionWithoutRequireParallelTestingTest {
+    @MockK
+    private lateinit var car: Car
+
+    @BeforeEach
+    fun setUp() {
+        Dispatchers.setMain(Dispatchers.Unconfined)
+    }
+
+    @AfterEach
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    companion object {
+        @JvmStatic
+        @AfterAll
+        fun afterAll() {
+            Dispatchers.shutdown()
+        }
+    }
+
+    @Test
+    fun `given car when test without require parallel testing execution returns successfully`() = runTest {
+        // Given
+        every { car.drive() } returns "driving"
+
+        // When
+        val result = car.drive()
+
+        // Then
+        verify { car.drive() }
+        assert(result == "driving")
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/mockk/mockk/issues/1329

V1.13.13 added calling unmockkAll() after tests when using the JUnit 5 MockKExtension. It has the same problems with running tests in parallel that happened when the extension was modified to call clearAllMocks() after tests. The call to unmockkAll() is wrapped in a check with `!context.requireParallelTesting` in this PR.