### PR TITLE
Update README.md - Clarify that private fields cannot be mocked

### DIFF
--- a/README.md
+++ b/README.md
@@ -1123,6 +1123,8 @@ Note: in the examples below, we use `propertyType` to specify the type of the `f
 This is needed because it is possible to capture the type automatically for the getter.
 Use `nullablePropertyType` to specify a nullable type.
 
+**Note:** This is only for public fields. It is nearly impossible to mock private properties as they don't have getter methods attached. Use Java reflection to make the field accessible or use `@VisibleForTesting` annotation in the source.
+
 ```kotlin
 val mock = spyk(MockCls(), recordPrivateCalls = true)
 


### PR DESCRIPTION
This will avoid the creation of more Issues regarding this topic and save hours to devs trying to mock private fields. See [this comment](https://github.com/mockk/mockk/issues/263#issuecomment-549018282) from Oleksiy which explains this

Current issues about this topic:
- https://github.com/mockk/mockk/issues/1307
- https://github.com/mockk/mockk/issues/1244
- https://github.com/mockk/mockk/issues/1291
- https://github.com/mockk/mockk/issues/1159
- https://github.com/mockk/mockk/issues/1111
- https://github.com/mockk/mockk/issues/1070
- https://github.com/mockk/mockk/issues/866