### PR TITLE
Added new property "failOnSetBackingFieldException" to fail test if a backing field could not be set

### DIFF
--- a/README.md
+++ b/README.md
@@ -1309,10 +1309,14 @@ relaxUnitFun=true|false
 recordPrivateCalls=true|false
 stackTracesOnVerify=true|false
 stackTracesAlignment=left|center
+failOnSetBackingFieldException=true|false
 ```
 
-`stackTracesAlignment` determines whether to align the stack traces to the center (default),
+* `stackTracesAlignment` determines whether to align the stack traces to the center (default),
  or to the left (more consistent with usual JVM stackTraces).
+* If `failOnSetBackingFieldException` (`false` by default) is set to `true`, tests fail if a
+ backing field could not be set. Otherwise, only the warning "Failed to set backing field" will be logged.
+ See [here](https://github.com/mockk/mockk/issues/1291) for more details.
 
 ## DSL tables
 

--- a/modules/mockk-dsl/api/mockk-dsl.api
+++ b/modules/mockk-dsl/api/mockk-dsl.api
@@ -924,11 +924,13 @@ public final class io/mockk/MockKObjectScope : io/mockk/MockKUnmockKScope {
 
 public final class io/mockk/MockKSettings {
 	public static final field INSTANCE Lio/mockk/MockKSettings;
+	public final fun getFailOnSetBackingFieldException ()Z
 	public final fun getRecordPrivateCalls ()Z
 	public final fun getRelaxUnitFun ()Z
 	public final fun getRelaxed ()Z
 	public final fun getStackTracesAlignment ()Lio/mockk/StackTracesAlignment;
 	public final fun getStackTracesOnVerify ()Z
+	public final fun setFailOnSetBackingFieldException (Z)V
 	public final fun setRecordPrivateCalls (Z)V
 	public final fun setRelaxUnitFun (Z)V
 	public final fun setRelaxed (Z)V

--- a/modules/mockk-dsl/src/commonMain/kotlin/io/mockk/MockKSettings.kt
+++ b/modules/mockk-dsl/src/commonMain/kotlin/io/mockk/MockKSettings.kt
@@ -10,6 +10,8 @@ expect object MockKSettings {
     val stackTracesOnVerify: Boolean
 
     val stackTracesAlignment: StackTracesAlignment
+
+    val failOnSetBackingFieldException: Boolean
 }
 
 enum class StackTracesAlignment {

--- a/modules/mockk-dsl/src/jsMain/kotlin/io/mockk/MockKSettings.kt
+++ b/modules/mockk-dsl/src/jsMain/kotlin/io/mockk/MockKSettings.kt
@@ -17,4 +17,7 @@ actual object MockKSettings {
         get() = stackTracesAlignmentValueOf(
             js("global.io_mockk_settings_stackTracesAlignment || \"center\"") as String
         )
+
+    actual val failOnSetBackingFieldException: Boolean
+        get() = js("global.io_mockk_settings_failOnSetBackingFieldException || false") as Boolean
 }

--- a/modules/mockk-dsl/src/jvmMain/kotlin/io/mockk/MockKSettings.kt
+++ b/modules/mockk-dsl/src/jvmMain/kotlin/io/mockk/MockKSettings.kt
@@ -32,6 +32,9 @@ actual object MockKSettings {
     actual val stackTracesAlignment: StackTracesAlignment
         get() = stackTracesAlignmentValueOf(properties.getProperty("stackTracesAlignment", "center"))
 
+    actual val failOnSetBackingFieldException: Boolean
+        get() = booleanProperty("failOnSetBackingFieldException", "false")
+
     fun setRelaxed(value: Boolean) {
         properties.setProperty("relaxed", value.toString())
     }
@@ -46,5 +49,9 @@ actual object MockKSettings {
 
     fun setStackTracesAlignment(value: String) {
         properties.setProperty("stackTracesAlignment", value)
+    }
+
+    fun setFailOnSetBackingFieldException(value: Boolean) {
+        properties.setProperty("failOnSetBackingFieldException", value.toString())
     }
 }

--- a/modules/mockk/src/commonMain/kotlin/io/mockk/impl/recording/states/StubbingAwaitingAnswerState.kt
+++ b/modules/mockk/src/commonMain/kotlin/io/mockk/impl/recording/states/StubbingAwaitingAnswerState.kt
@@ -67,7 +67,12 @@ class StubbingAwaitingAnswerState(recorder: CommonCallRecorder) : CallRecordingS
 
             InternalPlatformDsl.dynamicSetField(mock, fieldName, ans.constantValue)
         } catch (ex: Exception) {
-            log.warn(ex) { "Failed to set backing field (skipping)" }
+            if (MockKSettings.failOnSetBackingFieldException) {
+                log.error(ex) { "Failed to set backing field"}
+               throw ex
+            } else {
+                log.warn(ex) { "Failed to set backing field (skipping)" }
+            }
         }
     }
 

--- a/modules/mockk/src/commonTest/kotlin/io/mockk/impl/recording/states/StubbingAwaitingAnswerStateTest.kt
+++ b/modules/mockk/src/commonTest/kotlin/io/mockk/impl/recording/states/StubbingAwaitingAnswerStateTest.kt
@@ -3,6 +3,9 @@ package io.mockk.impl.recording.states
 import io.mockk.*
 import io.mockk.impl.recording.CommonCallRecorder
 import io.mockk.impl.stub.AnswerAnsweringOpportunity
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.assertThrows
+import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 
@@ -40,4 +43,29 @@ class StubbingAwaitingAnswerStateTest {
         verify { recorder.stubRepo.stubFor(obj2).addAnswer(call2.matcher, ofType(AnswerAnsweringOpportunity::class)) }
         verify { recorder.factories.answeringState(any()) }
     }
+
+    @Test
+    fun `failOnSetBackingFieldException false just runs for invalid mock`() {
+        val testContainerMock = mockk<TestContainer>()
+
+        every { testContainerMock getProperty "someInt" } returns "mockValue"
+    }
+
+    @Test
+    fun `failOnSetBackingFieldException true leads to exception for invalid mock`() {
+        try {
+            MockKSettings.setFailOnSetBackingFieldException(true)
+            val testContainerMock = mockk<TestContainer>()
+            assertThrows<IllegalArgumentException> {
+                every { testContainerMock getProperty "someInt" } returns "mockValue" }
+        } finally {
+            // We reset the settings in the end to avoid side effects for other tests
+            MockKSettings.setFailOnSetBackingFieldException(false)
+        }
+    }
+}
+
+private class TestContainer {
+    @Suppress("unused") // Accessed via reflection
+    val someInt = 5
 }


### PR DESCRIPTION
Hi,

as mentioned in https://github.com/mockk/mockk/issues/1291, if setting a backing field fails, it just prints a warning but the test does not fail. I introduced a new parameter to alter this behavior - when the new property is set to true, the test fails.
I think this improves handling a lot, as clearly the developer wanted to mock something which failed.
The parameters are a bit confusing to me, as there is the io/mockk/settings.properties and the mockk.properties file. I used settings.properties because it is available in the code I added the fix to. The property "throwExceptionOnBadMock" sounds like it should do what I implemented, but I did not want to break existing codebases by re-using this property.
The unit tests are not very nice, the real problem occurs if you mix Java and Kotlin code (see the original issue) and Java files are not available on the classpath in the current setup of MockK.

Please check it out, I would be happy if this change made it :)