### PR TITLE
Fix returning result values

### DIFF
--- a/modules/mockk-core/src/jvmMain/kotlin/io/mockk/core/ValueClassSupport.kt
+++ b/modules/mockk-core/src/jvmMain/kotlin/io/mockk/core/ValueClassSupport.kt
@@ -70,6 +70,7 @@ actual object ValueClassSupport {
 
     /**
      * Underlying property value of a **`value class`** or self.
+     * Includes workaround for [Result] class
      *
      * The type of the return might also be a `value class`!
      */
@@ -78,7 +79,13 @@ actual object ValueClassSupport {
         get() = if (!this::class.isValue_safe) {
             this
         } else {
-            (this::class as KClass<T>).boxedProperty.get(this)
+            val klass = (this::class as KClass<T>)
+            val boxedProperty = klass.boxedProperty.get(this)
+            if (klass == Result::class) {
+                boxedProperty
+            } else {
+                boxedProperty?.boxedValue
+            }
         }
 
     /**

--- a/modules/mockk-core/src/jvmMain/kotlin/io/mockk/core/ValueClassSupport.kt
+++ b/modules/mockk-core/src/jvmMain/kotlin/io/mockk/core/ValueClassSupport.kt
@@ -78,7 +78,7 @@ actual object ValueClassSupport {
         get() = if (!this::class.isValue_safe) {
             this
         } else {
-            (this::class as KClass<T>).boxedProperty.get(this)?.boxedValue
+            (this::class as KClass<T>).boxedProperty.get(this)
         }
 
     /**

--- a/modules/mockk/src/commonTest/kotlin/io/mockk/it/ValueClassTest.kt
+++ b/modules/mockk/src/commonTest/kotlin/io/mockk/it/ValueClassTest.kt
@@ -7,6 +7,7 @@ import io.mockk.slot
 import io.mockk.spyk
 import io.mockk.verify
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.assertTimeoutPreemptively
 import java.time.Duration
 import java.util.UUID
@@ -18,6 +19,9 @@ class ValueClassTest {
 
     private val dummyValueWrapperArg get() = DummyValueWrapper(DummyValue(42))
     private val dummyValueWrapperReturn get() = DummyValueWrapper(DummyValue(99))
+    private val complexValueParam = UUID.fromString("4d19b22c-7754-4c55-ba4d-f80109708a1f")
+    private val complexValueResultArg get() = ComplexValue(complexValueParam)
+    private val complexValueResultReturn get() = Result.success(complexValueResultArg)
 
     private val dummyValueClassArg get() = DummyValue(101)
     private val dummyComplexValueClassArg get() = ComplexValue(UUID.fromString("4d19b22c-7754-4c55-ba4d-f80109708a1f"))
@@ -542,6 +546,18 @@ class ValueClassTest {
     }
     //</editor-fold>
 
+    @Test
+    fun `receiver is ComplexValue, return is Result with ComplexValue`() {
+        val service = mockk<DummyService>()
+
+        every {  service.argGenericValueClassReturnResultWrapped(complexValueResultArg) } returns complexValueResultReturn
+
+        val result = service.argGenericValueClassReturnResultWrapped(complexValueResultArg)
+
+        assertEquals(complexValueResultReturn.getOrNull()?.value, result.getOrNull()?.value)
+        assertEquals(complexValueResultReturn.getOrNull(), result.getOrNull())
+    }
+
     //<editor-fold desc="extension function on ValueClass">
     @Test
     @Ignore // TODO fix infinite loop
@@ -786,6 +802,9 @@ class ValueClassTest {
 
             fun argValueClassReturnWrapper(valueClass: DummyValue): DummyValueWrapper =
                 DummyValueWrapper(valueClass)
+
+            fun argGenericValueClassReturnResultWrapped(valueClass: ComplexValue): Result<ComplexValue> =
+                Result.success(valueClass)
 
             fun argValueClassReturnValueClass(valueClass: DummyValue): DummyValue =
                 DummyValue(0)


### PR DESCRIPTION
Last version that worked for me with returned `Result` classes was [1.13.9](https://github.com/mockk/mockk/releases/tag/1.13.9). I've checked all the commits that were added between `1.13.1` and `1.13.10` and realized that [this](https://github.com/mockk/mockk/pull/1202/files#diff-257408db2d9e7ef45cb767a310cd6b2e2d98d372d4bcee67618d290c28ce5b37R23) change was responsible for this behavior.

I've reverted changes, at it looks like all tests are passing (even those added in the below PR that was causing issues). I think the change is not needed anymore and can be simply reverted

However I tested it mostly with `Result` class, so alternatively I can change this PR to only include workaround for `Result`:
```kotlin
actual val <T : Any> T.boxedValue: Any?
    @Suppress("UNCHECKED_CAST")
    get() = if (!this::class.isValue_safe) {
        this
    } else {
        val klass = (this::class as KClass<T>)
        val boxedProperty = klass.boxedProperty.get(this)
        if (klass == Result::class) {
            boxedProperty
        } else {
            boxedProperty?.boxedValue
        }
    }
```

This PR fixes: https://github.com/mockk/mockk/issues/1351, https://github.com/mockk/mockk/issues/1338