### PR TITLE
fix: handle fallback to default constructor parameters in constructed…

### DIFF
--- a/modules/mockk/src/commonTest/kotlin/io/mockk/it/ConstructorMockTest.kt
+++ b/modules/mockk/src/commonTest/kotlin/io/mockk/it/ConstructorMockTest.kt
@@ -153,6 +153,19 @@ class ConstructorMockTest {
     }
 
     @Test
+    fun `constructedWith() using default constructor params`() {
+        mockkConstructor(MockCls::class)
+
+        every { constructedWith<MockCls>().op(1, 3) } returns 33
+
+        assertEquals(33, MockCls().op(1, 3))
+
+        verify {
+            constructedWith<MockCls>().op(1, 3)
+        }
+    }
+
+    @Test
     fun unmockkAllconstructedWith() {
         mockkConstructor(MockCls::class)
         mockkConstructor(MockCls::class)

--- a/modules/mockk/src/jvmMain/kotlin/io/mockk/impl/instantiation/JvmConstructorMockFactory.kt
+++ b/modules/mockk/src/jvmMain/kotlin/io/mockk/impl/instantiation/JvmConstructorMockFactory.kt
@@ -116,7 +116,7 @@ class JvmConstructorMockFactory(
 
         private fun getConstructorMock(args: Array<Matcher<*>>?): ConstructorMock? {
             return synchronized(handlers) {
-                if (args == null) {
+                if (args.isNullOrEmpty()) {
                     if (allHandler == null) {
                         allHandler = ConstructorMock(cls, recordPrivateCalls)
                     }


### PR DESCRIPTION
Fixes #1355 

Handle `null` and `empty` constructor parameters the same way.