### PR TITLE
fix: prevent confirmVerified(vararg mocks) from clearing unrelated mocks

### DIFF
--- a/modules/mockk-dsl/src/commonMain/kotlin/io/mockk/API.kt
+++ b/modules/mockk-dsl/src/commonMain/kotlin/io/mockk/API.kt
@@ -272,16 +272,19 @@ object MockKDsl {
     fun internalConfirmVerified(mocks: Array<out Any>) {
         val verifier = MockKGateway.implementation().verificationAcknowledger
 
-        if (mocks.isEmpty()) {
-            verifier.acknowledgeVerified()
-        } else {
-            mocks.forEach { verifier.acknowledgeVerified(it) }
+        try {
+            if (mocks.isEmpty()) {
+                verifier.acknowledgeVerified()
+            } else {
+                mocks.forEach { verifier.acknowledgeVerified(it) }
+            }
+        } finally {
+            resetVerificationState(mocks)
         }
-
-        resetVerificationState()
     }
 
-    private fun resetVerificationState() {
+    private fun resetVerificationState(mocks: Array<out Any>) {
+        val implementation = MockKGateway.implementation()
         val options = ClearOptions(
             answers = false,
             recordedCalls = true,
@@ -290,7 +293,11 @@ object MockKDsl {
             exclusionRules = false
         )
 
-        MockKGateway.implementation().clearer.clearAll(options, currentThreadOnly = true)
+        if (mocks.isEmpty()) {
+            implementation.clearer.clearAll(options, false)
+        } else {
+            implementation.clearer.clear(mocks, options)
+        }
     }
 
     /**

--- a/modules/mockk/src/jvmTest/kotlin/io/mockk/it/VerificationAcknowledgeTest.kt
+++ b/modules/mockk/src/jvmTest/kotlin/io/mockk/it/VerificationAcknowledgeTest.kt
@@ -629,5 +629,23 @@ class VerificationAcknowledgeTest {
 
         confirmVerified()
     }
+
+    @Test
+    fun confirmVerifiedSpecificMock() {
+        val mockA = mockk<MockCls>()
+        val mockB = mockk<MockCls>()
+
+        every { mockA.op(1) } returns 1
+        every { mockB.op(2) } returns 2
+
+        mockA.op(1)
+        mockB.op(2)
+
+        verify { mockA.op(1) }
+        confirmVerified(mockA)
+
+        verify { mockB.op(2) }
+        confirmVerified(mockB)
+    }
 }
 


### PR DESCRIPTION
## 🚧 Draft Pull Request – Partial Fix for Issue [#1379](https://github.com/mockk/mockk/issues/1379)

This PR builds upon the changes introduced in [#821](https://github.com/mockk/mockk/issues/821), aiming to improve test isolation while addressing the regression reported in [#1379](https://github.com/mockk/mockk/issues/1379).

### 🛠 What's Being Done

- Refactored `internalConfirmVerified` to **reset only the specified mocks** when parameters are passed.
- Updated `resetVerificationState` to **selectively clear** verification state for specific mocks.
- Ensured cleanup with `try-finally`, making the verification process more robust.
- Added a test case `confirmVerifiedSpecificMock` to verify that `confirmVerified(mock)` behavior is correct.

### ⚠️ Current Status

This PR is still **in progress**. While the targeted clearing works in isolated tests, the test suite fails when running `confirmVerifiedAll`.

This issue appears similar to the cross-test interference previously addressed in issue [#821](https://github.com/mockk/mockk/issues/821), but now occurs when `confirmVerified` is used without parameters after using it with specific mocks in other tests.

👉 Notably, if we add a `clearAllMocks()` call before the `confirmVerifiedAll` test, it passes successfully — just like it did before PR [#1367](https://github.com/mockk/mockk/pull/1367).

### 🔍 Next Steps
Investigate and resolve the failure of `confirmVerifiedAll` in the full test suite  

@Raibaz  do you have any idea why this might be happening? It seems related to state retention when mixing `confirmVerified(mock)` and `confirmVerified()` in different tests.
