### PR TITLE
chore: bump byte buddy version to support java 24

### DIFF
--- a/buildSrc/src/main/kotlin/buildsrc/config/Deps.kt
+++ b/buildSrc/src/main/kotlin/buildsrc/config/Deps.kt
@@ -19,7 +19,7 @@ object Deps {
         const val junitJupiter = "5.8.2"
         const val junit4 = "4.13.2"
 
-        const val byteBuddy = "1.14.17"
+        const val byteBuddy = "1.17.5"
         const val objenesis = "3.3"
         const val dexmaker = "2.28.3"
         const val androidxEspresso = "3.5.1"


### PR DESCRIPTION
Bump byte buddy version to 1.17.5, to support java 24

Related issue: #1386 