### PR TITLE
chore: bump dokka, kotlinx.coroutines, slf4j, logback, junit jupiter

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -7,7 +7,7 @@ val kotlinPluginVersion: String = "2.0.0"
 
 val androidGradle = "8.1.1"
 val kotlinxKover = "0.7.3"
-val dokka = "1.9.0"
+val dokka = "2.0.0"
 val binaryCompatibilityValidator = "0.13.2"
 
 dependencies {

--- a/buildSrc/src/main/kotlin/buildsrc/config/Deps.kt
+++ b/buildSrc/src/main/kotlin/buildsrc/config/Deps.kt
@@ -11,15 +11,15 @@ object Deps {
     object Versions {
         val jvmTarget = JavaVersion.VERSION_1_8
 
-        const val dokka = "1.9.0"
+        const val dokka = "2.0.0"
         const val kotlinDefault = "2.0.0"
-        const val coroutines = "1.6.4"
-        const val slfj = "2.0.5"
-        const val logback = "1.4.5"
-        const val junitJupiter = "5.8.2"
+        const val coroutines = "1.10.1"
+        const val slfj = "2.0.17"
+        const val logback = "1.5.18"
+        const val junitJupiter = "5.12.2"
         const val junit4 = "4.13.2"
 
-        const val byteBuddy = "1.14.17"
+        const val byteBuddy = "1.17.5"
         const val objenesis = "3.3"
         const val dexmaker = "2.28.3"
         const val androidxEspresso = "3.5.1"

--- a/modules/mockk/src/commonTest/kotlin/io/mockk/it/CoJustAwaitTest.kt
+++ b/modules/mockk/src/commonTest/kotlin/io/mockk/it/CoJustAwaitTest.kt
@@ -17,8 +17,9 @@ import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertTrue
+import kotlin.time.ExperimentalTime
 
-@OptIn(ExperimentalCoroutinesApi::class)
+@OptIn(ExperimentalCoroutinesApi::class, ExperimentalTime::class)
 class CoJustAwaitTest {
 
     private val mock = mockk<MockCls>()

--- a/modules/mockk/src/jvmTest/kotlin/io/mockk/junit5/MockKExtensionRequireParallelTestingTest.kt
+++ b/modules/mockk/src/jvmTest/kotlin/io/mockk/junit5/MockKExtensionRequireParallelTestingTest.kt
@@ -3,8 +3,9 @@ package io.mockk.junit5
 import io.mockk.every
 import io.mockk.impl.annotations.MockK
 import io.mockk.verify
+import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
@@ -13,7 +14,9 @@ import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
+import kotlin.time.ExperimentalTime
 
+@OptIn(ExperimentalTime::class, ExperimentalCoroutinesApi::class)
 @ExtendWith(MockKExtension::class)
 @MockKExtension.RequireParallelTesting
 class MockKExtensionRequireParallelTestingTest {
@@ -30,6 +33,7 @@ class MockKExtensionRequireParallelTestingTest {
         Dispatchers.resetMain()
     }
 
+    @OptIn(DelicateCoroutinesApi::class)
     companion object {
         @JvmStatic
         @AfterAll

--- a/modules/mockk/src/jvmTest/kotlin/io/mockk/junit5/MockKExtensionWithoutRequireParallelTestingTest.kt
+++ b/modules/mockk/src/jvmTest/kotlin/io/mockk/junit5/MockKExtensionWithoutRequireParallelTestingTest.kt
@@ -3,8 +3,9 @@ package io.mockk.junit5
 import io.mockk.every
 import io.mockk.impl.annotations.MockK
 import io.mockk.verify
+import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
@@ -13,7 +14,9 @@ import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
+import kotlin.time.ExperimentalTime
 
+@OptIn(ExperimentalTime::class, ExperimentalCoroutinesApi::class)
 @ExtendWith(MockKExtension::class)
 class MockKExtensionWithoutRequireParallelTestingTest {
     @MockK
@@ -29,6 +32,7 @@ class MockKExtensionWithoutRequireParallelTestingTest {
         Dispatchers.resetMain()
     }
 
+    @OptIn(DelicateCoroutinesApi::class)
     companion object {
         @JvmStatic
         @AfterAll


### PR DESCRIPTION
Bump versions:
dokka: 2.0.0
kotlinx.coroutines: 1.10.1
slf4j: 2.0.17
logback: 1.5.18
junit jupiter: 5.12.2