### PR TITLE
chore: bump kotlin to 2.1.20

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -8,7 +8,7 @@ val kotlinPluginVersion: String = "2.1.20"
 val androidGradle = "8.9.2"
 val kotlinxKover = "0.7.3"
 val dokka = "2.0.0"
-val binaryCompatibilityValidator = "0.13.2"
+val binaryCompatibilityValidator = "0.17.0"
 
 dependencies {
     implementation(platform("org.jetbrains.kotlin:kotlin-bom:$kotlinPluginVersion"))

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 // set the versions of Gradle plugins that the subprojects will use here
 val kotlinPluginVersion: String = "2.1.20"
 
-val androidGradle = "8.1.1"
+val androidGradle = "8.9.2"
 val kotlinxKover = "0.7.3"
 val dokka = "2.0.0"
 val binaryCompatibilityValidator = "0.13.2"

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
 }
 
 // set the versions of Gradle plugins that the subprojects will use here
-val kotlinPluginVersion: String = "2.0.0"
+val kotlinPluginVersion: String = "2.1.20"
 
 val androidGradle = "8.1.1"
 val kotlinxKover = "0.7.3"

--- a/buildSrc/src/main/kotlin/buildsrc/config/Deps.kt
+++ b/buildSrc/src/main/kotlin/buildsrc/config/Deps.kt
@@ -12,7 +12,7 @@ object Deps {
         val jvmTarget = JavaVersion.VERSION_1_8
 
         const val dokka = "2.0.0"
-        const val kotlinDefault = "2.0.0"
+        const val kotlinDefault = "2.1.20"
         const val coroutines = "1.10.1"
         const val slfj = "2.0.17"
         const val logback = "1.5.18"

--- a/buildSrc/src/main/kotlin/buildsrc/convention/android-application.gradle.kts
+++ b/buildSrc/src/main/kotlin/buildsrc/convention/android-application.gradle.kts
@@ -1,7 +1,8 @@
 package buildsrc.convention
 
 import buildsrc.config.Deps
-import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
 
 plugins {
     id("com.android.application")
@@ -38,9 +39,9 @@ android {
     }
 }
 
-tasks.withType<KotlinCompile> {
-    kotlinOptions {
-        jvmTarget = Deps.Versions.jvmTarget.toString()
+tasks.withType<KotlinJvmCompile>().configureEach {
+    compilerOptions {
+        jvmTarget.set(JvmTarget.fromTarget(Deps.Versions.jvmTarget.toString()))
     }
 }
 

--- a/buildSrc/src/main/kotlin/buildsrc/convention/android-library.gradle.kts
+++ b/buildSrc/src/main/kotlin/buildsrc/convention/android-library.gradle.kts
@@ -1,7 +1,10 @@
 package buildsrc.convention
 
 import buildsrc.config.Deps
+import org.gradle.kotlin.dsl.withType
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
 
 plugins {
     id("com.android.library")
@@ -45,9 +48,9 @@ android {
     }
 }
 
-tasks.withType<KotlinCompile> {
-    kotlinOptions {
-        jvmTarget = Deps.Versions.jvmTarget.toString()
+tasks.withType<KotlinJvmCompile>().configureEach {
+    compilerOptions {
+        jvmTarget.set(JvmTarget.fromTarget(Deps.Versions.jvmTarget.toString()))
     }
 }
 

--- a/buildSrc/src/main/kotlin/buildsrc/convention/kotlin-jvm.gradle.kts
+++ b/buildSrc/src/main/kotlin/buildsrc/convention/kotlin-jvm.gradle.kts
@@ -1,7 +1,9 @@
 package buildsrc.convention
 
 import buildsrc.config.Deps
-import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
+import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
 
 plugins {
     `java-library`
@@ -22,12 +24,13 @@ tasks.withType<JavaCompile>().configureEach {
     options.encoding = "UTF-8"
 }
 
-tasks.withType<KotlinCompile>().configureEach {
-    kotlinOptions.apply {
-        freeCompilerArgs += listOf("-Xjsr305=strict")
-        jvmTarget = Deps.Versions.jvmTarget.toString()
-        apiVersion = "1.5"
-        languageVersion = "1.7"
+tasks.withType<KotlinJvmCompile>().configureEach {
+    compilerOptions {
+        jvmTarget.set(JvmTarget.fromTarget(Deps.Versions.jvmTarget.toString()))
+
+        freeCompilerArgs = listOf("-Xjsr305=strict")
+        apiVersion = KotlinVersion.KOTLIN_1_6
+        languageVersion = KotlinVersion.KOTLIN_1_7
     }
 }
 

--- a/buildSrc/src/main/kotlin/buildsrc/convention/kotlin-jvm.gradle.kts
+++ b/buildSrc/src/main/kotlin/buildsrc/convention/kotlin-jvm.gradle.kts
@@ -28,7 +28,7 @@ tasks.withType<KotlinJvmCompile>().configureEach {
     compilerOptions {
         jvmTarget.set(JvmTarget.fromTarget(Deps.Versions.jvmTarget.toString()))
 
-        freeCompilerArgs = listOf("-Xjsr305=strict")
+        freeCompilerArgs.add("-Xjsr305=strict")
         apiVersion = KotlinVersion.KOTLIN_1_6
         languageVersion = KotlinVersion.KOTLIN_1_7
     }

--- a/buildSrc/src/main/kotlin/buildsrc/convention/kotlin-multiplatform.gradle.kts
+++ b/buildSrc/src/main/kotlin/buildsrc/convention/kotlin-multiplatform.gradle.kts
@@ -16,7 +16,7 @@ kotlin {
     targets.configureEach {
         compilations.configureEach {
             kotlinOptions {
-                apiVersion = "1.5"
+                apiVersion = "1.6"
                 languageVersion = "1.7"
             }
         }

--- a/buildSrc/src/main/kotlin/buildsrc/convention/kotlin-multiplatform.gradle.kts
+++ b/buildSrc/src/main/kotlin/buildsrc/convention/kotlin-multiplatform.gradle.kts
@@ -1,5 +1,6 @@
 package buildsrc.convention
 
+import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
 import org.jetbrains.kotlin.gradle.targets.jvm.KotlinJvmTarget
 
 plugins {
@@ -15,9 +16,9 @@ plugins {
 kotlin {
     targets.configureEach {
         compilations.configureEach {
-            kotlinOptions {
-                apiVersion = "1.6"
-                languageVersion = "1.7"
+            compilerOptions.configure {
+                apiVersion = KotlinVersion.KOTLIN_1_6
+                languageVersion = KotlinVersion.KOTLIN_1_7
             }
         }
     }

--- a/buildSrc/src/main/kotlin/buildsrc/convention/toolchain-jvm.gradle.kts
+++ b/buildSrc/src/main/kotlin/buildsrc/convention/toolchain-jvm.gradle.kts
@@ -1,8 +1,11 @@
 package buildsrc.convention
 
 import buildsrc.config.Deps
+import org.gradle.kotlin.dsl.withType
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.plugin.KotlinBasePlugin
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
 import org.jetbrains.kotlin.gradle.tasks.UsesKotlinJavaToolchain
 
 
@@ -15,9 +18,9 @@ tasks.withType<JavaCompile>().configureEach {
     targetCompatibility = Deps.Versions.jvmTarget.toString()
 }
 
-tasks.withType<KotlinCompile>().configureEach {
-    kotlinOptions {
-        jvmTarget = Deps.Versions.jvmTarget.toString()
+tasks.withType<KotlinJvmCompile>().configureEach {
+    compilerOptions {
+        jvmTarget.set(JvmTarget.fromTarget(Deps.Versions.jvmTarget.toString()))
     }
 }
 

--- a/modules/mockk-agent/build.gradle.kts
+++ b/modules/mockk-agent/build.gradle.kts
@@ -13,7 +13,6 @@ val mavenDescription: String by extra("${project.description}")
 
 kotlin {
     jvm {
-        withJava()
     }
 
     sourceSets {

--- a/modules/mockk/build.gradle.kts
+++ b/modules/mockk/build.gradle.kts
@@ -13,7 +13,6 @@ val mavenDescription: String by extra("${project.description}")
 
 kotlin {
     jvm {
-        withJava()
     }
 
     sourceSets {

--- a/test-modules/client-tests/build.gradle.kts
+++ b/test-modules/client-tests/build.gradle.kts
@@ -1,3 +1,4 @@
+import buildsrc.config.Deps
 import buildsrc.config.kotlinVersion
 
 plugins {
@@ -7,17 +8,16 @@ plugins {
 
 kotlin {
     jvm {
-        withJava()
     }
 
     sourceSets {
         val commonMain by getting {
             dependencies {
-                implementation(enforcedPlatform(kotlin("bom", version = kotlinVersion())))
+                implementation(project.dependencies.enforcedPlatform(kotlin("bom", version = kotlinVersion())))
                 implementation(kotlin("reflect"))
 
-                implementation(platform(buildsrc.config.Deps.Libs.kotlinCoroutinesBom))
-                implementation(buildsrc.config.Deps.Libs.kotlinCoroutinesCore)
+                implementation(project.dependencies.platform(Deps.Libs.kotlinCoroutinesBom))
+                implementation(Deps.Libs.kotlinCoroutinesCore)
             }
         }
 

--- a/test-modules/logger-tests/build.gradle.kts
+++ b/test-modules/logger-tests/build.gradle.kts
@@ -4,7 +4,6 @@ plugins {
 
 kotlin {
     jvm {
-        withJava()
     }
 
     sourceSets {


### PR DESCRIPTION
Bump kotlin version to 2.1.20
Bump com.android.tools.build:gradle to 8.9.2
Bump org.jetbrains.kotlinx:binary-compatibility-validator to 0.17.0

Breaking Change: Minimal Kotlin API version for 2.1.20 is 1.6