### PR TITLE
Add logging on failure inside withArg

### DIFF
--- a/modules/mockk-dsl/api/mockk-dsl.api
+++ b/modules/mockk-dsl/api/mockk-dsl.api
@@ -310,12 +310,13 @@ public final class io/mockk/FunctionMatcher : io/mockk/EquivalentMatcher, io/moc
 }
 
 public final class io/mockk/FunctionWithNullableArgMatcher : io/mockk/EquivalentMatcher, io/mockk/Matcher, io/mockk/TypedMatcher {
-	public fun <init> (Lkotlin/jvm/functions/Function1;Lkotlin/reflect/KClass;)V
+	public fun <init> (Lkotlin/jvm/functions/Function1;Lkotlin/reflect/KClass;Z)V
+	public synthetic fun <init> (Lkotlin/jvm/functions/Function1;Lkotlin/reflect/KClass;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun checkType (Ljava/lang/Object;)Z
 	public final fun component1 ()Lkotlin/jvm/functions/Function1;
 	public final fun component2 ()Lkotlin/reflect/KClass;
-	public final fun copy (Lkotlin/jvm/functions/Function1;Lkotlin/reflect/KClass;)Lio/mockk/FunctionWithNullableArgMatcher;
-	public static synthetic fun copy$default (Lio/mockk/FunctionWithNullableArgMatcher;Lkotlin/jvm/functions/Function1;Lkotlin/reflect/KClass;ILjava/lang/Object;)Lio/mockk/FunctionWithNullableArgMatcher;
+	public final fun copy (Lkotlin/jvm/functions/Function1;Lkotlin/reflect/KClass;Z)Lio/mockk/FunctionWithNullableArgMatcher;
+	public static synthetic fun copy$default (Lio/mockk/FunctionWithNullableArgMatcher;Lkotlin/jvm/functions/Function1;Lkotlin/reflect/KClass;ZILjava/lang/Object;)Lio/mockk/FunctionWithNullableArgMatcher;
 	public fun equals (Ljava/lang/Object;)Z
 	public fun equivalent ()Lio/mockk/Matcher;
 	public fun getArgumentType ()Lkotlin/reflect/KClass;

--- a/modules/mockk-dsl/api/mockk-dsl.api
+++ b/modules/mockk-dsl/api/mockk-dsl.api
@@ -292,12 +292,13 @@ public final class io/mockk/FunctionAnswer : io/mockk/Answer {
 }
 
 public final class io/mockk/FunctionMatcher : io/mockk/EquivalentMatcher, io/mockk/Matcher, io/mockk/TypedMatcher {
-	public fun <init> (Lkotlin/jvm/functions/Function1;Lkotlin/reflect/KClass;)V
+	public fun <init> (Lkotlin/jvm/functions/Function1;Lkotlin/reflect/KClass;Z)V
+	public synthetic fun <init> (Lkotlin/jvm/functions/Function1;Lkotlin/reflect/KClass;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun checkType (Ljava/lang/Object;)Z
 	public final fun component1 ()Lkotlin/jvm/functions/Function1;
 	public final fun component2 ()Lkotlin/reflect/KClass;
-	public final fun copy (Lkotlin/jvm/functions/Function1;Lkotlin/reflect/KClass;)Lio/mockk/FunctionMatcher;
-	public static synthetic fun copy$default (Lio/mockk/FunctionMatcher;Lkotlin/jvm/functions/Function1;Lkotlin/reflect/KClass;ILjava/lang/Object;)Lio/mockk/FunctionMatcher;
+	public final fun copy (Lkotlin/jvm/functions/Function1;Lkotlin/reflect/KClass;Z)Lio/mockk/FunctionMatcher;
+	public static synthetic fun copy$default (Lio/mockk/FunctionMatcher;Lkotlin/jvm/functions/Function1;Lkotlin/reflect/KClass;ZILjava/lang/Object;)Lio/mockk/FunctionMatcher;
 	public fun equals (Ljava/lang/Object;)Z
 	public fun equivalent ()Lio/mockk/Matcher;
 	public fun getArgumentType ()Lkotlin/reflect/KClass;

--- a/modules/mockk-dsl/src/commonMain/kotlin/io/mockk/API.kt
+++ b/modules/mockk-dsl/src/commonMain/kotlin/io/mockk/API.kt
@@ -2179,10 +2179,16 @@ class MockKVerificationScope(
         )
 
     inline fun <reified T : Any> withNullableArg(noinline captureBlock: MockKAssertScope.(T?) -> Unit): T =
-        matchNullable {
-            MockKAssertScope(it).captureBlock(it)
-            true
-        }
+        match(
+            FunctionWithNullableArgMatcher(
+                {
+                    MockKAssertScope(it).captureBlock(it)
+                    true
+                },
+                T::class,
+                logAssertionError = true
+            )
+        )
 
     inline fun <reified T : Any> coWithArg(noinline captureBlock: suspend MockKAssertScope.(T) -> Unit): T =
         withArg {

--- a/modules/mockk-dsl/src/commonMain/kotlin/io/mockk/API.kt
+++ b/modules/mockk-dsl/src/commonMain/kotlin/io/mockk/API.kt
@@ -2166,10 +2166,17 @@ class MockKVerificationScope(
     callRecorder: CallRecorder,
     lambda: CapturingSlot<Function<*>>
 ) : MockKMatcherScope(callRecorder, lambda) {
-    inline fun <reified T : Any> withArg(noinline captureBlock: MockKAssertScope.(T) -> Unit): T = match {
-        MockKAssertScope(it).captureBlock(it)
-        true
-    }
+    inline fun <reified T : Any> withArg(noinline captureBlock: MockKAssertScope.(T) -> Unit): T =
+        match(
+            FunctionMatcher(
+                {
+                    MockKAssertScope(it).captureBlock(it)
+                    true
+                },
+                T::class,
+                logAssertionError = true
+            )
+        )
 
     inline fun <reified T : Any> withNullableArg(noinline captureBlock: MockKAssertScope.(T?) -> Unit): T =
         matchNullable {

--- a/modules/mockk-dsl/src/commonMain/kotlin/io/mockk/Matchers.kt
+++ b/modules/mockk-dsl/src/commonMain/kotlin/io/mockk/Matchers.kt
@@ -76,11 +76,19 @@ data class FunctionMatcher<in T : Any>(
 
 data class FunctionWithNullableArgMatcher<in T : Any>(
     val matchingFunc: (T?) -> Boolean,
-    override val argumentType: KClass<*>
+    override val argumentType: KClass<*>,
+    private val logAssertionError: Boolean = false,
 ) : Matcher<T>, TypedMatcher, EquivalentMatcher {
     override fun equivalent(): Matcher<Any> = ConstantMatcher(true)
 
-    override fun match(arg: T?): Boolean = matchingFunc(arg)
+    override fun match(arg: T?): Boolean = try {
+        matchingFunc(arg)
+    } catch (a: AssertionError) {
+        if (logAssertionError) {
+            a.printStackTrace()
+        }
+        false
+    }
 
     override fun checkType(arg: Any?): Boolean {
         if (arg == null) {

--- a/modules/mockk-dsl/src/commonMain/kotlin/io/mockk/Matchers.kt
+++ b/modules/mockk-dsl/src/commonMain/kotlin/io/mockk/Matchers.kt
@@ -51,7 +51,8 @@ data class ConstantMatcher<in T : Any>(val constValue: Boolean) : Matcher<T> {
  */
 data class FunctionMatcher<in T : Any>(
     val matchingFunc: (T) -> Boolean,
-    override val argumentType: KClass<*>
+    override val argumentType: KClass<*>,
+    private val logAssertionError: Boolean = false,
 ) : Matcher<T>, TypedMatcher, EquivalentMatcher {
     override fun equivalent(): Matcher<Any> = ConstantMatcher(true)
 
@@ -62,6 +63,9 @@ data class FunctionMatcher<in T : Any>(
             try {
                 matchingFunc(arg)
             } catch (a: AssertionError) {
+                if (logAssertionError) {
+                    a.printStackTrace()
+                }
                 false
             }
         }


### PR DESCRIPTION
One more fix for #707

Previous fix (#776) was reverted (https://github.com/mockk/mockk/issues/707#issuecomment-1056006754), but this one should not repeat the same error.

I use the same idea as in mockito-kotlin `check`: https://github.com/mockito/mockito-kotlin/blob/main/mockito-kotlin/src/main/kotlin/org/mockito/kotlin/Verification.kt#L285

It is not ideal, as it may print assertion errors even on verify pass (in case on many invocations), but this is how mockit-kotlin `check` works too. And I think this is better than nothing