### PR TITLE
fix: enable confirmVerified to work with static mocks

### DIFF
--- a/modules/mockk-dsl/src/commonMain/kotlin/io/mockk/API.kt
+++ b/modules/mockk-dsl/src/commonMain/kotlin/io/mockk/API.kt
@@ -275,8 +275,14 @@ object MockKDsl {
         if (mocks.isEmpty()) {
             verifier.acknowledgeVerified()
         } else {
-            mocks.forEach { verifier.acknowledgeVerified(it) }
+            mocks.forEach {
+                when (it) {
+                    is KClass<*> -> verifier.acknowledgeVerified(it.java)
+                    else -> verifier.acknowledgeVerified(it)
+                }
+            }
         }
+
 
         resetVerificationState()
     }

--- a/modules/mockk-dsl/src/commonMain/kotlin/io/mockk/API.kt
+++ b/modules/mockk-dsl/src/commonMain/kotlin/io/mockk/API.kt
@@ -283,7 +283,6 @@ object MockKDsl {
             }
         }
 
-
         resetVerificationState()
     }
 

--- a/modules/mockk/src/jvmTest/kotlin/io/mockk/it/VerificationAcknowledgeTest.kt
+++ b/modules/mockk/src/jvmTest/kotlin/io/mockk/it/VerificationAcknowledgeTest.kt
@@ -8,6 +8,7 @@ import io.mockk.confirmVerified
 import io.mockk.every
 import io.mockk.excludeRecords
 import io.mockk.mockk
+import io.mockk.mockkStatic
 import io.mockk.verify
 import io.mockk.verifyCount
 import io.mockk.verifyOrder
@@ -18,6 +19,7 @@ import kotlin.test.assertFailsWith
 import org.hamcrest.CoreMatchers.equalTo
 import org.hamcrest.MatcherAssert.assertThat
 import org.junit.jupiter.api.Test
+import java.time.Instant
 
 class VerificationAcknowledgeTest {
     class MockCls {
@@ -628,6 +630,19 @@ class VerificationAcknowledgeTest {
         }
 
         confirmVerified()
+    }
+
+    @Test
+    fun confirmVerifiedToWorkWithStaticMock() {
+        val epochSeconds = 123L
+        mockkStatic(Instant::class)
+        every { Instant.now().epochSecond } returns epochSeconds
+
+        assertEquals(123L, Instant.now().epochSecond)
+
+        verify(exactly = 1) { Instant.now().epochSecond  }
+
+        confirmVerified(Instant::class)
     }
 }
 


### PR DESCRIPTION
fixes #242

When a static class is mocked using the mockStatic method, its javaClass is used as the key in the stubRepo. 
To make use of this, add logic to convert a given KClass to its javaClass and use it in the when clause.

