### PR TITLE
[Feature] Implement BDD-style aliases as separate module (mockk-bdd)

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,30 @@ confirmVerified(car)
 
 See the "Features" section below for more detailed examples.
 
+## BDD style (optional)
+
+For teams using Behavior-Driven Development, MockK provides BDD-style aliases:
+
+```gradle
+testImplementation "io.mockk:mockk:${mockkVersion}"
+testImplementation "io.mockk:mockk-bdd:${mockkVersion}"
+```
+
+```gradle
+androidTestImplementation "io.mockk:mockk-android:${mockkVersion}"
+androidTestImplementation "io.mockk:mockk-bdd-android:${mockkVersion}"
+```
+
+### BDD aliases
+
+| Standard MockK | BDD style |
+|----------------|-----------|
+| `every { ... }` | `given { ... }` |
+| `coEvery { ... }` | `coGiven { ... }` |
+| `verify { ... }` | `then { ... }` |
+| `coVerify { ... }` | `coThen { ... }` |
+
+
 ### Spring support
 
  * [springmockk](https://github.com/Ninja-Squad/springmockk) introduced in official [Spring Boot Kotlin tutorial](https://spring.io/guides/tutorials/spring-boot-kotlin/)

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ See the "Features" section below for more detailed examples.
 
 ## BDD style (optional)
 
-For teams using Behavior-Driven Development, MockK provides BDD-style aliases:
+For teams using Behavior-Driven Development, MockK provides BDD-style aliases
 
 ```gradle
 testImplementation "io.mockk:mockk:${mockkVersion}"

--- a/modules/mockk-bdd-android/build.gradle.kts
+++ b/modules/mockk-bdd-android/build.gradle.kts
@@ -1,0 +1,28 @@
+import buildsrc.config.Deps
+
+plugins {
+    buildsrc.convention.`android-library`
+    buildsrc.convention.`mockk-publishing`
+}
+
+description = "MockK BDD style aliases for Android"
+
+val mavenName: String by extra("MockK BDD Android")
+val mavenDescription: String by extra("${project.description}")
+
+android {
+    namespace = "io.mockk.bdd.android"
+    packaging {
+        resources {
+            excludes += "META-INF/LICENSE.md"
+            excludes += "META-INF/LICENSE-notice.md"
+        }
+    }
+}
+
+dependencies {
+    api(projects.modules.mockkAndroid)
+    api(projects.modules.mockkBdd)
+    testImplementation(kotlin("test-junit5"))
+    testImplementation(Deps.Libs.junitJupiter)
+} 

--- a/modules/mockk-bdd-android/build.gradle.kts
+++ b/modules/mockk-bdd-android/build.gradle.kts
@@ -1,5 +1,3 @@
-import buildsrc.config.Deps
-
 plugins {
     buildsrc.convention.`android-library`
     buildsrc.convention.`mockk-publishing`
@@ -23,6 +21,7 @@ android {
 dependencies {
     api(projects.modules.mockkAndroid)
     api(projects.modules.mockkBdd)
-    testImplementation(kotlin("test-junit5"))
-    testImplementation(Deps.Libs.junitJupiter)
+    
+    androidTestImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-core")
+
 } 

--- a/modules/mockk-bdd-android/src/androidTest/kotlin/io/mockk/bdd/BDDAndroidTest.kt
+++ b/modules/mockk-bdd-android/src/androidTest/kotlin/io/mockk/bdd/BDDAndroidTest.kt
@@ -1,0 +1,118 @@
+package io.mockk.bdd
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import io.mockk.clearAllMocks
+import io.mockk.mockk
+import io.mockk.slot
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Android instrumentation tests for BDD-style API.
+ * Verifies that the BDD functions work correctly in Android environment.
+ */
+@RunWith(AndroidJUnit4::class)
+class BDDAndroidTest {
+    
+    interface AndroidTestService {
+        fun getValue(): String
+        fun setValue(value: String)
+        suspend fun getAsyncValue(): List<String>
+        fun processData(data: Any): Boolean
+    }
+    
+    private lateinit var service: AndroidTestService
+    
+    @Before
+    fun setup() {
+        service = mockk()
+    }
+    
+    @After
+    fun tearDown() {
+        clearAllMocks()
+    }
+    
+    @Test
+    fun givenShouldWorkInAndroidTests() {
+        // Given
+        given { service.getValue() } returns "Android BDD Style"
+        
+        // When
+        val result = service.getValue()
+        
+        // Then
+        assertEquals("Android BDD Style", result)
+    }
+    
+    @Test
+    fun coGivenShouldWorkInAndroidTests() = runBlocking {
+        // Given
+        coGiven { service.getAsyncValue() } returns listOf("Android", "BDD", "Async")
+        
+        // When
+        val result = service.getAsyncValue()
+        
+        // Then
+        assertEquals(listOf("Android", "BDD", "Async"), result)
+    }
+    
+    @Test
+    fun thenShouldWorkInAndroidTests() {
+        // Given
+        val captureSlot = slot<String>()
+        given { service.setValue(capture(captureSlot)) } returns Unit
+        
+        // When
+        service.setValue("Android test value")
+        
+        // Then
+        then { service.setValue("Android test value") }
+        assertTrue(captureSlot.isCaptured)
+        assertEquals("Android test value", captureSlot.captured)
+    }
+    
+    @Test
+    fun coThenShouldWorkInAndroidTests() = runBlocking {
+        // Given
+        coGiven { service.getAsyncValue() } returns listOf("test")
+        
+        // When
+        service.getAsyncValue()
+        
+        // Then
+        coThen { service.getAsyncValue() }
+    }
+    
+    @Test
+    fun thenWithParametersShouldWorkInAndroidTests() {
+        // Given
+        given { service.getValue() } returns "test"
+        
+        // When
+        repeat(3) { service.getValue() }
+        
+        // Then
+        then(exactly = 3) { service.getValue() }
+        then(atLeast = 2) { service.getValue() }
+        then(atMost = 5) { service.getValue() }
+    }
+    
+    @Test
+    fun shouldWorkWithAndroidSpecificObjects() {
+        // Given
+        given { service.processData(any()) } returns true
+        
+        // When
+        val result = service.processData("Android specific data")
+        
+        // Then
+        then { service.processData(any()) }
+        assertEquals(true, result)
+    }
+} 

--- a/modules/mockk-bdd-android/src/main/AndroidManifest.xml
+++ b/modules/mockk-bdd-android/src/main/AndroidManifest.xml
@@ -1,0 +1,3 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="io.mockk.bdd.android">
+</manifest> 

--- a/modules/mockk-bdd-android/src/main/kotlin/io/mockk/bdd/BDDAndroid.kt
+++ b/modules/mockk-bdd-android/src/main/kotlin/io/mockk/bdd/BDDAndroid.kt
@@ -1,0 +1,11 @@
+package io.mockk.bdd
+
+/**
+ * BDD style API for MockK Android.
+ * This module re-exports the base BDD functions and adds Android-specific extensions.
+ * 
+ * To use this module in your Android tests:
+ * ```
+ * testImplementation("io.mockk:mockk-bdd-android:x.y.z")
+ * ```
+ */ 

--- a/modules/mockk-bdd/api/mockk-bdd.api
+++ b/modules/mockk-bdd/api/mockk-bdd.api
@@ -1,0 +1,9 @@
+public final class io/mockk/bdd/BDDKt {
+	public static final fun coGiven (Lkotlin/jvm/functions/Function2;)Lio/mockk/MockKStubScope;
+	public static final fun coThen (Lio/mockk/Ordering;ZIIIJLkotlin/jvm/functions/Function2;)V
+	public static synthetic fun coThen$default (Lio/mockk/Ordering;ZIIIJLkotlin/jvm/functions/Function2;ILjava/lang/Object;)V
+	public static final fun given (Lkotlin/jvm/functions/Function1;)Lio/mockk/MockKStubScope;
+	public static final fun then (Lio/mockk/Ordering;ZIIIJLkotlin/jvm/functions/Function1;)V
+	public static synthetic fun then$default (Lio/mockk/Ordering;ZIIIJLkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+}
+

--- a/modules/mockk-bdd/build.gradle.kts
+++ b/modules/mockk-bdd/build.gradle.kts
@@ -1,0 +1,43 @@
+import buildsrc.config.Deps
+
+plugins {
+    buildsrc.convention.`kotlin-multiplatform`
+    buildsrc.convention.`mockk-publishing`
+}
+
+description = "MockK BDD style aliases for DSL"
+
+val mavenName: String by extra("MockK BDD")
+val mavenDescription: String by extra("${project.description}")
+
+kotlin {
+    jvm()
+
+    sourceSets {
+        val commonMain by getting {
+            dependencies {
+                implementation(dependencies.platform(Deps.Libs.kotlinCoroutinesBom))
+                implementation(Deps.Libs.kotlinCoroutinesCore)
+                implementation(kotlin("reflect"))
+                implementation(projects.modules.mockkCore)
+                implementation(projects.modules.mockkDsl)
+                implementation(projects.modules.mockk)
+            }
+        }
+        val commonTest by getting {
+            dependencies {
+                implementation(kotlin("test"))
+            }
+        }
+        val jvmMain by getting {
+            dependencies {
+            }
+        }
+        val jvmTest by getting {
+            dependencies {
+                implementation(kotlin("test-junit5"))
+                implementation(Deps.Libs.junitJupiter)
+            }
+        }
+    }
+} 

--- a/modules/mockk-bdd/src/commonMain/kotlin/io/mockk/bdd/BDD.kt
+++ b/modules/mockk-bdd/src/commonMain/kotlin/io/mockk/bdd/BDD.kt
@@ -1,0 +1,105 @@
+package io.mockk.bdd
+
+import io.mockk.MockKMatcherScope
+import io.mockk.MockKStubScope
+import io.mockk.MockKVerificationScope
+import io.mockk.MockK
+import io.mockk.MockKDsl
+import io.mockk.Ordering
+import io.mockk.every
+import io.mockk.coEvery
+import io.mockk.verify
+import io.mockk.coVerify
+
+/**
+ * BDD style API for MockK.
+ * Provides aliases for MockK functions in BDD style:
+ * - given/coGiven (aliases for every/coEvery)
+ * - then/coThen (aliases for verify/coVerify)
+ */
+
+/**
+ * Starts a block of stubbing in BDD style. Part of DSL.
+ *
+ * Used to define what behaviour is going to be mocked.
+ *
+ * @sample
+ * ```
+ * val navigator = mockk<Navigator>()
+ * given { navigator.currentLocation } returns "Home"
+ *
+ * println(navigator.currentLocation) // prints "Home"
+ * ```
+ * @see [coGiven] Coroutine version.
+ * @see [io.mockk.every] MockK original function.
+ */
+fun <T> given(stubBlock: MockKMatcherScope.() -> T): MockKStubScope<T, T> = 
+    every(stubBlock)
+
+/**
+ * Starts a block of stubbing for coroutines in BDD style. Part of DSL.
+ * Similar to [given], but works with suspend functions.
+ *
+ * Used to define what behaviour is going to be mocked.
+ * @see [given]
+ * @see [io.mockk.coEvery] MockK original function.
+ */
+fun <T> coGiven(stubBlock: suspend MockKMatcherScope.() -> T): MockKStubScope<T, T> = 
+    coEvery(stubBlock)
+
+/**
+ * Verifies calls happened in the past in BDD style. Part of DSL
+ *
+ * @param ordering how the verification should be ordered
+ * @param inverse when true, the verification will check that the behaviour specified did **not** happen
+ * @param atLeast verifies that the behaviour happened at least [atLeast] times
+ * @param atMost verifies that the behaviour happened at most [atMost] times
+ * @param exactly verifies that the behaviour happened exactly [exactly] times. Use -1 to disable
+ * @param timeout timeout value in milliseconds. Will wait until one of two following states: either verification is
+ * passed or timeout is reached.
+ * @param verifyBlock code block containing at least 1 call to verify
+ *
+ * @sample
+ * ```
+ * val navigator = mockk<Navigator>(relaxed = true)
+ *
+ * navigator.navigateTo("Park")
+ * then { navigator.navigateTo(any()) }
+ * ```
+ * @see [coThen] Coroutine version
+ * @see [io.mockk.verify] MockK original function.
+ */
+fun then(
+    ordering: Ordering = Ordering.UNORDERED,
+    inverse: Boolean = false,
+    atLeast: Int = 1,
+    atMost: Int = Int.MAX_VALUE,
+    exactly: Int = -1,
+    timeout: Long = 0,
+    verifyBlock: MockKVerificationScope.() -> Unit
+) = verify(ordering, inverse, atLeast, atMost, exactly, timeout, verifyBlock)
+
+/**
+ * Verifies that calls were made inside a coroutine in BDD style.
+ *
+ * @param ordering how the verification should be ordered
+ * @param inverse when true, the verification will check that the behaviour specified did **not** happen
+ * @param atLeast verifies that the behaviour happened at least [atLeast] times
+ * @param atMost verifies that the behaviour happened at most [atMost] times
+ * @param exactly verifies that the behaviour happened exactly [exactly] times. Use -1 to disable
+ * @param timeout timeout value in milliseconds. Will wait until one of two following states: either verification is
+ * passed or timeout is reached.
+ * @param verifyBlock code block containing at least 1 call to verify
+ *
+ * @see [then]
+ * @see [io.mockk.coVerify] MockK original function.
+ */
+fun coThen(
+    ordering: Ordering = Ordering.UNORDERED,
+    inverse: Boolean = false,
+    atLeast: Int = 1,
+    atMost: Int = Int.MAX_VALUE,
+    exactly: Int = -1,
+    timeout: Long = 0,
+    verifyBlock: suspend MockKVerificationScope.() -> Unit
+) = coVerify(ordering, inverse, atLeast, atMost, exactly, timeout, verifyBlock) 

--- a/modules/mockk-bdd/src/jvmTest/kotlin/io/mockk/bdd/BDDTest.kt
+++ b/modules/mockk-bdd/src/jvmTest/kotlin/io/mockk/bdd/BDDTest.kt
@@ -1,0 +1,133 @@
+package io.mockk.bdd
+
+import io.mockk.MockKVerificationScope
+import io.mockk.every
+import io.mockk.coEvery
+import io.mockk.verify
+import io.mockk.coVerify
+import io.mockk.clearAllMocks
+import io.mockk.mockk
+import io.mockk.slot
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Tests for BDD-style API.
+ * Verifies that the BDD functions correctly delegate to the MockK core functions.
+ */
+class BDDTest {
+    
+    interface TestService {
+        fun getValue(): String
+        fun setValue(value: String)
+        suspend fun getAsyncValue(): List<String>
+    }
+    
+    private lateinit var service: TestService
+    
+    @BeforeEach
+    fun setup() {
+        service = mockk()
+    }
+    
+    @AfterEach
+    fun tearDown() {
+        clearAllMocks()
+    }
+    
+    @Test
+    fun `given should work like every`() {
+        // Stub using original MockK API
+        every { service.getValue() } returns "MockK"
+        
+        // Reset and stub using BDD API
+        clearAllMocks()
+        given { service.getValue() } returns "BDD Style"
+        
+        // Verify both APIs work the same
+        assertEquals("BDD Style", service.getValue())
+    }
+    
+    @Test
+    fun `coGiven should work like coEvery`() = runBlocking {
+        // Stub using original MockK API
+        coEvery { service.getAsyncValue() } returns listOf("MockK")
+        
+        // Reset and stub using BDD API
+        clearAllMocks()
+        coGiven { service.getAsyncValue() } returns listOf("BDD Style")
+        
+        // Verify both APIs work the same
+        assertEquals(listOf("BDD Style"), service.getAsyncValue())
+    }
+    
+    @Test
+    fun `then should work like verify`() {
+        // Setup
+        val captureSlot = slot<String>()
+        given { service.setValue(capture(captureSlot)) } returns Unit
+        
+        // Action
+        service.setValue("test value")
+        
+        // Verify using original MockK API
+        verify { service.setValue("test value") }
+        
+        // Reset verification
+        captureSlot.clear()
+        
+        // Action again
+        service.setValue("BDD value")
+        
+        // Verify using BDD API
+        then { service.setValue("BDD value") }
+        
+        // Check captured value
+        assertTrue(captureSlot.isCaptured)
+        assertEquals("BDD value", captureSlot.captured)
+    }
+    
+    @Test
+    fun `coThen should work like coVerify`() = runBlocking {
+        // Setup
+        coGiven { service.getAsyncValue() } returns listOf("async value")
+        
+        // Action
+        service.getAsyncValue()
+        
+        // Verify using original MockK API
+        coVerify { service.getAsyncValue() }
+        
+        // Reset and setup again
+        clearAllMocks()
+        coGiven { service.getAsyncValue() } returns listOf("BDD async")
+        
+        // Action again
+        service.getAsyncValue()
+        
+        // Verify using BDD API
+        coThen { service.getAsyncValue() }
+    }
+    
+    @Test
+    fun `then should support all parameters like verify`() {
+        // Setup
+        given { service.getValue() } returns "value"
+        
+        // Action multiple times
+        repeat(3) { service.getValue() }
+        
+        // Verify exact count using BDD API
+        then(exactly = 3) { service.getValue() }
+        
+        // Verify with atLeast
+        then(atLeast = 2) { service.getValue() }
+        
+        // Verify with atMost
+        then(atMost = 5) { service.getValue() }
+    }
+} 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -28,6 +28,7 @@ include(
     ":modules:mockk-agent",
     ":modules:mockk-core",
     ":modules:mockk-dsl",
+    ":modules:mockk-bdd",
 
     ":test-modules:client-tests",
     ":test-modules:performance-tests",
@@ -41,5 +42,6 @@ if (androidSdkDetected == true) {
         ":modules:mockk-agent-android",
         ":modules:mockk-agent-android-dispatcher",
         ":modules:mockk-android",
+        ":modules:mockk-bdd-android",
     )
 }


### PR DESCRIPTION
Implement BDD style aliases as separate modules

This PR implements BDD (Behavior-Driven Development) style API for MockK as proposed in issue #439. The implementation provides aliases for existing MockK functions with BDD-oriented naming

- `given` (alias for `every`)
- `coGiven` (alias for `coEvery`)
- `then` (alias for `verify`)
- `coThen` (alias for `coVerify`)

Following discussions in PR #662, these aliases are implemented as separate modules to avoid confusion and maintain code consistency.

## New Modules

- **mockk-bdd**: Base module with BDD style aliases
- **mockk-bdd-android**: Android-specific module (but... just wrapping mockk-bdd 😂)
**Separate Modules**: As suggested in PR #662 discussion, BDD aliases are implemented as separate modules to
- Avoid confusion with existing APIs
- Allow teams to choose their preferred style
- Maintain code consistency in projects

## Usage

```kotlin
// Regular MockK
testImplementation("io.mockk:mockk:x.y.z")

// Add BDD style
testImplementation("io.mockk:mockk-bdd:x.y.z")

// For Android
androidTestImplementation("io.mockk:mockk-bdd-android:x.y.z")
```

## Example

```kotlin
// Given
given { myService.getValue() } returns "test value"

// When
val result = myService.getValue()

// Then
then { myService.getValue() }
assertEquals("test value", result)
```

## Testing

- Added comprehensive tests for all BDD functions
- Verified compatibility with existing MockK functions
- Tested locally via `publishToMavenLocal` and confirmed functionality in [sample project](https://github.com/Minseok-2001/mockk-bdd-test/blob/main/src/test/kotlin/mockk/mockkbdd/BDDStyleTest.kt)

