### PR TITLE
fix: downgrade byte-buddy to 1.5.11

### DIFF
--- a/buildSrc/src/main/kotlin/buildsrc/config/Deps.kt
+++ b/buildSrc/src/main/kotlin/buildsrc/config/Deps.kt
@@ -19,7 +19,7 @@ object Deps {
         const val junitJupiter = "5.12.2"
         const val junit4 = "4.13.2"
 
-        const val byteBuddy = "1.17.5"
+        const val byteBuddy = "1.15.11"
         const val objenesis = "3.3"
         const val dexmaker = "2.28.3"
         const val androidxEspresso = "3.5.1"


### PR DESCRIPTION
Downgrade `net.bytebuddy.byte-buddy` to 1.5.11 to be compatible with current android build instrumentation.

Should fix issues:

#1406 
#1408 

But it is still compatible with Java 24 (https://github.com/mockk/mockk/pull/1387)