### PR TITLE
make captured value reference volatile

### DIFF
--- a/modules/mockk-dsl/src/commonMain/kotlin/io/mockk/API.kt
+++ b/modules/mockk-dsl/src/commonMain/kotlin/io/mockk/API.kt
@@ -2753,6 +2753,7 @@ class CapturingSlot<T : Any?> {
      * Hold captured value - [CapturedValue.NotYetCaptured] after initialization.
      * Once value is captured, then changes into [CapturedValue.Value]
      */
+    @Volatile
     private var capturedValue: CapturedValue<T> = CapturedValue.NotYetCaptured.singleton()
 
     /**


### PR DESCRIPTION
I'm getting `Value not yet captured.` at random. It's after the mock is verified, so it has been called for sure.