### PR TITLE
add fail-fast guard for Kotlin inline function mocking (#1030)

### DIFF
--- a/modules/mockk/src/commonMain/kotlin/io/mockk/impl/recording/SignatureMatcherDetector.kt
+++ b/modules/mockk/src/commonMain/kotlin/io/mockk/impl/recording/SignatureMatcherDetector.kt
@@ -94,7 +94,19 @@ class SignatureMatcherDetector(
 
         processCompositeMatchers()
         if (matcherMap.isNotEmpty()) {
-            throw MockKException("Failed matching mocking signature for\n${callRounds[0].calls.joinToString("\n")}\nleft matchers: ${matcherMap.values}")
+            val base =
+                "Failed matching mocking signature for\n${callRounds[0].calls.joinToString("\n")}\nleft matchers: ${matcherMap.values}"
+
+            // If there are matchers but no recorded calls (= likely an inline mocking attempt), add a hint
+            val inlineHint =
+                if (nMatchers > 0 && nCalls == 0)
+                    "\nNote: if you tried to stub a Kotlin inline function, it cannot be mocked. " +
+                            "Inline functions are inlined at call sites, so no call is recorded. " +
+                            "Extract a non-inline wrapper or mock the dependencies used inside the inline function."
+                else
+                    ""
+
+            throw MockKException(base + inlineHint)
         }
     }
 }

--- a/modules/mockk/src/commonMain/kotlin/io/mockk/impl/recording/states/StubbingState.kt
+++ b/modules/mockk/src/commonMain/kotlin/io/mockk/impl/recording/states/StubbingState.kt
@@ -11,7 +11,15 @@ class StubbingState(recorder: CommonCallRecorder) : RecordingState(recorder) {
 
     private fun checkMissingCalls() {
         if (recorder.calls.isEmpty()) {
-            throw MockKException("Missing mocked calls inside every { ... } block: make sure the object inside the block is a mock")
+            throw MockKException(
+                "Missing mocked calls inside every { ... } block: make sure the object inside the block is a mock " + inlineHint()
+            )
         }
     }
+
+    private fun inlineHint(): String =
+        ("\n" +
+                "Note: if you tried to stub a Kotlin inline function, it cannot be mocked. " +
+                "Inline functions are inlined at call sites, so no call is recorded. " +
+                "Extract a non-inline wrapper or mock the dependencies used inside the inline function.")
 }

--- a/modules/mockk/src/commonMain/kotlin/io/mockk/impl/recording/states/StubbingState.kt
+++ b/modules/mockk/src/commonMain/kotlin/io/mockk/impl/recording/states/StubbingState.kt
@@ -12,14 +12,12 @@ class StubbingState(recorder: CommonCallRecorder) : RecordingState(recorder) {
     private fun checkMissingCalls() {
         if (recorder.calls.isEmpty()) {
             throw MockKException(
-                "Missing mocked calls inside every { ... } block: make sure the object inside the block is a mock " + inlineHint()
+                "Missing mocked calls inside every { ... } block: make sure the object inside the block is a mock " +
+                        "\nNote: if you tried to stub a Kotlin inline function, it cannot be mocked. " +
+                        "Inline functions are inlined at call sites, so no call is recorded. " +
+                        "Extract a non-inline wrapper or mock the dependencies used inside the inline function."
+
             )
         }
     }
-
-    private fun inlineHint(): String =
-        ("\n" +
-                "Note: if you tried to stub a Kotlin inline function, it cannot be mocked. " +
-                "Inline functions are inlined at call sites, so no call is recorded. " +
-                "Extract a non-inline wrapper or mock the dependencies used inside the inline function.")
 }

--- a/modules/mockk/src/jvmMain/kotlin/io/mockk/impl/instantiation/JvmMockFactoryHelper.kt
+++ b/modules/mockk/src/jvmMain/kotlin/io/mockk/impl/instantiation/JvmMockFactoryHelper.kt
@@ -12,6 +12,7 @@ import java.util.concurrent.Callable
 import kotlin.coroutines.Continuation
 import kotlin.reflect.*
 import kotlin.reflect.full.memberProperties
+import kotlin.reflect.jvm.internal.KotlinReflectionInternalError
 import kotlin.reflect.jvm.javaField
 import kotlin.reflect.jvm.javaMethod
 import kotlin.reflect.jvm.kotlinFunction
@@ -107,8 +108,10 @@ object JvmMockFactoryHelper {
         try {
             val kotlinFunction = this.kotlinFunction
             if (kotlinFunction != null && kotlinFunction.isInline) return true
-        } catch (_: Throwable) {
-            null
+        } catch (_: KotlinReflectionInternalError) {
+            null // fall back to annotation check
+        } catch (_: UnsupportedOperationException) {
+            null // fall back to annotation check
         }
 
         return this.declaredAnnotations.any { ann ->

--- a/modules/mockk/src/jvmTest/kotlin/io/mockk/it/InlineMemberFunctionFailFastTest.kt
+++ b/modules/mockk/src/jvmTest/kotlin/io/mockk/it/InlineMemberFunctionFailFastTest.kt
@@ -1,0 +1,58 @@
+package io.mockk.it
+
+import io.mockk.MockKException
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.spyk
+import java.lang.reflect.InvocationTargetException
+import java.lang.reflect.Method
+import kotlin.reflect.KFunction
+import kotlin.test.Test
+import kotlin.test.assertContains
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+private class HasInline {
+    inline fun addOne(x: Int) = x + 1
+}
+
+private class HasWrapper {
+    private val impl = HasInline()
+    fun addOne(x: Int) = impl.addOne(x) // non-inline wrapper
+}
+
+class InlineMemberFunctionFailFastTest {
+
+    @Test
+    fun stubOfNonInlineWrapperReturnsConfiguredValue() {
+        val w = mockk<HasWrapper>()
+        every { w.addOne(10) } returns 42
+        assertEquals(42, w.addOne(10))
+    }
+
+    @Test
+    fun stubOfInlineFunctionFromKotlinThrowsDescriptiveError() {
+        val inlineMock = mockk<HasInline>()
+        val ex = assertFailsWith<MockKException> {
+            every { inlineMock.addOne(any()) } returns 42
+        }
+        assertContains(ex.message!!, "Kotlin inline function")
+    }
+
+    @Test
+    fun stubOfInlineFunctionViaReflectionThrowsFailFastError() {
+        val m = mockk<HasInline>()
+        val method = HasInline::class.java.getDeclaredMethod("addOne", Int::class.javaPrimitiveType)
+
+        val ex = assertFailsWith<InvocationTargetException> {
+            method.isAccessible = true
+            method.invoke(m, 10)
+        }
+        val cause = (ex.targetException ?: ex.cause) as? MockKException
+            ?: error("Unexpected cause: ${ex.targetException?.javaClass ?: ex.cause?.javaClass}")
+
+        val msg = cause.message ?: ""
+        assertContains(msg, "Mocking Kotlin inline functions is not supported")
+    }
+
+}


### PR DESCRIPTION
Fixes #1030 : "Throwing a descriptive error upon encountering inline function"

Kotlin `inline` functions are inlined at the call site, meaning their actual method calls disappear at runtime.
As a result, proxy-based mocking is fundamentally impossible.

Previously, attempts to mock inline functions would fail with vague messages like:
`"Failed matching mocking signature..."` or `"Missing mocked calls..."`, making it difficult to debug.

This change classifies such failures into two clear categories and provides more actionable feedback:

1. Interceptable environment (proxy created)
     - Detects inline functions in JvmMockFactoryHelper and immediately throws a MockKException
     - Message: Mocking Kotlin inline functions is not supported
2. Non-interceptable environment (no proxy created)
    - When no calls are recorded, the DSL layer now includes a hint about possible inline function usage
