### PR TITLE
refactor: enhance confirmVerified function to include clear option

### DIFF
--- a/modules/mockk-dsl/api/mockk-dsl.api
+++ b/modules/mockk-dsl/api/mockk-dsl.api
@@ -601,7 +601,7 @@ public final class io/mockk/MockKDsl {
 	public static synthetic fun internalCoVerifyOrder$default (Lio/mockk/MockKDsl;ZLkotlin/jvm/functions/Function2;ILjava/lang/Object;)V
 	public final fun internalCoVerifySequence (ZLkotlin/jvm/functions/Function2;)V
 	public static synthetic fun internalCoVerifySequence$default (Lio/mockk/MockKDsl;ZLkotlin/jvm/functions/Function2;ILjava/lang/Object;)V
-	public final fun internalConfirmVerified ([Ljava/lang/Object;)V
+	public final fun internalConfirmVerified ([Ljava/lang/Object;Z)V
 	public final fun internalEvery (Lkotlin/jvm/functions/Function1;)Lio/mockk/MockKStubScope;
 	public final fun internalExcludeRecords (ZLkotlin/jvm/functions/Function1;)V
 	public static synthetic fun internalExcludeRecords$default (Lio/mockk/MockKDsl;ZLkotlin/jvm/functions/Function1;ILjava/lang/Object;)V

--- a/modules/mockk-dsl/src/commonMain/kotlin/io/mockk/API.kt
+++ b/modules/mockk-dsl/src/commonMain/kotlin/io/mockk/API.kt
@@ -269,7 +269,7 @@ object MockKDsl {
     /**
      * Checks if all recorded calls were verified.
      */
-    fun internalConfirmVerified(mocks: Array<out Any>) {
+    fun internalConfirmVerified(mocks: Array<out Any>, clear: Boolean) {
         val verifier = MockKGateway.implementation().verificationAcknowledger
 
         if (mocks.isEmpty()) {
@@ -283,10 +283,12 @@ object MockKDsl {
             }
         }
 
-        resetVerificationState()
+        if (clear) {
+            resetVerificationState(mocks)
+        }
     }
 
-    private fun resetVerificationState() {
+    private fun resetVerificationState(mocks: Array<out Any>) {
         val options = ClearOptions(
             answers = false,
             recordedCalls = true,
@@ -295,7 +297,7 @@ object MockKDsl {
             exclusionRules = false
         )
 
-        MockKGateway.implementation().clearer.clearAll(options, currentThreadOnly = true)
+        MockKGateway.implementation().clearer.clear(mocks, options)
     }
 
     /**

--- a/modules/mockk/api/mockk.api
+++ b/modules/mockk/api/mockk.api
@@ -45,7 +45,8 @@ public final class io/mockk/MockKKt {
 	public static synthetic fun coVerifyOrder$default (ZLkotlin/jvm/functions/Function2;ILjava/lang/Object;)V
 	public static final fun coVerifySequence (ZLkotlin/jvm/functions/Function2;)V
 	public static synthetic fun coVerifySequence$default (ZLkotlin/jvm/functions/Function2;ILjava/lang/Object;)V
-	public static final fun confirmVerified ([Ljava/lang/Object;)V
+	public static final fun confirmVerified ([Ljava/lang/Object;Z)V
+	public static synthetic fun confirmVerified$default ([Ljava/lang/Object;ZILjava/lang/Object;)V
 	public static final fun every (Lkotlin/jvm/functions/Function1;)Lio/mockk/MockKStubScope;
 	public static final fun excludeRecords (ZLkotlin/jvm/functions/Function1;)V
 	public static synthetic fun excludeRecords$default (ZLkotlin/jvm/functions/Function1;ILjava/lang/Object;)V

--- a/modules/mockk/src/commonMain/kotlin/io/mockk/MockK.kt
+++ b/modules/mockk/src/commonMain/kotlin/io/mockk/MockK.kt
@@ -430,8 +430,8 @@ fun coExcludeRecords(
 /**
  * Checks if all recorded calls were verified.
  */
-fun confirmVerified(vararg mocks: Any) = MockK.useImpl {
-    MockKDsl.internalConfirmVerified(mocks)
+fun confirmVerified(vararg mocks: Any, clear: Boolean = false) = MockK.useImpl {
+    MockKDsl.internalConfirmVerified(mocks, clear = clear)
 }
 
 /**

--- a/modules/mockk/src/commonTest/kotlin/io/mockk/it/ClearMocksTest.kt
+++ b/modules/mockk/src/commonTest/kotlin/io/mockk/it/ClearMocksTest.kt
@@ -26,7 +26,7 @@ class ClearMocksTest {
 
         clearMocks(spyObj, answers = true, recordedCalls = false, childMocks = false, verificationMarks = false)
 
-        confirmVerified(spyObj)
+        confirmVerified(spyObj, clear = true)
         assertEquals(2, spyObj.op(1))
         verify(exactly = 1) { spyObj.op(1) }
     }
@@ -40,7 +40,7 @@ class ClearMocksTest {
 
         clearMocks(mockObj, answers = true, recordedCalls = false, childMocks = false, verificationMarks = false)
 
-        confirmVerified(child)
+        confirmVerified(child, clear = true)
         assertEquals(3, child.op(1))
         verify(exactly = 1) { child.op(1) }
         assertSame(child, mockObj.child())
@@ -68,7 +68,7 @@ class ClearMocksTest {
 
         clearMocks(mockObj, answers = false, recordedCalls = true, childMocks = false, verificationMarks = false)
 
-        confirmVerified(child)
+        confirmVerified(child, clear = true)
         assertEquals(3, child.op(1))
         verify(exactly = 1) { child.op(1) }
         assertSame(child, mockObj.child())
@@ -121,7 +121,7 @@ class ClearMocksTest {
 
         clearMocks(mockObj, answers = false, recordedCalls = false, childMocks = false, verificationMarks = true)
 
-        confirmVerified(child)
+        confirmVerified(child, clear = true)
         assertEquals(3, child.op(1))
         verify(exactly = 1) { child.op(1) }
         assertSame(child, mockObj.child())

--- a/modules/mockk/src/jvmTest/kotlin/io/mockk/it/VerificationAcknowledgeTest.kt
+++ b/modules/mockk/src/jvmTest/kotlin/io/mockk/it/VerificationAcknowledgeTest.kt
@@ -644,5 +644,22 @@ class VerificationAcknowledgeTest {
 
         confirmVerified(Instant::class)
     }
-}
 
+    @Test
+    fun confirmVerifiedSpecificMock() {
+        val mockA = mockk<MockCls>()
+        val mockB = mockk<MockCls>()
+
+        every { mockA.op(1) } returns 1
+        every { mockB.op(2) } returns 2
+
+        mockA.op(1)
+        mockB.op(2)
+
+        verify { mockA.op(1) }
+        confirmVerified(mockA)
+
+        verify { mockB.op(2) }
+        confirmVerified(mockB)
+    }
+}


### PR DESCRIPTION
Updated `resetVerificationState` to clear only the mocks passed in.
Updated `confirmVerified` to accept a `clear` parameter, allowing users to specify whether to clear verification state.
Adjusted related tests and API definitions to support this change.

closes #1379 