### PR TITLE
fix: normalize value class arguments in EqMatcher for consistent comparison

### DIFF
--- a/modules/mockk-dsl/src/commonMain/kotlin/io/mockk/Matchers.kt
+++ b/modules/mockk-dsl/src/commonMain/kotlin/io/mockk/Matchers.kt
@@ -2,6 +2,7 @@ package io.mockk
 
 import io.mockk.InternalPlatformDsl.toArray
 import io.mockk.InternalPlatformDsl.toStr
+import io.mockk.core.ValueClassSupport.boxedValue
 import kotlin.math.min
 import kotlin.reflect.KClass
 
@@ -10,16 +11,16 @@ import kotlin.reflect.KClass
  */
 data class EqMatcher<in T : Any>(private val valueArg: T, val ref: Boolean = false, val inverse: Boolean = false) :
     Matcher<T> {
-    val value = InternalPlatformDsl.unboxChar(valueArg)
+    val value = InternalPlatformDsl.unboxChar(valueArg).boxedValue
 
     override fun match(arg: T?): Boolean {
         val result = if (ref) {
-            arg === value
+            arg?.boxedValue === value
         } else {
             if (arg == null) {
                 false
             } else {
-                val unboxedArg = InternalPlatformDsl.unboxChar(arg)
+                val unboxedArg = InternalPlatformDsl.unboxChar(arg).boxedValue
                 InternalPlatformDsl.deepEquals(unboxedArg, value)
             }
         }

--- a/modules/mockk/src/commonTest/kotlin/io/mockk/it/ValueClassTest.kt
+++ b/modules/mockk/src/commonTest/kotlin/io/mockk/it/ValueClassTest.kt
@@ -65,6 +65,28 @@ class ValueClassTest {
     }
 
     @Test
+    fun `arg is eq(ValueClass), returns ValueClass`() {
+        val mock = mockk<DummyService> {
+            every { argValueClassReturnValueClass(eq(dummyValueClassArg)) } returns dummyValueClassReturn
+        }
+
+        assertEquals(dummyValueClassReturn, mock.argValueClassReturnValueClass(dummyValueClassArg))
+
+        verify { mock.argValueClassReturnValueClass(dummyValueClassArg) }
+    }
+
+    @Test
+    fun `arg is refEq(ValueClass), returns ValueClass`() {
+        val mock = mockk<DummyService> {
+            every { argValueClassReturnValueClass(refEq(dummyValueClassArg)) } returns dummyValueClassReturn
+        }
+
+        assertEquals(dummyValueClassReturn, mock.argValueClassReturnValueClass(dummyValueClassArg))
+
+        verify { mock.argValueClassReturnValueClass(dummyValueClassArg) }
+    }
+
+    @Test
     fun `arg is slot(ValueClass), returns ValueClass`() {
         val slot = slot<DummyValue>()
         val mock = mockk<DummyService> {


### PR DESCRIPTION
The `eq()` (and  `refEq()`) matcher fails when comparing value classes, resulting in "no answer found" errors when MockK cannot match configured answers to actual method calls.

**Symptom:**
``` 
MockKException: no answer found for DummyService(#18).argValueClassReturnValueClass-fKa6D0c(101) 
among the configured answers: (DummyService(#18).argValueClassReturnValueClass-fKa6D0c(refEq(DummyValue(value=101))))
```

**Root Cause:**
- **Expected value** (passed to `eq()`): Created at test time as a value class wrapper, stored in the matcher before JVM erasure occurs
- **Actual value** (method argument): Already erased to its underlying type by the JVM when it reaches the matcher

This creates a type mismatch where we're comparing:
- Expected: `DummyValue` wrapper containing `101`
- Actual: Raw `Int` value `101`

The comparison fails because `deepEquals(101, DummyValue(101))` returns `false`.

**Solution:**

Extract the boxed (underlying) value from the expected value class when creating the `EqMatcher`, ensuring both sides of the comparison use the same representation.

**Changes:**
- Modified `EqMatcher`  to call `.boxedValue` on both the actual arg and comarpsion value
- This normalizes the expected value to its underlying representation, matching what the JVM provides for the actual argument

Without this fix, the newly added tests in `ValueClassTest.kt` fail with "no answer found" errors.

I'm not 100% certain this is the optimal location for this fix. The fix works but I'd appreciate input on whether this normalization should happen elsewhere in the matching pipeline or if there's a more appropriate architectural approach for handling value class comparisons.

The fix is backward compatible since `boxedValue` returns the original object unchanged when called on non-value classes.