### PR TITLE
docs(readme): document suppressing superclass calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -1241,6 +1241,7 @@ To suppress a method call, especially a `super` call inside an overridden method
 Using `every { ... } just runs` replaces the entire method body, preventing the original code from executing.
 
 This is particularly useful for users coming from frameworks like PowerMockito or for testing classes like Android Activities.
+For reference, see [PowerMockito suppress documentation](https://github.com/powermock/powermock/wiki/Suppress-Unwanted-Behavior).
 
 ```kotlin
 // A simple inheritance hierarchy
@@ -1269,7 +1270,7 @@ child.doWork()
 assertFalse(child.superCalled)
 ```
 
-This approach allows you to isolate the logic within your method for unit testing without executing unwanted parent class behavior
+This approach allows you to isolate the logic within your method for unit testing without executing unwanted parent class behavior.
 
 ## Matcher extensibility
 


### PR DESCRIPTION
### Summary

Added a short guide to the **Features** section of the README explaining  
how to suppress superclass method calls using existing MockK features (`spyk` + `every { ... } just runs`).

This provides a simple, built-in alternative to PowerMockito’s `suppress` functionality,  
showing how to isolate subclass logic during testing without executing unwanted parent behavior.

---

### Motivation

Users migrating from PowerMockito or testing complex class hierarchies (such as framework base classes)  
often look for a way to “suppress” `super` method calls.  
MockK already supports this pattern, but it was not explicitly documented.

Adding this example improves discoverability and helps users understand how to achieve  
the same behavior using `spyk` and explicit stubbing.

---

### Changes

- Updated `README.md`  
  - Added a new subsection **“Suppressing superclass calls”** under **Features**
  - Included an example using a simple `Parent` / `Child` class hierarchy  
    demonstrating suppression via `every { ... } just runs`
  - Added a short explanation for users coming from PowerMockito

---

### Notes

- Documentation-only change — no code modifications.
- Based on discussion in #818