### PR TITLE
Add optional restricted mock system property

### DIFF
--- a/README.md
+++ b/README.md
@@ -1653,6 +1653,51 @@ To strictly prevent mocking restricted classes, explicitly set:
 mockk.throwExceptionOnBadMock=true
 ```
 
+### Configure Restricted Mocking with System Properties
+
+You can also configure
+
+```
+mockk.throwExceptionOnBadMock=true
+```
+
+Example with system properties in your build.gradle.kts file:
+
+```
+tasks.withType<Test> {
+    systemProperty("mockk.throwExceptionOnBadMock", "true")
+}
+```
+You can also do a variable system property and pass the value
+via the terminal like so:
+
+```
+tasks.withType<Test> {
+    systemProperty("mockk.throwExceptionOnBadMock", System.getProperty("mockk.throwExceptionOnBadMock"))
+}
+```
+Then:
+```
+./gradlew -Dmockk.throwExceptionOnBadMock=true :modules:name:test
+```
+
+### Configure Restricted Mocking with Gradle Properties
+
+You can add the property to your `gradle.properties` file:
+```properties
+systemProp.mockk.throwExceptionOnBadMock=true
+```
+Then in your terminal:
+
+```
+./gradlew -Pmockk.throwExceptionOnBadMock=true :modules:name:test
+```
+
+⚠️ **Note:**
+
+The `mockk.throwExceptionOnBadMock` that is set in `gradle.properties` or
+in your `build.gradle` will override the value that is set in `mockk.properties` file.
+
 ### Behavior When Mocking Restricted Classes
 
 #### When `mockk.throwExceptionOnBadMock=false` (Default)

--- a/modules/mockk/src/commonMain/kotlin/io/mockk/impl/restrict/RestrictMockkConfiguration.kt
+++ b/modules/mockk/src/commonMain/kotlin/io/mockk/impl/restrict/RestrictMockkConfiguration.kt
@@ -14,8 +14,10 @@ class RestrictMockkConfiguration(propertiesLoader: PropertiesLoader = DefaultPro
         userDefinedRestrictedTypes = loadRestrictedTypesFromConfig(properties)
 
         restrictedTypes = DEFAULT_RESTRICTED_CLAZZ + userDefinedRestrictedTypes
-        throwExceptionOnBadMock = loadThrowExceptionSetting(properties) ||
-            loadThrowExceptionSystemProperty()
+
+        // System Property takes precedence.
+        throwExceptionOnBadMock = loadThrowExceptionSystemProperty() ?:
+            loadThrowExceptionSetting(properties)
     }
 
     companion object {
@@ -36,8 +38,13 @@ class RestrictMockkConfiguration(propertiesLoader: PropertiesLoader = DefaultPro
                 .toSet()
         }
 
-        private fun loadThrowExceptionSystemProperty() =
-            System.getProperty(RESTRICTED_MOCK_PROP_KEY, "false").toBoolean()
+        private fun loadThrowExceptionSystemProperty(): Boolean? {
+            val throwExceptionSystemProperty = System.getProperty(RESTRICTED_MOCK_PROP_KEY)
+            if (throwExceptionSystemProperty.isNullOrEmpty()) {
+                return null
+            }
+            return throwExceptionSystemProperty.toBoolean()
+        }
 
         private fun loadThrowExceptionSetting(properties: Properties): Boolean {
             return properties.getProperty(RESTRICTED_MOCK_PROP_KEY, "false").toBoolean()

--- a/modules/mockk/src/commonTest/kotlin/io/mockk/restrict/RestrictMockkTest.kt
+++ b/modules/mockk/src/commonTest/kotlin/io/mockk/restrict/RestrictMockkTest.kt
@@ -167,7 +167,7 @@ class RestrictMockkTest {
             mockk<File>(mockValidator = validator)
         }
 
-        System.setProperty("mockk.throwExceptionOnBadMock", "false")
+        System.clearProperty("mockk.throwExceptionOnBadMock")
     }
 
     @Test
@@ -181,6 +181,8 @@ class RestrictMockkTest {
         assertDoesNotThrow {
             mockk<File>(mockValidator = validator)
         }
+
+        System.clearProperty("mockk.throwExceptionOnBadMock")
     }
 
     @Test
@@ -196,7 +198,7 @@ class RestrictMockkTest {
             mockk<Path>(mockValidator = validator)
         }
 
-        System.setProperty("mockk.throwExceptionOnBadMock", "false")
+        System.clearProperty("mockk.throwExceptionOnBadMock")
     }
 
     @Test
@@ -215,7 +217,67 @@ class RestrictMockkTest {
             mockk<Foo>(mockValidator = validator)
         }
 
+        System.clearProperty("mockk.throwExceptionOnBadMock")
+    }
+
+    @Test
+    fun `when system property true, it should override properties file`() {
+        val config = mapOf(
+            "mockk.throwExceptionOnBadMock" to "false",
+            "mockk.restrictedClasses" to "io.mockk.restrict.Foo"
+        )
+
+        System.setProperty("mockk.throwExceptionOnBadMock", "true")
+
+        val validator = MockkValidator(
+            RestrictMockkConfiguration(TestPropertiesLoader(config))
+        )
+
+        assertThrows<MockKException> {
+            mockk<Foo>(mockValidator = validator)
+        }
+
+        System.clearProperty("mockk.throwExceptionOnBadMock")
+    }
+
+    @Test
+    fun `when system property false, it should override properties file`() {
+        val config = mapOf(
+            "mockk.throwExceptionOnBadMock" to "true",
+            "mockk.restrictedClasses" to "io.mockk.restrict.Foo"
+        )
+
         System.setProperty("mockk.throwExceptionOnBadMock", "false")
+
+        val validator = MockkValidator(
+            RestrictMockkConfiguration(TestPropertiesLoader(config))
+        )
+
+        assertDoesNotThrow {
+            mockk<Foo>(mockValidator = validator)
+        }
+
+        System.clearProperty("mockk.throwExceptionOnBadMock")
+    }
+
+    @Test
+    fun `when system property is empty, it should not override properties file`() {
+        val config = mapOf(
+            "mockk.throwExceptionOnBadMock" to "true",
+            "mockk.restrictedClasses" to "io.mockk.restrict.Foo"
+        )
+
+        System.setProperty("mockk.throwExceptionOnBadMock", "")
+
+        val validator = MockkValidator(
+            RestrictMockkConfiguration(TestPropertiesLoader(config))
+        )
+
+        assertThrows<MockKException> {
+            mockk<Foo>(mockValidator = validator)
+        }
+
+        System.clearProperty("mockk.throwExceptionOnBadMock")
     }
 }
 


### PR DESCRIPTION
## Overview

Hello! 

Currently, we can enable restricted mocking via `mockk.properties` file. One thing that would be really helpful for large projects with multi-modules is the ability to have restricted mocking per class or even per gradle command via terminal. This would make it easier to tackle modules one-by-one, for example:

`./gradlew -Pmockk.throwExceptionOnBadMock=true feature:your-module:test`

I've added a couple of tests to demonstrate this works with current config as well.

@Raibaz, what are your thoughts on this?