### PR TITLE
Update slicer from AOSP tools/dexter

### DIFF
--- a/modules/mockk-agent-android/external/slicer/bytecode_encoder.cc
+++ b/modules/mockk-agent-android/external/slicer/bytecode_encoder.cc
@@ -15,86 +15,89 @@
  */
 
 #include "slicer/bytecode_encoder.h"
+
 #include "slicer/common.h"
 #include "slicer/chronometer.h"
 
 #include <assert.h>
+#include <sstream>
+#include <iomanip>
 
 namespace lir {
 
 // Pack a 16bit word: 00AA
 static dex::u2 Pack_Z_8(dex::u4 a) {
   dex::u2 fa = (a & 0xff);
-  SLICER_CHECK(fa == a);
+  SLICER_CHECK_EQ(fa, a);
   return fa;
 }
 
 // Pack a 16bit word: AABB
 static dex::u2 Pack_8_8(dex::u4 a, dex::u4 b) {
   dex::u2 fa = (a & 0xff);
-  SLICER_CHECK(fa == a);
+  SLICER_CHECK_EQ(fa, a);
   dex::u2 fb = (b & 0xff);
-  SLICER_CHECK(fb == b);
+  SLICER_CHECK_EQ(fb, b);
   return (fa << 8) | fb;
 }
 
 // Pack a 16bit word: ABCC
 static dex::u2 Pack_4_4_8(dex::u4 a, dex::u4 b, dex::u4 c) {
   dex::u2 fa = (a & 0xf);
-  SLICER_CHECK(fa == a);
+  SLICER_CHECK_EQ(fa, a);
   dex::u2 fb = (b & 0xf);
-  SLICER_CHECK(fb == b);
+  SLICER_CHECK_EQ(fb, b);
   dex::u2 fc = (c & 0xff);
-  SLICER_CHECK(fc == c);
+  SLICER_CHECK_EQ(fc, c);
   return (fa << 12) | (fb << 8) | fc;
 }
 
 // Pack a 16bit word: ABCD
 static dex::u2 Pack_4_4_4_4(dex::u4 a, dex::u4 b, dex::u4 c, dex::u4 d) {
   dex::u2 fa = (a & 0xf);
-  SLICER_CHECK(fa == a);
+  SLICER_CHECK_EQ(fa, a);
   dex::u2 fb = (b & 0xf);
-  SLICER_CHECK(fb == b);
+  SLICER_CHECK_EQ(fb, b);
   dex::u2 fc = (c & 0xf);
-  SLICER_CHECK(fc == c);
+  SLICER_CHECK_EQ(fc, c);
   dex::u2 fd = (d & 0xf);
-  SLICER_CHECK(fd == d);
+  SLICER_CHECK_EQ(fd, d);
   return (fa << 12) | (fb << 8) | (fc << 4) | fd;
 }
 
 // Pack a 16bit word: AAAA
 static dex::u2 Pack_16(dex::u4 a) {
   dex::u2 fa = (a & 0xffff);
-  SLICER_CHECK(fa == a);
+  SLICER_CHECK_EQ(fa, a);
   return fa;
 }
 
 // Trim a 4bit signed integer, making sure we're not discarding significant bits
 static dex::u4 Trim_S0(dex::u4 value) {
   dex::u4 trim = value & 0xf;
-  SLICER_CHECK(dex::u4(dex::s4(trim << 28) >> 28) == value);
+  SLICER_CHECK_EQ(dex::u4(dex::s4(trim << 28) >> 28), value);
   return trim;
 }
 
 // Trim a 8bit signed integer, making sure we're not discarding significant bits
 static dex::u4 Trim_S1(dex::u4 value) {
   dex::u4 trim = value & 0xff;
-  SLICER_CHECK(dex::u4(dex::s4(trim << 24) >> 24) == value);
+  SLICER_CHECK_EQ(dex::u4(dex::s4(trim << 24) >> 24), value);
   return trim;
 }
 
 // Trim a 16bit signed integer, making sure we're not discarding significant bits
 static dex::u4 Trim_S2(dex::u4 value) {
   dex::u4 trim = value & 0xffff;
-  SLICER_CHECK(dex::u4(dex::s4(trim << 16) >> 16) == value);
+  SLICER_CHECK_EQ(dex::u4(dex::s4(trim << 16) >> 16), value);
   return trim;
 }
 
 // Returns a register operand, checking the match between format and type
 // (register fields can encode either a single 32bit vreg or a wide 64bit vreg pair)
 static dex::u4 GetRegA(const Bytecode* bytecode, int index) {
-  auto flags = dex::GetFlagsFromOpcode(bytecode->opcode);
-  return (flags & dex::kInstrWideRegA) != 0
+  auto verify_flags = dex::GetVerifyFlagsFromOpcode(bytecode->opcode);
+  return (verify_flags & dex::kVerifyRegAWide) != 0
              ? bytecode->CastOperand<VRegPair>(index)->base_reg
              : bytecode->CastOperand<VReg>(index)->reg;
 }
@@ -102,8 +105,8 @@ static dex::u4 GetRegA(const Bytecode* bytecode, int index) {
 // Returns a register operand, checking the match between format and type
 // (register fields can encode either a single 32bit vreg or a wide 64bit vreg pair)
 static dex::u4 GetRegB(const Bytecode* bytecode, int index) {
-  auto flags = dex::GetFlagsFromOpcode(bytecode->opcode);
-  return (flags & dex::kInstrWideRegB) != 0
+  auto verify_flags = dex::GetVerifyFlagsFromOpcode(bytecode->opcode);
+  return (verify_flags & dex::kVerifyRegBWide) != 0
              ? bytecode->CastOperand<VRegPair>(index)->base_reg
              : bytecode->CastOperand<VReg>(index)->reg;
 }
@@ -111,8 +114,8 @@ static dex::u4 GetRegB(const Bytecode* bytecode, int index) {
 // Returns a register operand, checking the match between format and type
 // (register fields can encode either a single 32bit vreg or a wide 64bit vreg pair)
 static dex::u4 GetRegC(const Bytecode* bytecode, int index) {
-  auto flags = dex::GetFlagsFromOpcode(bytecode->opcode);
-  return (flags & dex::kInstrWideRegC) != 0
+  auto verify_flags = dex::GetVerifyFlagsFromOpcode(bytecode->opcode);
+  return (verify_flags & dex::kVerifyRegCWide) != 0
              ? bytecode->CastOperand<VRegPair>(index)->base_reg
              : bytecode->CastOperand<VReg>(index)->reg;
 }
@@ -137,32 +140,32 @@ bool BytecodeEncoder::Visit(Bytecode* bytecode) {
   auto format = dex::GetFormatFromOpcode(opcode);
 
   switch (format) {
-    case dex::kFmt10x:  // op
+    case dex::k10x:  // op
     {
-      SLICER_CHECK(bytecode->operands.size() == 0);
+      SLICER_CHECK_EQ(bytecode->operands.size(), 0);
       bytecode_.Push<dex::u2>(Pack_Z_8(opcode));
     } break;
 
-    case dex::kFmt12x:  // op vA, vB
+    case dex::k12x:  // op vA, vB
     {
-      SLICER_CHECK(bytecode->operands.size() == 2);
+      SLICER_CHECK_EQ(bytecode->operands.size(), 2);
       dex::u4 vA = GetRegA(bytecode, 0);
       dex::u4 vB = GetRegB(bytecode, 1);
       bytecode_.Push<dex::u2>(Pack_4_4_8(vB, vA, opcode));
     } break;
 
-    case dex::kFmt22x:  // op vAA, vBBBB
+    case dex::k22x:  // op vAA, vBBBB
     {
-      SLICER_CHECK(bytecode->operands.size() == 2);
+      SLICER_CHECK_EQ(bytecode->operands.size(), 2);
       dex::u4 vA = GetRegA(bytecode, 0);
       dex::u4 vB = GetRegB(bytecode, 1);
       bytecode_.Push<dex::u2>(Pack_8_8(vA, opcode));
       bytecode_.Push<dex::u2>(Pack_16(vB));
     } break;
 
-    case dex::kFmt32x:  // op vAAAA, vBBBB
+    case dex::k32x:  // op vAAAA, vBBBB
     {
-      SLICER_CHECK(bytecode->operands.size() == 2);
+      SLICER_CHECK_EQ(bytecode->operands.size(), 2);
       dex::u4 vA = GetRegA(bytecode, 0);
       dex::u4 vB = GetRegB(bytecode, 1);
       bytecode_.Push<dex::u2>(Pack_Z_8(opcode));
@@ -170,33 +173,33 @@ bool BytecodeEncoder::Visit(Bytecode* bytecode) {
       bytecode_.Push<dex::u2>(Pack_16(vB));
     } break;
 
-    case dex::kFmt11n:  // op vA, #+B
+    case dex::k11n:  // op vA, #+B
     {
-      SLICER_CHECK(bytecode->operands.size() == 2);
+      SLICER_CHECK_EQ(bytecode->operands.size(), 2);
       dex::u4 vA = GetRegA(bytecode, 0);
       dex::u4 B = Trim_S0(bytecode->CastOperand<Const32>(1)->u.u4_value);
       bytecode_.Push<dex::u2>(Pack_4_4_8(B, vA, opcode));
     } break;
 
-    case dex::kFmt21s:  // op vAA, #+BBBB
+    case dex::k21s:  // op vAA, #+BBBB
     {
-      SLICER_CHECK(bytecode->operands.size() == 2);
+      SLICER_CHECK_EQ(bytecode->operands.size(), 2);
       dex::u4 vA = GetRegA(bytecode, 0);
       dex::u4 B = Trim_S2(bytecode->CastOperand<Const32>(1)->u.u4_value);
       bytecode_.Push<dex::u2>(Pack_8_8(vA, opcode));
       bytecode_.Push<dex::u2>(Pack_16(B));
     } break;
 
-    case dex::kFmt11x:  // op vAA
+    case dex::k11x:  // op vAA
     {
-      SLICER_CHECK(bytecode->operands.size() == 1);
+      SLICER_CHECK_EQ(bytecode->operands.size(), 1);
       dex::u4 vA = GetRegA(bytecode, 0);
       bytecode_.Push<dex::u2>(Pack_8_8(vA, opcode));
     } break;
 
-    case dex::kFmt31i:  // op vAA, #+BBBBBBBB
+    case dex::k31i:  // op vAA, #+BBBBBBBB
     {
-      SLICER_CHECK(bytecode->operands.size() == 2);
+      SLICER_CHECK_EQ(bytecode->operands.size(), 2);
       dex::u4 vA = GetRegA(bytecode, 0);
       dex::u4 B = bytecode->CastOperand<Const32>(1)->u.u4_value;
       bytecode_.Push<dex::u2>(Pack_8_8(vA, opcode));
@@ -204,16 +207,16 @@ bool BytecodeEncoder::Visit(Bytecode* bytecode) {
       bytecode_.Push<dex::u2>(Pack_16(B >> 16));
     } break;
 
-    case dex::kFmt20t:  // op +AAAA
+    case dex::k20t:  // op +AAAA
     {
-      SLICER_CHECK(bytecode->operands.size() == 1);
+      SLICER_CHECK_EQ(bytecode->operands.size(), 1);
       auto label = bytecode->CastOperand<CodeLocation>(0)->label;
       dex::u4 A = 0;
       if (label->offset != kInvalidOffset) {
         assert(label->offset <= offset_);
         A = label->offset - offset_;
-        SLICER_CHECK(A != 0);
-        SLICER_CHECK((A >> 16) == 0xffff);  // TODO: out of range!
+        SLICER_CHECK_NE(A, 0);
+        SLICER_CHECK_EQ((A >> 16), 0xffff);  // TODO: out of range!
       } else {
         fixups_.push_back(LabelFixup(offset_, label, true));
       }
@@ -221,9 +224,9 @@ bool BytecodeEncoder::Visit(Bytecode* bytecode) {
       bytecode_.Push<dex::u2>(Pack_16(A & 0xffff));
     } break;
 
-    case dex::kFmt30t:  // op +AAAAAAAA
+    case dex::k30t:  // op +AAAAAAAA
     {
-      SLICER_CHECK(bytecode->operands.size() == 1);
+      SLICER_CHECK_EQ(bytecode->operands.size(), 1);
       auto label = bytecode->CastOperand<CodeLocation>(0)->label;
       dex::u4 A = 0;
       if (label->offset != kInvalidOffset) {
@@ -238,17 +241,17 @@ bool BytecodeEncoder::Visit(Bytecode* bytecode) {
       bytecode_.Push<dex::u2>(Pack_16(A >> 16));
     } break;
 
-    case dex::kFmt21t:  // op vAA, +BBBB
+    case dex::k21t:  // op vAA, +BBBB
     {
-      SLICER_CHECK(bytecode->operands.size() == 2);
+      SLICER_CHECK_EQ(bytecode->operands.size(), 2);
       dex::u4 vA = GetRegA(bytecode, 0);
       auto label = bytecode->CastOperand<CodeLocation>(1)->label;
       dex::u4 B = 0;
       if (label->offset != kInvalidOffset) {
         assert(label->offset <= offset_);
         B = label->offset - offset_;
-        SLICER_CHECK(B != 0);
-        SLICER_CHECK((B >> 16) == 0xffff);  // TODO: out of range!
+        SLICER_CHECK_NE(B, 0);
+        SLICER_CHECK_EQ((B >> 16), 0xffff);  // TODO: out of range!
       } else {
         fixups_.push_back(LabelFixup(offset_, label, true));
       }
@@ -256,9 +259,9 @@ bool BytecodeEncoder::Visit(Bytecode* bytecode) {
       bytecode_.Push<dex::u2>(Pack_16(B & 0xffff));
     } break;
 
-    case dex::kFmt22t:  // op vA, vB, +CCCC
+    case dex::k22t:  // op vA, vB, +CCCC
     {
-      SLICER_CHECK(bytecode->operands.size() == 3);
+      SLICER_CHECK_EQ(bytecode->operands.size(), 3);
       dex::u4 vA = GetRegA(bytecode, 0);
       dex::u4 vB = GetRegB(bytecode, 1);
       auto label = bytecode->CastOperand<CodeLocation>(2)->label;
@@ -266,8 +269,8 @@ bool BytecodeEncoder::Visit(Bytecode* bytecode) {
       if (label->offset != kInvalidOffset) {
         assert(label->offset <= offset_);
         C = label->offset - offset_;
-        SLICER_CHECK(C != 0);
-        SLICER_CHECK((C >> 16) == 0xffff);  // TODO: out of range!
+        SLICER_CHECK_NE(C, 0);
+        SLICER_CHECK_EQ((C >> 16), 0xffff);  // TODO: out of range!
       } else {
         fixups_.push_back(LabelFixup(offset_, label, true));
       }
@@ -275,16 +278,16 @@ bool BytecodeEncoder::Visit(Bytecode* bytecode) {
       bytecode_.Push<dex::u2>(Pack_16(C & 0xffff));
     } break;
 
-    case dex::kFmt31t:  // op vAA, +BBBBBBBB
+    case dex::k31t:  // op vAA, +BBBBBBBB
     {
-      SLICER_CHECK(bytecode->operands.size() == 2);
+      SLICER_CHECK_EQ(bytecode->operands.size(), 2);
       dex::u4 vA = GetRegA(bytecode, 0);
       auto label = bytecode->CastOperand<CodeLocation>(1)->label;
       dex::u4 B = 0;
       if (label->offset != kInvalidOffset) {
         assert(label->offset <= offset_);
         B = label->offset - offset_;
-        SLICER_CHECK(B != 0);
+        SLICER_CHECK_NE(B, 0);
       } else {
         fixups_.push_back(LabelFixup(offset_, label, false));
       }
@@ -293,9 +296,9 @@ bool BytecodeEncoder::Visit(Bytecode* bytecode) {
       bytecode_.Push<dex::u2>(Pack_16(B >> 16));
     } break;
 
-    case dex::kFmt23x:  // op vAA, vBB, vCC
+    case dex::k23x:  // op vAA, vBB, vCC
     {
-      SLICER_CHECK(bytecode->operands.size() == 3);
+      SLICER_CHECK_EQ(bytecode->operands.size(), 3);
       dex::u4 vA = GetRegA(bytecode, 0);
       dex::u4 vB = GetRegB(bytecode, 1);
       dex::u4 vC = GetRegC(bytecode, 2);
@@ -303,9 +306,9 @@ bool BytecodeEncoder::Visit(Bytecode* bytecode) {
       bytecode_.Push<dex::u2>(Pack_8_8(vC, vB));
     } break;
 
-    case dex::kFmt22b:  // op vAA, vBB, #+CC
+    case dex::k22b:  // op vAA, vBB, #+CC
     {
-      SLICER_CHECK(bytecode->operands.size() == 3);
+      SLICER_CHECK_EQ(bytecode->operands.size(), 3);
       dex::u4 vA = GetRegA(bytecode, 0);
       dex::u4 vB = GetRegB(bytecode, 1);
       dex::u4 C = Trim_S1(bytecode->CastOperand<Const32>(2)->u.u4_value);
@@ -313,9 +316,9 @@ bool BytecodeEncoder::Visit(Bytecode* bytecode) {
       bytecode_.Push<dex::u2>(Pack_8_8(C, vB));
     } break;
 
-    case dex::kFmt22s:  // op vA, vB, #+CCCC
+    case dex::k22s:  // op vA, vB, #+CCCC
     {
-      SLICER_CHECK(bytecode->operands.size() == 3);
+      SLICER_CHECK_EQ(bytecode->operands.size(), 3);
       dex::u4 vA = GetRegA(bytecode, 0);
       dex::u4 vB = GetRegB(bytecode, 1);
       dex::u4 C = Trim_S2(bytecode->CastOperand<Const32>(2)->u.u4_value);
@@ -323,9 +326,9 @@ bool BytecodeEncoder::Visit(Bytecode* bytecode) {
       bytecode_.Push<dex::u2>(Pack_16(C));
     } break;
 
-    case dex::kFmt22c:  // op vA, vB, thing@CCCC
+    case dex::k22c:  // op vA, vB, thing@CCCC
     {
-      SLICER_CHECK(bytecode->operands.size() == 3);
+      SLICER_CHECK_EQ(bytecode->operands.size(), 3);
       dex::u4 vA = GetRegA(bytecode, 0);
       dex::u4 vB = GetRegB(bytecode, 1);
       dex::u4 C = bytecode->CastOperand<IndexedOperand>(2)->index;
@@ -333,18 +336,18 @@ bool BytecodeEncoder::Visit(Bytecode* bytecode) {
       bytecode_.Push<dex::u2>(Pack_16(C));
     } break;
 
-    case dex::kFmt21c:  // op vAA, thing@BBBB
+    case dex::k21c:  // op vAA, thing@BBBB
     {
-      SLICER_CHECK(bytecode->operands.size() == 2);
+      SLICER_CHECK_EQ(bytecode->operands.size(), 2);
       dex::u4 vA = GetRegA(bytecode, 0);
       dex::u4 B = bytecode->CastOperand<IndexedOperand>(1)->index;
       bytecode_.Push<dex::u2>(Pack_8_8(vA, opcode));
       bytecode_.Push<dex::u2>(Pack_16(B));
     } break;
 
-    case dex::kFmt31c:  // op vAA, string@BBBBBBBB
+    case dex::k31c:  // op vAA, string@BBBBBBBB
     {
-      SLICER_CHECK(bytecode->operands.size() == 2);
+      SLICER_CHECK_EQ(bytecode->operands.size(), 2);
       dex::u4 vA = GetRegA(bytecode, 0);
       dex::u4 B = bytecode->CastOperand<IndexedOperand>(1)->index;
       bytecode_.Push<dex::u2>(Pack_8_8(vA, opcode));
@@ -352,9 +355,9 @@ bool BytecodeEncoder::Visit(Bytecode* bytecode) {
       bytecode_.Push<dex::u2>(Pack_16(B >> 16));
     } break;
 
-    case dex::kFmt35c:  // op {vC,vD,vE,vF,vG}, thing@BBBB
+    case dex::k35c:  // op {vC,vD,vE,vF,vG}, thing@BBBB
     {
-      SLICER_CHECK(bytecode->operands.size() == 2);
+      SLICER_CHECK_EQ(bytecode->operands.size(), 2);
       const auto& regs = bytecode->CastOperand<VRegList>(0)->registers;
       dex::u4 B = bytecode->CastOperand<IndexedOperand>(1)->index;
       dex::u4 A = regs.size();
@@ -368,14 +371,14 @@ bool BytecodeEncoder::Visit(Bytecode* bytecode) {
       bytecode_.Push<dex::u2>(Pack_4_4_4_4(F, E, D, C));
 
       // keep track of the outs_count
-      if ((dex::GetFlagsFromOpcode(opcode) & dex::kInstrInvoke) != 0) {
+      if ((dex::GetFlagsFromOpcode(opcode) & dex::kInvoke) != 0) {
         outs_count_ = std::max(outs_count_, A);
       }
     } break;
 
-    case dex::kFmt3rc:  // op {vCCCC .. v(CCCC+AA-1)}, thing@BBBB
+    case dex::k3rc:  // op {vCCCC .. v(CCCC+AA-1)}, thing@BBBB
     {
-      SLICER_CHECK(bytecode->operands.size() == 2);
+      SLICER_CHECK_EQ(bytecode->operands.size(), 2);
       auto vreg_range = bytecode->CastOperand<VRegRange>(0);
       dex::u4 A = vreg_range->count;
       dex::u4 B = bytecode->CastOperand<IndexedOperand>(1)->index;
@@ -385,14 +388,14 @@ bool BytecodeEncoder::Visit(Bytecode* bytecode) {
       bytecode_.Push<dex::u2>(Pack_16(C));
 
       // keep track of the outs_count
-      if ((dex::GetFlagsFromOpcode(opcode) & dex::kInstrInvoke) != 0) {
+      if ((dex::GetFlagsFromOpcode(opcode) & dex::kInvoke) != 0) {
         outs_count_ = std::max(outs_count_, A);
       }
     } break;
 
-    case dex::kFmt51l:  // op vAA, #+BBBBBBBBBBBBBBBB
+    case dex::k51l:  // op vAA, #+BBBBBBBBBBBBBBBB
     {
-      SLICER_CHECK(bytecode->operands.size() == 2);
+      SLICER_CHECK_EQ(bytecode->operands.size(), 2);
       dex::u4 vA = GetRegA(bytecode, 0);
       dex::u8 B = bytecode->CastOperand<Const64>(1)->u.u8_value;
       bytecode_.Push<dex::u2>(Pack_8_8(vA, opcode));
@@ -402,8 +405,50 @@ bool BytecodeEncoder::Visit(Bytecode* bytecode) {
       bytecode_.Push<dex::u2>(Pack_16((B >> 48) & 0xffff));
     } break;
 
-    case dex::kFmt21h:  // op vAA, #+BBBB0000[00000000]
-      SLICER_CHECK(bytecode->operands.size() == 2);
+    case dex::k45cc:  // op {vC, vD, vE, vF, vG}, thing@BBBB, other@HHHH
+    {
+      SLICER_CHECK_EQ(bytecode->operands.size(), 3);
+      const auto& regs = bytecode->CastOperand<VRegList>(0)->registers;
+      dex::u4 A = regs.size();
+      dex::u4 B = bytecode->CastOperand<IndexedOperand>(1)->index;
+      dex::u4 H = bytecode->CastOperand<IndexedOperand>(2)->index;
+      dex::u4 C = (A > 0) ? regs[0] : 0;
+      dex::u4 D = (A > 1) ? regs[1] : 0;
+      dex::u4 E = (A > 2) ? regs[2] : 0;
+      dex::u4 F = (A > 3) ? regs[3] : 0;
+      dex::u4 G = (A > 4) ? regs[4] : 0;
+      bytecode_.Push<dex::u2>(Pack_4_4_8(A, G, opcode));
+      bytecode_.Push<dex::u2>(Pack_16(B));
+      bytecode_.Push<dex::u2>(Pack_4_4_4_4(F, E, D, C));
+      bytecode_.Push<dex::u2>(Pack_16(H));
+
+      // keep track of the outs_count
+      if ((dex::GetFlagsFromOpcode(opcode) & dex::kInvoke) != 0) {
+        outs_count_ = std::max(outs_count_, A);
+      }
+    } break;
+
+    case dex::k4rcc:  // op {vCCCC .. v(CCCC+AA-1)}, thing@BBBB, other@HHHH
+    {
+      SLICER_CHECK_EQ(bytecode->operands.size(), 3);
+      auto vreg_range = bytecode->CastOperand<VRegRange>(0);
+      dex::u4 A = vreg_range->count;
+      dex::u4 B = bytecode->CastOperand<IndexedOperand>(1)->index;
+      dex::u4 C = vreg_range->base_reg;
+      dex::u4 H = bytecode->CastOperand<IndexedOperand>(2)->index;
+      bytecode_.Push<dex::u2>(Pack_8_8(A, opcode));
+      bytecode_.Push<dex::u2>(Pack_16(B));
+      bytecode_.Push<dex::u2>(Pack_16(C));
+      bytecode_.Push<dex::u2>(Pack_16(H));
+
+      // keep track of the outs_count
+      if ((dex::GetFlagsFromOpcode(opcode) & dex::kInvoke) != 0) {
+        outs_count_ = std::max(outs_count_, A);
+      }
+    } break;
+
+    case dex::k21h:  // op vAA, #+BBBB0000[00000000]
+      SLICER_CHECK_EQ(bytecode->operands.size(), 2);
       switch (opcode) {
         case dex::OP_CONST_HIGH16: {
           dex::u4 vA = GetRegA(bytecode, 0);
@@ -419,27 +464,33 @@ bool BytecodeEncoder::Visit(Bytecode* bytecode) {
           bytecode_.Push<dex::u2>(Pack_16(B));
         } break;
 
-        default:
-          SLICER_FATAL("Unexpected fmt21h opcode: 0x%02x", opcode);
+        default: {
+          std::stringstream ss;
+          ss << "Unexpected fmt21h opcode: " << opcode;
+          SLICER_FATAL(ss.str());
+        }
       }
       break;
 
-    default:
-      SLICER_FATAL("Unexpected format: 0x%02x", format);
+    default: {
+      std::stringstream ss;
+      ss << "Unexpected format: " << format;
+      SLICER_FATAL(ss.str());
+    }
   }
 
-  SLICER_CHECK(bytecode_.size() - buff_offset == 2 * GetWidthFromOpcode(opcode));
-  offset_ += GetWidthFromOpcode(opcode);
+  SLICER_CHECK_EQ(bytecode_.size() - buff_offset, 2 * GetWidthFromFormat(format));
+  offset_ += GetWidthFromFormat(format);
   return true;
 }
 
 bool BytecodeEncoder::Visit(PackedSwitchPayload* packed_switch) {
-  SLICER_CHECK(offset_ % 2 == 0);
+  SLICER_CHECK_EQ(offset_ % 2, 0);
 
   // keep track of the switches
   packed_switch->offset = offset_;
   auto& instr = packed_switches_[offset_];
-  SLICER_CHECK(instr == nullptr);
+  SLICER_CHECK_EQ(instr, nullptr);
   instr = packed_switch;
 
   // we're going to fix up the offsets in a later pass
@@ -458,12 +509,12 @@ bool BytecodeEncoder::Visit(PackedSwitchPayload* packed_switch) {
 }
 
 bool BytecodeEncoder::Visit(SparseSwitchPayload* sparse_switch) {
-  SLICER_CHECK(offset_ % 2 == 0);
+  SLICER_CHECK_EQ(offset_ % 2, 0);
 
   // keep track of the switches
   sparse_switch->offset = offset_;
   auto& instr = sparse_switches_[offset_];
-  SLICER_CHECK(instr == nullptr);
+  SLICER_CHECK_EQ(instr, nullptr);
   instr = sparse_switch;
 
   // we're going to fix up the offsets in a later pass
@@ -482,7 +533,7 @@ bool BytecodeEncoder::Visit(SparseSwitchPayload* sparse_switch) {
 }
 
 bool BytecodeEncoder::Visit(ArrayData* array_data) {
-  SLICER_CHECK(offset_ % 2 == 0);
+  SLICER_CHECK_EQ(offset_ % 2, 0);
 
   array_data->offset = offset_;
   auto orig_size = bytecode_.size();
@@ -539,19 +590,19 @@ void BytecodeEncoder::FixupSwitchOffsets() {
       FixupSparseSwitch(offset, offset + dex::s4(dex_instr.vB));
     }
     auto isize = dex::GetWidthFromBytecode(ptr);
-    SLICER_CHECK(isize > 0);
+    SLICER_CHECK_GT(isize, 0);
     ptr += isize;
   }
-  SLICER_CHECK(ptr == end);
+  SLICER_CHECK_EQ(ptr, end);
 }
 
 void BytecodeEncoder::FixupPackedSwitch(dex::u4 base_offset,
                                         dex::u4 payload_offset) {
   auto instr = packed_switches_[payload_offset];
-  SLICER_CHECK(instr != nullptr);
+  SLICER_CHECK_NE(instr, nullptr);
 
   auto payload = bytecode_.ptr<dex::PackedSwitchPayload>(payload_offset * 2);
-  SLICER_CHECK(payload->ident == dex::kPackedSwitchSignature);
+  SLICER_CHECK_EQ(payload->ident, dex::kPackedSwitchSignature);
   SLICER_CHECK(reinterpret_cast<dex::u1*>(payload->targets + payload->size) <=
         bytecode_.data() + bytecode_.size());
 
@@ -565,10 +616,10 @@ void BytecodeEncoder::FixupPackedSwitch(dex::u4 base_offset,
 void BytecodeEncoder::FixupSparseSwitch(dex::u4 base_offset,
                                         dex::u4 payload_offset) {
   auto instr = sparse_switches_[payload_offset];
-  SLICER_CHECK(instr != nullptr);
+  SLICER_CHECK_NE(instr, nullptr);
 
   auto payload = bytecode_.ptr<dex::SparseSwitchPayload>(payload_offset * 2);
-  SLICER_CHECK(payload->ident == dex::kSparseSwitchSignature);
+  SLICER_CHECK_EQ(payload->ident, dex::kSparseSwitchSignature);
 
   dex::s4* const targets = payload->data + payload->size;
   SLICER_CHECK(reinterpret_cast<dex::u1*>(targets + payload->size) <=
@@ -587,7 +638,7 @@ void BytecodeEncoder::FixupLabels() {
     assert(label_offset != kInvalidOffset);
     assert(label_offset > fixup.offset);
     dex::u4 rel_offset = label_offset - fixup.offset;
-    SLICER_CHECK(rel_offset != 0);
+    SLICER_CHECK_NE(rel_offset, 0);
     dex::u2* instr = bytecode_.ptr<dex::u2>(fixup.offset * 2);
     if (fixup.short_fixup) {
       // TODO: explicit out-of-range check
@@ -604,8 +655,8 @@ void BytecodeEncoder::FixupLabels() {
 
 void BytecodeEncoder::Encode(ir::Code* ir_code, std::shared_ptr<ir::DexFile> dex_ir) {
   SLICER_CHECK(bytecode_.empty());
-  SLICER_CHECK(offset_ == 0);
-  SLICER_CHECK(outs_count_ == 0);
+  SLICER_CHECK_EQ(offset_, 0);
+  SLICER_CHECK_EQ(outs_count_, 0);
 
   packed_switches_.clear();
   sparse_switches_.clear();

--- a/modules/mockk-agent-android/external/slicer/common.cc
+++ b/modules/mockk-agent-android/external/slicer/common.cc
@@ -18,15 +18,52 @@
 
 #include <stdio.h>
 #include <stdlib.h>
-#include <cstdarg>
+
+#include <iostream>
+#include <sstream>
 #include <set>
 #include <utility>
 
 namespace slicer {
 
+static void log_(const std::string& msg) {
+  printf("%s", msg.c_str());
+  fflush(stdout);
+}
+
+static logger_type log = log_;
+
+void set_logger(logger_type new_logger) {
+  log = new_logger;
+}
+
 // Helper for the default SLICER_CHECK() policy
 void _checkFailed(const char* expr, int line, const char* file) {
-  printf("\nSLICER_CHECK failed [%s] at %s:%d\n\n", expr, file, line);
+  std::stringstream ss;
+  ss << std::endl << "SLICER_CHECK failed [";
+  ss << expr << "] at " << file << ":" << line;
+  ss << std::endl << std::endl;
+  log(ss.str());
+  abort();
+}
+
+void _checkFailedOp(const void* lhs, const void* rhs, const char* op, const char* suffix, int line,
+                    const char* file) {
+  std::stringstream ss;
+  ss << std::endl << "SLICER_CHECK_" << suffix << " failed [";
+  ss << lhs << " " << op << " " << rhs;
+  ss << "] at " << file << ":" << line;
+  log(ss.str());
+  abort();
+}
+
+void _checkFailedOp(uint32_t lhs, uint32_t rhs, const char* op, const char* suffix, int line,
+                    const char* file) {
+  std::stringstream ss;
+  ss << std::endl << "SLICER_CHECK_" << suffix << " failed [";
+  ss << lhs << " " << op << " " << rhs;
+  ss << "] at " << file << ":" << line;
+  log(ss.str());
   abort();
 }
 
@@ -40,17 +77,18 @@ thread_local std::set<std::pair<int, const char*>> weak_failures;
 void _weakCheckFailed(const char* expr, int line, const char* file) {
   auto failure_id = std::make_pair(line, file);
   if (weak_failures.find(failure_id) == weak_failures.end()) {
-    printf("\nSLICER_WEAK_CHECK failed [%s] at %s:%d\n\n", expr, file, line);
+    std::stringstream ss;
+    ss << std::endl << "SLICER_WEAK_CHECK failed [";
+    ss << expr << "] at " << file << ":";
+    ss << line << std::endl << std::endl;
+    log(ss.str());
     weak_failures.insert(failure_id);
   }
 }
 
 // Prints a formatted message and aborts
-void _fatal(const char* format, ...) {
-  va_list args;
-  va_start(args, format);
-  vprintf(format, args);
-  va_end(args);
+void _fatal(const std::string& msg) {
+  log("SLICER_FATAL: " + msg);
   abort();
 }
 

--- a/modules/mockk-agent-android/external/slicer/control_flow_graph.cc
+++ b/modules/mockk-agent-android/external/slicer/control_flow_graph.cc
@@ -15,7 +15,6 @@
  */
 
 #include "slicer/control_flow_graph.h"
-#include "slicer/chronometer.h"
 
 namespace lir {
 
@@ -56,16 +55,16 @@ bool BasicBlocksVisitor::Visit(Bytecode* bytecode) {
   const auto flags = dex::GetFlagsFromOpcode(bytecode->opcode);
   if (model_exceptions_) {
     constexpr auto exit_instr_flags =
-        dex::kInstrCanBranch |
-        dex::kInstrCanSwitch |
-        dex::kInstrCanThrow |
-        dex::kInstrCanReturn;
+        dex::kBranch |
+        dex::kSwitch |
+        dex::kThrow |
+        dex::kReturn;
     terminate_block = (flags & exit_instr_flags) != 0;
   } else {
     constexpr auto exit_instr_flags =
-        dex::kInstrCanBranch |
-        dex::kInstrCanSwitch |
-        dex::kInstrCanReturn;
+        dex::kBranch |
+        dex::kSwitch |
+        dex::kReturn;
     terminate_block = bytecode->opcode == dex::OP_THROW || (flags & exit_instr_flags) != 0;
   }
   if (terminate_block) {

--- a/modules/mockk-agent-android/external/slicer/dex_bytecode.cc
+++ b/modules/mockk-agent-android/external/slicer/dex_bytecode.cc
@@ -15,133 +15,92 @@
  */
 
 #include "slicer/dex_bytecode.h"
+
 #include "slicer/common.h"
 
-#include <assert.h>
 #include <array>
+#include <iomanip>
+#include <sstream>
 
 namespace dex {
 
 Opcode OpcodeFromBytecode(u2 bytecode) {
   Opcode opcode = Opcode(bytecode & 0xff);
-  SLICER_CHECK(opcode != OP_UNUSED_FF);
   return opcode;
 }
 
 // Table that maps each opcode to the index type implied by that opcode
-static constexpr std::array<InstructionIndexType, kNumPackedOpcodes>
-  gInstructionIndexTypeTable = {
-    kIndexNone,         kIndexNone,         kIndexNone,
-    kIndexNone,         kIndexNone,         kIndexNone,
-    kIndexNone,         kIndexNone,         kIndexNone,
-    kIndexNone,         kIndexNone,         kIndexNone,
-    kIndexNone,         kIndexNone,         kIndexNone,
-    kIndexNone,         kIndexNone,         kIndexNone,
-    kIndexNone,         kIndexNone,         kIndexNone,
-    kIndexNone,         kIndexNone,         kIndexNone,
-    kIndexNone,         kIndexNone,         kIndexStringRef,
-    kIndexStringRef,    kIndexTypeRef,      kIndexNone,
-    kIndexNone,         kIndexTypeRef,      kIndexTypeRef,
-    kIndexNone,         kIndexTypeRef,      kIndexTypeRef,
-    kIndexTypeRef,      kIndexTypeRef,      kIndexNone,
-    kIndexNone,         kIndexNone,         kIndexNone,
-    kIndexNone,         kIndexNone,         kIndexNone,
-    kIndexNone,         kIndexNone,         kIndexNone,
-    kIndexNone,         kIndexNone,         kIndexNone,
-    kIndexNone,         kIndexNone,         kIndexNone,
-    kIndexNone,         kIndexNone,         kIndexNone,
-    kIndexNone,         kIndexNone,         kIndexNone,
-    kIndexNone,         kIndexNone,         kIndexUnknown,
-    kIndexUnknown,      kIndexUnknown,      kIndexUnknown,
-    kIndexUnknown,      kIndexUnknown,      kIndexNone,
-    kIndexNone,         kIndexNone,         kIndexNone,
-    kIndexNone,         kIndexNone,         kIndexNone,
-    kIndexNone,         kIndexNone,         kIndexNone,
-    kIndexNone,         kIndexNone,         kIndexNone,
-    kIndexNone,         kIndexFieldRef,     kIndexFieldRef,
-    kIndexFieldRef,     kIndexFieldRef,     kIndexFieldRef,
-    kIndexFieldRef,     kIndexFieldRef,     kIndexFieldRef,
-    kIndexFieldRef,     kIndexFieldRef,     kIndexFieldRef,
-    kIndexFieldRef,     kIndexFieldRef,     kIndexFieldRef,
-    kIndexFieldRef,     kIndexFieldRef,     kIndexFieldRef,
-    kIndexFieldRef,     kIndexFieldRef,     kIndexFieldRef,
-    kIndexFieldRef,     kIndexFieldRef,     kIndexFieldRef,
-    kIndexFieldRef,     kIndexFieldRef,     kIndexFieldRef,
-    kIndexFieldRef,     kIndexFieldRef,     kIndexMethodRef,
-    kIndexMethodRef,    kIndexMethodRef,    kIndexMethodRef,
-    kIndexMethodRef,    kIndexUnknown,      kIndexMethodRef,
-    kIndexMethodRef,    kIndexMethodRef,    kIndexMethodRef,
-    kIndexMethodRef,    kIndexUnknown,      kIndexUnknown,
-    kIndexNone,         kIndexNone,         kIndexNone,
-    kIndexNone,         kIndexNone,         kIndexNone,
-    kIndexNone,         kIndexNone,         kIndexNone,
-    kIndexNone,         kIndexNone,         kIndexNone,
-    kIndexNone,         kIndexNone,         kIndexNone,
-    kIndexNone,         kIndexNone,         kIndexNone,
-    kIndexNone,         kIndexNone,         kIndexNone,
-    kIndexNone,         kIndexNone,         kIndexNone,
-    kIndexNone,         kIndexNone,         kIndexNone,
-    kIndexNone,         kIndexNone,         kIndexNone,
-    kIndexNone,         kIndexNone,         kIndexNone,
-    kIndexNone,         kIndexNone,         kIndexNone,
-    kIndexNone,         kIndexNone,         kIndexNone,
-    kIndexNone,         kIndexNone,         kIndexNone,
-    kIndexNone,         kIndexNone,         kIndexNone,
-    kIndexNone,         kIndexNone,         kIndexNone,
-    kIndexNone,         kIndexNone,         kIndexNone,
-    kIndexNone,         kIndexNone,         kIndexNone,
-    kIndexNone,         kIndexNone,         kIndexNone,
-    kIndexNone,         kIndexNone,         kIndexNone,
-    kIndexNone,         kIndexNone,         kIndexNone,
-    kIndexNone,         kIndexNone,         kIndexNone,
-    kIndexNone,         kIndexNone,         kIndexNone,
-    kIndexNone,         kIndexNone,         kIndexNone,
-    kIndexNone,         kIndexNone,         kIndexNone,
-    kIndexNone,         kIndexNone,         kIndexNone,
-    kIndexNone,         kIndexNone,         kIndexNone,
-    kIndexNone,         kIndexNone,         kIndexNone,
-    kIndexNone,         kIndexNone,         kIndexNone,
-    kIndexNone,         kIndexNone,         kIndexNone,
-    kIndexNone,         kIndexNone,         kIndexNone,
-    kIndexNone,         kIndexNone,         kIndexNone,
-    kIndexNone,         kIndexNone,         kIndexNone,
-    kIndexNone,         kIndexNone,         kIndexNone,
-    kIndexNone,         kIndexNone,         kIndexFieldRef,
-    kIndexFieldRef,     kIndexFieldRef,     kIndexFieldRef,
-    kIndexFieldRef,     kIndexFieldRef,     kIndexFieldRef,
-    kIndexFieldRef,     kIndexFieldRef,     kIndexUnknown,
-    kIndexVaries,       kIndexInlineMethod, kIndexInlineMethod,
-    kIndexMethodRef,    kIndexNone,         kIndexFieldOffset,
-    kIndexFieldOffset,  kIndexFieldOffset,  kIndexFieldOffset,
-    kIndexFieldOffset,  kIndexFieldOffset,  kIndexVtableOffset,
-    kIndexVtableOffset, kIndexVtableOffset, kIndexVtableOffset,
-    kIndexFieldRef,     kIndexFieldRef,     kIndexFieldRef,
-    kIndexUnknown,
-};
+static constexpr std::array<InstructionDescriptor, kNumPackedOpcodes>
+    gInstructionDescriptors = {{
+#define INSTRUCTION_DESCR(o, c, p, format, index, flags, e, vflags) \
+  {                                                                 \
+      vflags,                                                       \
+      format,                                                       \
+      index,                                                        \
+      flags,                                                        \
+  },
+#include "export/slicer/dex_instruction_list.h"
+        DEX_INSTRUCTION_LIST(INSTRUCTION_DESCR)
+#undef DEX_INSTRUCTION_LIST
+#undef INSTRUCTION_DESCR
+    }};
 
 InstructionIndexType GetIndexTypeFromOpcode(Opcode opcode) {
-  return gInstructionIndexTypeTable[opcode];
+  return gInstructionDescriptors[opcode].index_type;
 }
 
-// Table that maps each opcode to the full width of instructions that
-// use that opcode, in (16-bit) code units. Unimplemented opcodes as
-// well as the "breakpoint" opcode have a width of zero.
-static constexpr std::array<u1, kNumPackedOpcodes> gInstructionWidthTable = {
-  1, 1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 1, 1, 1, 1, 1, 1, 1, 1, 2, 3, 2, 2, 3,
-  5, 2, 2, 3, 2, 1, 1, 2, 2, 1, 2, 2, 3, 3, 3, 1, 1, 2, 3, 3, 3, 2, 2, 2,
-  2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 0, 0, 0, 0, 0, 0, 2, 2, 2, 2,
-  2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
-  2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 3, 3, 3, 3, 3, 0, 3, 3, 3, 3,
-  3, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-  2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
-  2, 2, 2, 2, 2, 2, 2, 2, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-  1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2, 2, 2,
-  2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 0, 2, 3, 3,
-  3, 1, 2, 2, 2, 2, 2, 2, 3, 3, 3, 3, 2, 2, 2, 0,
-};
+InstructionFormat GetFormatFromOpcode(Opcode opcode) {
+  return gInstructionDescriptors[opcode].format;
+}
 
-size_t GetWidthFromOpcode(Opcode opcode) {
-  return gInstructionWidthTable[opcode];
+OpcodeFlags GetFlagsFromOpcode(Opcode opcode) {
+  return gInstructionDescriptors[opcode].flags;
+}
+
+VerifyFlags GetVerifyFlagsFromOpcode(Opcode opcode) {
+  return gInstructionDescriptors[opcode].verify_flags;
+}
+
+size_t GetWidthFromFormat(InstructionFormat format) {
+  switch (format) {
+    case k10x:
+    case k12x:
+    case k11n:
+    case k11x:
+    case k10t:
+      return 1;
+    case k20t:
+    case k20bc:
+    case k21c:
+    case k22x:
+    case k21s:
+    case k21t:
+    case k21h:
+    case k23x:
+    case k22b:
+    case k22s:
+    case k22t:
+    case k22c:
+    case k22cs:
+      return 2;
+    case k30t:
+    case k31t:
+    case k31c:
+    case k32x:
+    case k31i:
+    case k35c:
+    case k35ms:
+    case k35mi:
+    case k3rc:
+    case k3rms:
+    case k3rmi:
+      return 3;
+    case k45cc:
+    case k4rcc:
+      return 4;
+    case k51l:
+      return 5;
+  }
 }
 
 size_t GetWidthFromBytecode(const u2* bytecode) {
@@ -156,578 +115,19 @@ size_t GetWidthFromBytecode(const u2* bytecode) {
     // The plus 1 is to round up for odd size and width.
     width = 4 + (elemWidth * len + 1) / 2;
   } else {
-    width = GetWidthFromOpcode(OpcodeFromBytecode(bytecode[0]));
+    width = GetWidthFromFormat(
+        GetFormatFromOpcode(OpcodeFromBytecode(bytecode[0])));
   }
   return width;
 }
 
-// Table that maps each opcode to the instruction flags
-static constexpr std::array<OpcodeFlags, kNumPackedOpcodes> gOpcodeFlagsTable = {
-  /* NOP                        */ kInstrCanContinue,
-  /* MOVE                       */ kInstrCanContinue,
-  /* MOVE_FROM16                */ kInstrCanContinue,
-  /* MOVE_16                    */ kInstrCanContinue,
-  /* MOVE_WIDE                  */ kInstrCanContinue|kInstrWideRegA|kInstrWideRegB,
-  /* MOVE_WIDE_FROM16           */ kInstrCanContinue|kInstrWideRegA|kInstrWideRegB,
-  /* MOVE_WIDE_16               */ kInstrCanContinue|kInstrWideRegA|kInstrWideRegB,
-  /* MOVE_OBJECT                */ kInstrCanContinue,
-  /* MOVE_OBJECT_FROM16         */ kInstrCanContinue,
-  /* MOVE_OBJECT_16             */ kInstrCanContinue,
-  /* MOVE_RESULT                */ kInstrCanContinue,
-  /* MOVE_RESULT_WIDE           */ kInstrCanContinue|kInstrWideRegA,
-  /* MOVE_RESULT_OBJECT         */ kInstrCanContinue,
-  /* MOVE_EXCEPTION             */ kInstrCanContinue,
-  /* RETURN_VOID                */ kInstrCanReturn,
-  /* RETURN                     */ kInstrCanReturn,
-  /* RETURN_WIDE                */ kInstrCanReturn|kInstrWideRegA,
-  /* RETURN_OBJECT              */ kInstrCanReturn,
-  /* CONST_4                    */ kInstrCanContinue,
-  /* CONST_16                   */ kInstrCanContinue,
-  /* CONST                      */ kInstrCanContinue,
-  /* CONST_HIGH16               */ kInstrCanContinue,
-  /* CONST_WIDE_16              */ kInstrCanContinue|kInstrWideRegA,
-  /* CONST_WIDE_32              */ kInstrCanContinue|kInstrWideRegA,
-  /* CONST_WIDE                 */ kInstrCanContinue|kInstrWideRegA,
-  /* CONST_WIDE_HIGH16          */ kInstrCanContinue|kInstrWideRegA,
-  /* CONST_STRING               */ kInstrCanContinue|kInstrCanThrow,
-  /* CONST_STRING_JUMBO         */ kInstrCanContinue|kInstrCanThrow,
-  /* CONST_CLASS                */ kInstrCanContinue|kInstrCanThrow,
-  /* MONITOR_ENTER              */ kInstrCanContinue|kInstrCanThrow,
-  /* MONITOR_EXIT               */ kInstrCanContinue|kInstrCanThrow,
-  /* SLICER_CHECK_CAST                 */ kInstrCanContinue|kInstrCanThrow,
-  /* INSTANCE_OF                */ kInstrCanContinue|kInstrCanThrow,
-  /* ARRAY_LENGTH               */ kInstrCanContinue|kInstrCanThrow,
-  /* NEW_INSTANCE               */ kInstrCanContinue|kInstrCanThrow,
-  /* NEW_ARRAY                  */ kInstrCanContinue|kInstrCanThrow,
-  /* FILLED_NEW_ARRAY           */ kInstrCanContinue|kInstrCanThrow,
-  /* FILLED_NEW_ARRAY_RANGE     */ kInstrCanContinue|kInstrCanThrow,
-  /* FILL_ARRAY_DATA            */ kInstrCanContinue,
-  /* THROW                      */ kInstrCanThrow,
-  /* GOTO                       */ kInstrCanBranch,
-  /* GOTO_16                    */ kInstrCanBranch,
-  /* GOTO_32                    */ kInstrCanBranch,
-  /* PACKED_SWITCH              */ kInstrCanContinue|kInstrCanSwitch,
-  /* SPARSE_SWITCH              */ kInstrCanContinue|kInstrCanSwitch,
-  /* CMPL_FLOAT                 */ kInstrCanContinue,
-  /* CMPG_FLOAT                 */ kInstrCanContinue,
-  /* CMPL_DOUBLE                */ kInstrCanContinue|kInstrWideRegB|kInstrWideRegC,
-  /* CMPG_DOUBLE                */ kInstrCanContinue|kInstrWideRegB|kInstrWideRegC,
-  /* CMP_LONG                   */ kInstrCanContinue|kInstrWideRegB|kInstrWideRegC,
-  /* IF_EQ                      */ kInstrCanContinue|kInstrCanBranch,
-  /* IF_NE                      */ kInstrCanContinue|kInstrCanBranch,
-  /* IF_LT                      */ kInstrCanContinue|kInstrCanBranch,
-  /* IF_GE                      */ kInstrCanContinue|kInstrCanBranch,
-  /* IF_GT                      */ kInstrCanContinue|kInstrCanBranch,
-  /* IF_LE                      */ kInstrCanContinue|kInstrCanBranch,
-  /* IF_EQZ                     */ kInstrCanContinue|kInstrCanBranch,
-  /* IF_NEZ                     */ kInstrCanContinue|kInstrCanBranch,
-  /* IF_LTZ                     */ kInstrCanContinue|kInstrCanBranch,
-  /* IF_GEZ                     */ kInstrCanContinue|kInstrCanBranch,
-  /* IF_GTZ                     */ kInstrCanContinue|kInstrCanBranch,
-  /* IF_LEZ                     */ kInstrCanContinue|kInstrCanBranch,
-  /* UNUSED_3E                  */ 0,
-  /* UNUSED_3F                  */ 0,
-  /* UNUSED_40                  */ 0,
-  /* UNUSED_41                  */ 0,
-  /* UNUSED_42                  */ 0,
-  /* UNUSED_43                  */ 0,
-  /* AGET                       */ kInstrCanContinue|kInstrCanThrow,
-  /* AGET_WIDE                  */ kInstrCanContinue|kInstrCanThrow|kInstrWideRegA,
-  /* AGET_OBJECT                */ kInstrCanContinue|kInstrCanThrow,
-  /* AGET_BOOLEAN               */ kInstrCanContinue|kInstrCanThrow,
-  /* AGET_BYTE                  */ kInstrCanContinue|kInstrCanThrow,
-  /* AGET_CHAR                  */ kInstrCanContinue|kInstrCanThrow,
-  /* AGET_SHORT                 */ kInstrCanContinue|kInstrCanThrow,
-  /* APUT                       */ kInstrCanContinue|kInstrCanThrow,
-  /* APUT_WIDE                  */ kInstrCanContinue|kInstrCanThrow|kInstrWideRegA,
-  /* APUT_OBJECT                */ kInstrCanContinue|kInstrCanThrow,
-  /* APUT_BOOLEAN               */ kInstrCanContinue|kInstrCanThrow,
-  /* APUT_BYTE                  */ kInstrCanContinue|kInstrCanThrow,
-  /* APUT_CHAR                  */ kInstrCanContinue|kInstrCanThrow,
-  /* APUT_SHORT                 */ kInstrCanContinue|kInstrCanThrow,
-  /* IGET                       */ kInstrCanContinue|kInstrCanThrow,
-  /* IGET_WIDE                  */ kInstrCanContinue|kInstrCanThrow|kInstrWideRegA,
-  /* IGET_OBJECT                */ kInstrCanContinue|kInstrCanThrow,
-  /* IGET_BOOLEAN               */ kInstrCanContinue|kInstrCanThrow,
-  /* IGET_BYTE                  */ kInstrCanContinue|kInstrCanThrow,
-  /* IGET_CHAR                  */ kInstrCanContinue|kInstrCanThrow,
-  /* IGET_SHORT                 */ kInstrCanContinue|kInstrCanThrow,
-  /* IPUT                       */ kInstrCanContinue|kInstrCanThrow,
-  /* IPUT_WIDE                  */ kInstrCanContinue|kInstrCanThrow|kInstrWideRegA,
-  /* IPUT_OBJECT                */ kInstrCanContinue|kInstrCanThrow,
-  /* IPUT_BOOLEAN               */ kInstrCanContinue|kInstrCanThrow,
-  /* IPUT_BYTE                  */ kInstrCanContinue|kInstrCanThrow,
-  /* IPUT_CHAR                  */ kInstrCanContinue|kInstrCanThrow,
-  /* IPUT_SHORT                 */ kInstrCanContinue|kInstrCanThrow,
-  /* SGET                       */ kInstrCanContinue|kInstrCanThrow,
-  /* SGET_WIDE                  */ kInstrCanContinue|kInstrCanThrow|kInstrWideRegA,
-  /* SGET_OBJECT                */ kInstrCanContinue|kInstrCanThrow,
-  /* SGET_BOOLEAN               */ kInstrCanContinue|kInstrCanThrow,
-  /* SGET_BYTE                  */ kInstrCanContinue|kInstrCanThrow,
-  /* SGET_CHAR                  */ kInstrCanContinue|kInstrCanThrow,
-  /* SGET_SHORT                 */ kInstrCanContinue|kInstrCanThrow,
-  /* SPUT                       */ kInstrCanContinue|kInstrCanThrow,
-  /* SPUT_WIDE                  */ kInstrCanContinue|kInstrCanThrow|kInstrWideRegA,
-  /* SPUT_OBJECT                */ kInstrCanContinue|kInstrCanThrow,
-  /* SPUT_BOOLEAN               */ kInstrCanContinue|kInstrCanThrow,
-  /* SPUT_BYTE                  */ kInstrCanContinue|kInstrCanThrow,
-  /* SPUT_CHAR                  */ kInstrCanContinue|kInstrCanThrow,
-  /* SPUT_SHORT                 */ kInstrCanContinue|kInstrCanThrow,
-  /* INVOKE_VIRTUAL             */ kInstrCanContinue|kInstrCanThrow|kInstrInvoke,
-  /* INVOKE_SUPER               */ kInstrCanContinue|kInstrCanThrow|kInstrInvoke,
-  /* INVOKE_DIRECT              */ kInstrCanContinue|kInstrCanThrow|kInstrInvoke,
-  /* INVOKE_STATIC              */ kInstrCanContinue|kInstrCanThrow|kInstrInvoke,
-  /* INVOKE_INTERFACE           */ kInstrCanContinue|kInstrCanThrow|kInstrInvoke,
-  /* UNUSED_73                  */ 0,
-  /* INVOKE_VIRTUAL_RANGE       */ kInstrCanContinue|kInstrCanThrow|kInstrInvoke,
-  /* INVOKE_SUPER_RANGE         */ kInstrCanContinue|kInstrCanThrow|kInstrInvoke,
-  /* INVOKE_DIRECT_RANGE        */ kInstrCanContinue|kInstrCanThrow|kInstrInvoke,
-  /* INVOKE_STATIC_RANGE        */ kInstrCanContinue|kInstrCanThrow|kInstrInvoke,
-  /* INVOKE_INTERFACE_RANGE     */ kInstrCanContinue|kInstrCanThrow|kInstrInvoke,
-  /* UNUSED_79                  */ 0,
-  /* UNUSED_7A                  */ 0,
-  /* NEG_INT                    */ kInstrCanContinue,
-  /* NOT_INT                    */ kInstrCanContinue,
-  /* NEG_LONG                   */ kInstrCanContinue|kInstrWideRegA|kInstrWideRegB,
-  /* NOT_LONG                   */ kInstrCanContinue|kInstrWideRegA|kInstrWideRegB,
-  /* NEG_FLOAT                  */ kInstrCanContinue,
-  /* NEG_DOUBLE                 */ kInstrCanContinue|kInstrWideRegA|kInstrWideRegB,
-  /* INT_TO_LONG                */ kInstrCanContinue|kInstrWideRegA,
-  /* INT_TO_FLOAT               */ kInstrCanContinue,
-  /* INT_TO_DOUBLE              */ kInstrCanContinue|kInstrWideRegA,
-  /* LONG_TO_INT                */ kInstrCanContinue|kInstrWideRegB,
-  /* LONG_TO_FLOAT              */ kInstrCanContinue|kInstrWideRegB,
-  /* LONG_TO_DOUBLE             */ kInstrCanContinue|kInstrWideRegA|kInstrWideRegB,
-  /* FLOAT_TO_INT               */ kInstrCanContinue,
-  /* FLOAT_TO_LONG              */ kInstrCanContinue|kInstrWideRegA,
-  /* FLOAT_TO_DOUBLE            */ kInstrCanContinue|kInstrWideRegA,
-  /* DOUBLE_TO_INT              */ kInstrCanContinue|kInstrWideRegB,
-  /* DOUBLE_TO_LONG             */ kInstrCanContinue|kInstrWideRegA|kInstrWideRegB,
-  /* DOUBLE_TO_FLOAT            */ kInstrCanContinue|kInstrWideRegB,
-  /* INT_TO_BYTE                */ kInstrCanContinue,
-  /* INT_TO_CHAR                */ kInstrCanContinue,
-  /* INT_TO_SHORT               */ kInstrCanContinue,
-  /* ADD_INT                    */ kInstrCanContinue,
-  /* SUB_INT                    */ kInstrCanContinue,
-  /* MUL_INT                    */ kInstrCanContinue,
-  /* DIV_INT                    */ kInstrCanContinue|kInstrCanThrow,
-  /* REM_INT                    */ kInstrCanContinue|kInstrCanThrow,
-  /* AND_INT                    */ kInstrCanContinue,
-  /* OR_INT                     */ kInstrCanContinue,
-  /* XOR_INT                    */ kInstrCanContinue,
-  /* SHL_INT                    */ kInstrCanContinue,
-  /* SHR_INT                    */ kInstrCanContinue,
-  /* USHR_INT                   */ kInstrCanContinue,
-  /* ADD_LONG                   */ kInstrCanContinue|kInstrWideRegA|kInstrWideRegB|kInstrWideRegC,
-  /* SUB_LONG                   */ kInstrCanContinue|kInstrWideRegA|kInstrWideRegB|kInstrWideRegC,
-  /* MUL_LONG                   */ kInstrCanContinue|kInstrWideRegA|kInstrWideRegB|kInstrWideRegC,
-  /* DIV_LONG                   */ kInstrCanContinue|kInstrCanThrow|kInstrWideRegA|kInstrWideRegB|kInstrWideRegC,
-  /* REM_LONG                   */ kInstrCanContinue|kInstrCanThrow|kInstrWideRegA|kInstrWideRegB|kInstrWideRegC,
-  /* AND_LONG                   */ kInstrCanContinue|kInstrWideRegA|kInstrWideRegB|kInstrWideRegC,
-  /* OR_LONG                    */ kInstrCanContinue|kInstrWideRegA|kInstrWideRegB|kInstrWideRegC,
-  /* XOR_LONG                   */ kInstrCanContinue|kInstrWideRegA|kInstrWideRegB|kInstrWideRegC,
-  /* SHL_LONG                   */ kInstrCanContinue|kInstrWideRegA|kInstrWideRegB,
-  /* SHR_LONG                   */ kInstrCanContinue|kInstrWideRegA|kInstrWideRegB,
-  /* USHR_LONG                  */ kInstrCanContinue|kInstrWideRegA|kInstrWideRegB,
-  /* ADD_FLOAT                  */ kInstrCanContinue,
-  /* SUB_FLOAT                  */ kInstrCanContinue,
-  /* MUL_FLOAT                  */ kInstrCanContinue,
-  /* DIV_FLOAT                  */ kInstrCanContinue,
-  /* REM_FLOAT                  */ kInstrCanContinue,
-  /* ADD_DOUBLE                 */ kInstrCanContinue|kInstrWideRegA|kInstrWideRegB|kInstrWideRegC,
-  /* SUB_DOUBLE                 */ kInstrCanContinue|kInstrWideRegA|kInstrWideRegB|kInstrWideRegC,
-  /* MUL_DOUBLE                 */ kInstrCanContinue|kInstrWideRegA|kInstrWideRegB|kInstrWideRegC,
-  /* DIV_DOUBLE                 */ kInstrCanContinue|kInstrWideRegA|kInstrWideRegB|kInstrWideRegC,
-  /* REM_DOUBLE                 */ kInstrCanContinue|kInstrWideRegA|kInstrWideRegB|kInstrWideRegC,
-  /* ADD_INT_2ADDR              */ kInstrCanContinue,
-  /* SUB_INT_2ADDR              */ kInstrCanContinue,
-  /* MUL_INT_2ADDR              */ kInstrCanContinue,
-  /* DIV_INT_2ADDR              */ kInstrCanContinue|kInstrCanThrow,
-  /* REM_INT_2ADDR              */ kInstrCanContinue|kInstrCanThrow,
-  /* AND_INT_2ADDR              */ kInstrCanContinue,
-  /* OR_INT_2ADDR               */ kInstrCanContinue,
-  /* XOR_INT_2ADDR              */ kInstrCanContinue,
-  /* SHL_INT_2ADDR              */ kInstrCanContinue,
-  /* SHR_INT_2ADDR              */ kInstrCanContinue,
-  /* USHR_INT_2ADDR             */ kInstrCanContinue,
-  /* ADD_LONG_2ADDR             */ kInstrCanContinue|kInstrWideRegA|kInstrWideRegB,
-  /* SUB_LONG_2ADDR             */ kInstrCanContinue|kInstrWideRegA|kInstrWideRegB,
-  /* MUL_LONG_2ADDR             */ kInstrCanContinue|kInstrWideRegA|kInstrWideRegB,
-  /* DIV_LONG_2ADDR             */ kInstrCanContinue|kInstrCanThrow|kInstrWideRegA|kInstrWideRegB,
-  /* REM_LONG_2ADDR             */ kInstrCanContinue|kInstrCanThrow|kInstrWideRegA|kInstrWideRegB,
-  /* AND_LONG_2ADDR             */ kInstrCanContinue|kInstrWideRegA|kInstrWideRegB,
-  /* OR_LONG_2ADDR              */ kInstrCanContinue|kInstrWideRegA|kInstrWideRegB,
-  /* XOR_LONG_2ADDR             */ kInstrCanContinue|kInstrWideRegA|kInstrWideRegB,
-  /* SHL_LONG_2ADDR             */ kInstrCanContinue|kInstrWideRegA,
-  /* SHR_LONG_2ADDR             */ kInstrCanContinue|kInstrWideRegA,
-  /* USHR_LONG_2ADDR            */ kInstrCanContinue|kInstrWideRegA,
-  /* ADD_FLOAT_2ADDR            */ kInstrCanContinue,
-  /* SUB_FLOAT_2ADDR            */ kInstrCanContinue,
-  /* MUL_FLOAT_2ADDR            */ kInstrCanContinue,
-  /* DIV_FLOAT_2ADDR            */ kInstrCanContinue,
-  /* REM_FLOAT_2ADDR            */ kInstrCanContinue,
-  /* ADD_DOUBLE_2ADDR           */ kInstrCanContinue|kInstrWideRegA|kInstrWideRegB,
-  /* SUB_DOUBLE_2ADDR           */ kInstrCanContinue|kInstrWideRegA|kInstrWideRegB,
-  /* MUL_DOUBLE_2ADDR           */ kInstrCanContinue|kInstrWideRegA|kInstrWideRegB,
-  /* DIV_DOUBLE_2ADDR           */ kInstrCanContinue|kInstrWideRegA|kInstrWideRegB,
-  /* REM_DOUBLE_2ADDR           */ kInstrCanContinue|kInstrWideRegA|kInstrWideRegB,
-  /* ADD_INT_LIT16              */ kInstrCanContinue,
-  /* RSUB_INT                   */ kInstrCanContinue,
-  /* MUL_INT_LIT16              */ kInstrCanContinue,
-  /* DIV_INT_LIT16              */ kInstrCanContinue|kInstrCanThrow,
-  /* REM_INT_LIT16              */ kInstrCanContinue|kInstrCanThrow,
-  /* AND_INT_LIT16              */ kInstrCanContinue,
-  /* OR_INT_LIT16               */ kInstrCanContinue,
-  /* XOR_INT_LIT16              */ kInstrCanContinue,
-  /* ADD_INT_LIT8               */ kInstrCanContinue,
-  /* RSUB_INT_LIT8              */ kInstrCanContinue,
-  /* MUL_INT_LIT8               */ kInstrCanContinue,
-  /* DIV_INT_LIT8               */ kInstrCanContinue|kInstrCanThrow,
-  /* REM_INT_LIT8               */ kInstrCanContinue|kInstrCanThrow,
-  /* AND_INT_LIT8               */ kInstrCanContinue,
-  /* OR_INT_LIT8                */ kInstrCanContinue,
-  /* XOR_INT_LIT8               */ kInstrCanContinue,
-  /* SHL_INT_LIT8               */ kInstrCanContinue,
-  /* SHR_INT_LIT8               */ kInstrCanContinue,
-  /* USHR_INT_LIT8              */ kInstrCanContinue,
-  /* IGET_VOLATILE              */ kInstrCanContinue|kInstrCanThrow,
-  /* IPUT_VOLATILE              */ kInstrCanContinue|kInstrCanThrow,
-  /* SGET_VOLATILE              */ kInstrCanContinue|kInstrCanThrow,
-  /* SPUT_VOLATILE              */ kInstrCanContinue|kInstrCanThrow,
-  /* IGET_OBJECT_VOLATILE       */ kInstrCanContinue|kInstrCanThrow,
-  /* IGET_WIDE_VOLATILE         */ kInstrCanContinue|kInstrCanThrow|kInstrWideRegA,
-  /* IPUT_WIDE_VOLATILE         */ kInstrCanContinue|kInstrCanThrow|kInstrWideRegA,
-  /* SGET_WIDE_VOLATILE         */ kInstrCanContinue|kInstrCanThrow|kInstrWideRegA,
-  /* SPUT_WIDE_VOLATILE         */ kInstrCanContinue|kInstrCanThrow|kInstrWideRegA,
-  /* BREAKPOINT                 */ 0,
-  /* THROW_VERIFICATION_ERROR   */ kInstrCanThrow,
-  /* EXECUTE_INLINE             */ kInstrCanContinue|kInstrCanThrow,
-  /* EXECUTE_INLINE_RANGE       */ kInstrCanContinue|kInstrCanThrow,
-  /* INVOKE_OBJECT_INIT_RANGE   */ kInstrCanContinue|kInstrCanThrow|kInstrInvoke,
-  /* RETURN_VOID_BARRIER        */ kInstrCanReturn,
-  /* IGET_QUICK                 */ kInstrCanContinue|kInstrCanThrow,
-  /* IGET_WIDE_QUICK            */ kInstrCanContinue|kInstrCanThrow|kInstrWideRegA,
-  /* IGET_OBJECT_QUICK          */ kInstrCanContinue|kInstrCanThrow,
-  /* IPUT_QUICK                 */ kInstrCanContinue|kInstrCanThrow,
-  /* IPUT_WIDE_QUICK            */ kInstrCanContinue|kInstrCanThrow|kInstrWideRegA,
-  /* IPUT_OBJECT_QUICK          */ kInstrCanContinue|kInstrCanThrow,
-  /* INVOKE_VIRTUAL_QUICK       */ kInstrCanContinue|kInstrCanThrow|kInstrInvoke,
-  /* INVOKE_VIRTUAL_QUICK_RANGE */ kInstrCanContinue|kInstrCanThrow|kInstrInvoke,
-  /* INVOKE_SUPER_QUICK         */ kInstrCanContinue|kInstrCanThrow|kInstrInvoke,
-  /* INVOKE_SUPER_QUICK_RANGE   */ kInstrCanContinue|kInstrCanThrow|kInstrInvoke,
-  /* IPUT_OBJECT_VOLATILE       */ kInstrCanContinue|kInstrCanThrow,
-  /* SGET_OBJECT_VOLATILE       */ kInstrCanContinue|kInstrCanThrow,
-  /* SPUT_OBJECT_VOLATILE       */ kInstrCanContinue|kInstrCanThrow,
-  /* UNUSED_FF                  */ 0,
-};
-
-// Table that maps each opcode to the instruction format
-static constexpr std::array<InstructionFormat, kNumPackedOpcodes> gInstructionFormatTable = {
-  kFmt10x,  kFmt12x,  kFmt22x,  kFmt32x,  kFmt12x,  kFmt22x,  kFmt32x,
-  kFmt12x,  kFmt22x,  kFmt32x,  kFmt11x,  kFmt11x,  kFmt11x,  kFmt11x,
-  kFmt10x,  kFmt11x,  kFmt11x,  kFmt11x,  kFmt11n,  kFmt21s,  kFmt31i,
-  kFmt21h,  kFmt21s,  kFmt31i,  kFmt51l,  kFmt21h,  kFmt21c,  kFmt31c,
-  kFmt21c,  kFmt11x,  kFmt11x,  kFmt21c,  kFmt22c,  kFmt12x,  kFmt21c,
-  kFmt22c,  kFmt35c,  kFmt3rc,  kFmt31t,  kFmt11x,  kFmt10t,  kFmt20t,
-  kFmt30t,  kFmt31t,  kFmt31t,  kFmt23x,  kFmt23x,  kFmt23x,  kFmt23x,
-  kFmt23x,  kFmt22t,  kFmt22t,  kFmt22t,  kFmt22t,  kFmt22t,  kFmt22t,
-  kFmt21t,  kFmt21t,  kFmt21t,  kFmt21t,  kFmt21t,  kFmt21t,  kFmt00x,
-  kFmt00x,  kFmt00x,  kFmt00x,  kFmt00x,  kFmt00x,  kFmt23x,  kFmt23x,
-  kFmt23x,  kFmt23x,  kFmt23x,  kFmt23x,  kFmt23x,  kFmt23x,  kFmt23x,
-  kFmt23x,  kFmt23x,  kFmt23x,  kFmt23x,  kFmt23x,  kFmt22c,  kFmt22c,
-  kFmt22c,  kFmt22c,  kFmt22c,  kFmt22c,  kFmt22c,  kFmt22c,  kFmt22c,
-  kFmt22c,  kFmt22c,  kFmt22c,  kFmt22c,  kFmt22c,  kFmt21c,  kFmt21c,
-  kFmt21c,  kFmt21c,  kFmt21c,  kFmt21c,  kFmt21c,  kFmt21c,  kFmt21c,
-  kFmt21c,  kFmt21c,  kFmt21c,  kFmt21c,  kFmt21c,  kFmt35c,  kFmt35c,
-  kFmt35c,  kFmt35c,  kFmt35c,  kFmt00x,  kFmt3rc,  kFmt3rc,  kFmt3rc,
-  kFmt3rc,  kFmt3rc,  kFmt00x,  kFmt00x,  kFmt12x,  kFmt12x,  kFmt12x,
-  kFmt12x,  kFmt12x,  kFmt12x,  kFmt12x,  kFmt12x,  kFmt12x,  kFmt12x,
-  kFmt12x,  kFmt12x,  kFmt12x,  kFmt12x,  kFmt12x,  kFmt12x,  kFmt12x,
-  kFmt12x,  kFmt12x,  kFmt12x,  kFmt12x,  kFmt23x,  kFmt23x,  kFmt23x,
-  kFmt23x,  kFmt23x,  kFmt23x,  kFmt23x,  kFmt23x,  kFmt23x,  kFmt23x,
-  kFmt23x,  kFmt23x,  kFmt23x,  kFmt23x,  kFmt23x,  kFmt23x,  kFmt23x,
-  kFmt23x,  kFmt23x,  kFmt23x,  kFmt23x,  kFmt23x,  kFmt23x,  kFmt23x,
-  kFmt23x,  kFmt23x,  kFmt23x,  kFmt23x,  kFmt23x,  kFmt23x,  kFmt23x,
-  kFmt23x,  kFmt12x,  kFmt12x,  kFmt12x,  kFmt12x,  kFmt12x,  kFmt12x,
-  kFmt12x,  kFmt12x,  kFmt12x,  kFmt12x,  kFmt12x,  kFmt12x,  kFmt12x,
-  kFmt12x,  kFmt12x,  kFmt12x,  kFmt12x,  kFmt12x,  kFmt12x,  kFmt12x,
-  kFmt12x,  kFmt12x,  kFmt12x,  kFmt12x,  kFmt12x,  kFmt12x,  kFmt12x,
-  kFmt12x,  kFmt12x,  kFmt12x,  kFmt12x,  kFmt12x,  kFmt22s,  kFmt22s,
-  kFmt22s,  kFmt22s,  kFmt22s,  kFmt22s,  kFmt22s,  kFmt22s,  kFmt22b,
-  kFmt22b,  kFmt22b,  kFmt22b,  kFmt22b,  kFmt22b,  kFmt22b,  kFmt22b,
-  kFmt22b,  kFmt22b,  kFmt22b,  kFmt22c,  kFmt22c,  kFmt21c,  kFmt21c,
-  kFmt22c,  kFmt22c,  kFmt22c,  kFmt21c,  kFmt21c,  kFmt00x,  kFmt20bc,
-  kFmt35mi, kFmt3rmi, kFmt35c,  kFmt10x,  kFmt22cs, kFmt22cs, kFmt22cs,
-  kFmt22cs, kFmt22cs, kFmt22cs, kFmt35ms, kFmt3rms, kFmt35ms, kFmt3rms,
-  kFmt22c,  kFmt21c,  kFmt21c,  kFmt00x,
-};
-
-InstructionFormat GetFormatFromOpcode(Opcode opcode) {
-  return gInstructionFormatTable[opcode];
-}
-
-OpcodeFlags GetFlagsFromOpcode(Opcode opcode) {
-  return gOpcodeFlagsTable[opcode];
-}
-
 // Dalvik opcode names.
 static constexpr std::array<const char*, kNumPackedOpcodes> gOpcodeNames = {
-  "nop",
-  "move",
-  "move/from16",
-  "move/16",
-  "move-wide",
-  "move-wide/from16",
-  "move-wide/16",
-  "move-object",
-  "move-object/from16",
-  "move-object/16",
-  "move-result",
-  "move-result-wide",
-  "move-result-object",
-  "move-exception",
-  "return-void",
-  "return",
-  "return-wide",
-  "return-object",
-  "const/4",
-  "const/16",
-  "const",
-  "const/high16",
-  "const-wide/16",
-  "const-wide/32",
-  "const-wide",
-  "const-wide/high16",
-  "const-string",
-  "const-string/jumbo",
-  "const-class",
-  "monitor-enter",
-  "monitor-exit",
-  "check-cast",
-  "instance-of",
-  "array-length",
-  "new-instance",
-  "new-array",
-  "filled-new-array",
-  "filled-new-array/range",
-  "fill-array-data",
-  "throw",
-  "goto",
-  "goto/16",
-  "goto/32",
-  "packed-switch",
-  "sparse-switch",
-  "cmpl-float",
-  "cmpg-float",
-  "cmpl-double",
-  "cmpg-double",
-  "cmp-long",
-  "if-eq",
-  "if-ne",
-  "if-lt",
-  "if-ge",
-  "if-gt",
-  "if-le",
-  "if-eqz",
-  "if-nez",
-  "if-ltz",
-  "if-gez",
-  "if-gtz",
-  "if-lez",
-  "unused-3e",
-  "unused-3f",
-  "unused-40",
-  "unused-41",
-  "unused-42",
-  "unused-43",
-  "aget",
-  "aget-wide",
-  "aget-object",
-  "aget-boolean",
-  "aget-byte",
-  "aget-char",
-  "aget-short",
-  "aput",
-  "aput-wide",
-  "aput-object",
-  "aput-boolean",
-  "aput-byte",
-  "aput-char",
-  "aput-short",
-  "iget",
-  "iget-wide",
-  "iget-object",
-  "iget-boolean",
-  "iget-byte",
-  "iget-char",
-  "iget-short",
-  "iput",
-  "iput-wide",
-  "iput-object",
-  "iput-boolean",
-  "iput-byte",
-  "iput-char",
-  "iput-short",
-  "sget",
-  "sget-wide",
-  "sget-object",
-  "sget-boolean",
-  "sget-byte",
-  "sget-char",
-  "sget-short",
-  "sput",
-  "sput-wide",
-  "sput-object",
-  "sput-boolean",
-  "sput-byte",
-  "sput-char",
-  "sput-short",
-  "invoke-virtual",
-  "invoke-super",
-  "invoke-direct",
-  "invoke-static",
-  "invoke-interface",
-  "unused-73",
-  "invoke-virtual/range",
-  "invoke-super/range",
-  "invoke-direct/range",
-  "invoke-static/range",
-  "invoke-interface/range",
-  "unused-79",
-  "unused-7a",
-  "neg-int",
-  "not-int",
-  "neg-long",
-  "not-long",
-  "neg-float",
-  "neg-double",
-  "int-to-long",
-  "int-to-float",
-  "int-to-double",
-  "long-to-int",
-  "long-to-float",
-  "long-to-double",
-  "float-to-int",
-  "float-to-long",
-  "float-to-double",
-  "double-to-int",
-  "double-to-long",
-  "double-to-float",
-  "int-to-byte",
-  "int-to-char",
-  "int-to-short",
-  "add-int",
-  "sub-int",
-  "mul-int",
-  "div-int",
-  "rem-int",
-  "and-int",
-  "or-int",
-  "xor-int",
-  "shl-int",
-  "shr-int",
-  "ushr-int",
-  "add-long",
-  "sub-long",
-  "mul-long",
-  "div-long",
-  "rem-long",
-  "and-long",
-  "or-long",
-  "xor-long",
-  "shl-long",
-  "shr-long",
-  "ushr-long",
-  "add-float",
-  "sub-float",
-  "mul-float",
-  "div-float",
-  "rem-float",
-  "add-double",
-  "sub-double",
-  "mul-double",
-  "div-double",
-  "rem-double",
-  "add-int/2addr",
-  "sub-int/2addr",
-  "mul-int/2addr",
-  "div-int/2addr",
-  "rem-int/2addr",
-  "and-int/2addr",
-  "or-int/2addr",
-  "xor-int/2addr",
-  "shl-int/2addr",
-  "shr-int/2addr",
-  "ushr-int/2addr",
-  "add-long/2addr",
-  "sub-long/2addr",
-  "mul-long/2addr",
-  "div-long/2addr",
-  "rem-long/2addr",
-  "and-long/2addr",
-  "or-long/2addr",
-  "xor-long/2addr",
-  "shl-long/2addr",
-  "shr-long/2addr",
-  "ushr-long/2addr",
-  "add-float/2addr",
-  "sub-float/2addr",
-  "mul-float/2addr",
-  "div-float/2addr",
-  "rem-float/2addr",
-  "add-double/2addr",
-  "sub-double/2addr",
-  "mul-double/2addr",
-  "div-double/2addr",
-  "rem-double/2addr",
-  "add-int/lit16",
-  "rsub-int",
-  "mul-int/lit16",
-  "div-int/lit16",
-  "rem-int/lit16",
-  "and-int/lit16",
-  "or-int/lit16",
-  "xor-int/lit16",
-  "add-int/lit8",
-  "rsub-int/lit8",
-  "mul-int/lit8",
-  "div-int/lit8",
-  "rem-int/lit8",
-  "and-int/lit8",
-  "or-int/lit8",
-  "xor-int/lit8",
-  "shl-int/lit8",
-  "shr-int/lit8",
-  "ushr-int/lit8",
-  "+iget-volatile",
-  "+iput-volatile",
-  "+sget-volatile",
-  "+sput-volatile",
-  "+iget-object-volatile",
-  "+iget-wide-volatile",
-  "+iput-wide-volatile",
-  "+sget-wide-volatile",
-  "+sput-wide-volatile",
-  "^breakpoint",
-  "^throw-verification-error",
-  "+execute-inline",
-  "+execute-inline/range",
-  "+invoke-object-init/range",
-  "+return-void-barrier",
-  "+iget-quick",
-  "+iget-wide-quick",
-  "+iget-object-quick",
-  "+iput-quick",
-  "+iput-wide-quick",
-  "+iput-object-quick",
-  "+invoke-virtual-quick",
-  "+invoke-virtual-quick/range",
-  "+invoke-super-quick",
-  "+invoke-super-quick/range",
-  "+iput-object-volatile",
-  "+sget-object-volatile",
-  "+sput-object-volatile",
-  "unused-ff",
+#define INSTRUCTION_NAME(o, c, pname, f, i, a, e, v) pname,
+#include "export/slicer/dex_instruction_list.h"
+    DEX_INSTRUCTION_LIST(INSTRUCTION_NAME)
+#undef DEX_INSTRUCTION_LIST
+#undef INSTRUCTION_NAME
 };
 
 const char* GetOpcodeName(Opcode opcode) { return gOpcodeNames[opcode]; }
@@ -738,9 +138,7 @@ static u4 InstB(u2 inst) { return inst >> 12; }
 static u4 InstAA(u2 inst) { return inst >> 8; }
 
 // Helper for DecodeInstruction()
-static u4 FetchU4(const u2* ptr) {
-  return ptr[0] | (u4(ptr[1]) << 16);
-}
+static u4 FetchU4(const u2* ptr) { return ptr[0] | (u4(ptr[1]) << 16); }
 
 // Helper for DecodeInstruction()
 static u8 FetchU8(const u2* ptr) {
@@ -757,85 +155,84 @@ Instruction DecodeInstruction(const u2* bytecode) {
   dec.opcode = opcode;
 
   switch (format) {
-    case kFmt10x:  // op
-      break;
-    case kFmt12x:  // op vA, vB
+    case k10x:  // op
+      return dec;
+    case k12x:  // op vA, vB
       dec.vA = InstA(inst);
       dec.vB = InstB(inst);
-      break;
-    case kFmt11n:  // op vA, #+B
+      return dec;
+    case k11n:  // op vA, #+B
       dec.vA = InstA(inst);
       dec.vB = s4(InstB(inst) << 28) >> 28;  // sign extend 4-bit value
-      break;
-    case kFmt11x:  // op vAA
+      return dec;
+    case k11x:  // op vAA
       dec.vA = InstAA(inst);
-      break;
-    case kFmt10t:                 // op +AA
+      return dec;
+    case k10t:                    // op +AA
       dec.vA = s1(InstAA(inst));  // sign-extend 8-bit value
-      break;
-    case kFmt20t:                // op +AAAA
+      return dec;
+    case k20t:                   // op +AAAA
       dec.vA = s2(bytecode[1]);  // sign-extend 16-bit value
-      break;
-    case kFmt20bc:  // [opt] op AA, thing@BBBB
-    case kFmt21c:   // op vAA, thing@BBBB
-    case kFmt22x:   // op vAA, vBBBB
+      return dec;
+    case k20bc:  // [opt] op AA, thing@BBBB
+    case k21c:   // op vAA, thing@BBBB
+    case k22x:   // op vAA, vBBBB
       dec.vA = InstAA(inst);
       dec.vB = bytecode[1];
-      break;
-    case kFmt21s:  // op vAA, #+BBBB
-    case kFmt21t:  // op vAA, +BBBB
+      return dec;
+    case k21s:  // op vAA, #+BBBB
+    case k21t:  // op vAA, +BBBB
       dec.vA = InstAA(inst);
       dec.vB = s2(bytecode[1]);  // sign-extend 16-bit value
-      break;
-    case kFmt21h:  // op vAA, #+BBBB0000[00000000]
+      return dec;
+    case k21h:  // op vAA, #+BBBB0000[00000000]
       dec.vA = InstAA(inst);
       // The value should be treated as right-zero-extended, but we don't
       // actually do that here. Among other things, we don't know if it's
       // the top bits of a 32- or 64-bit value.
       dec.vB = bytecode[1];
-      break;
-    case kFmt23x:  // op vAA, vBB, vCC
+      return dec;
+    case k23x:  // op vAA, vBB, vCC
       dec.vA = InstAA(inst);
       dec.vB = bytecode[1] & 0xff;
       dec.vC = bytecode[1] >> 8;
-      break;
-    case kFmt22b:  // op vAA, vBB, #+CC
+      return dec;
+    case k22b:  // op vAA, vBB, #+CC
       dec.vA = InstAA(inst);
       dec.vB = bytecode[1] & 0xff;
       dec.vC = s1(bytecode[1] >> 8);  // sign-extend 8-bit value
-      break;
-    case kFmt22s:  // op vA, vB, #+CCCC
-    case kFmt22t:  // op vA, vB, +CCCC
+      return dec;
+    case k22s:  // op vA, vB, #+CCCC
+    case k22t:  // op vA, vB, +CCCC
       dec.vA = InstA(inst);
       dec.vB = InstB(inst);
       dec.vC = s2(bytecode[1]);  // sign-extend 16-bit value
-      break;
-    case kFmt22c:   // op vA, vB, thing@CCCC
-    case kFmt22cs:  // [opt] op vA, vB, field offset CCCC
+      return dec;
+    case k22c:   // op vA, vB, thing@CCCC
+    case k22cs:  // [opt] op vA, vB, field offset CCCC
       dec.vA = InstA(inst);
       dec.vB = InstB(inst);
       dec.vC = bytecode[1];
-      break;
-    case kFmt30t:  // op +AAAAAAAA
+      return dec;
+    case k30t:  // op +AAAAAAAA
       dec.vA = FetchU4(bytecode + 1);
-      break;
-    case kFmt31t:  // op vAA, +BBBBBBBB
-    case kFmt31c:  // op vAA, string@BBBBBBBB
+      return dec;
+    case k31t:  // op vAA, +BBBBBBBB
+    case k31c:  // op vAA, string@BBBBBBBB
       dec.vA = InstAA(inst);
       dec.vB = FetchU4(bytecode + 1);
-      break;
-    case kFmt32x:  // op vAAAA, vBBBB
+      return dec;
+    case k32x:  // op vAAAA, vBBBB
       dec.vA = bytecode[1];
       dec.vB = bytecode[2];
-      break;
-    case kFmt31i:  // op vAA, #+BBBBBBBB
+      return dec;
+    case k31i:  // op vAA, #+BBBBBBBB
       dec.vA = InstAA(inst);
       dec.vB = FetchU4(bytecode + 1);
-      break;
-    case kFmt35c:   // op {vC, vD, vE, vF, vG}, thing@BBBB
-    case kFmt35ms:  // [opt] invoke-virtual+super
-    case kFmt35mi:  // [opt] inline invoke
-    {
+      return dec;
+    case k35c:               // op {vC, vD, vE, vF, vG}, thing@BBBB
+    case k35ms:              // [opt] invoke-virtual+super
+    case k35mi: {            // [opt] inline invoke
       dec.vA = InstB(inst);  // This is labeled A in the spec.
       dec.vB = bytecode[1];
 
@@ -849,49 +246,91 @@ Instruction DecodeInstruction(const u2* bytecode) {
       switch (dec.vA) {
         case 5:
           // A fifth arg is verboten for inline invokes
-          SLICER_CHECK(format != kFmt35mi);
+          SLICER_CHECK_NE(format, k35mi);
 
           // Per note at the top of this format decoder, the
           // fifth argument comes from the A field in the
           // instruction, but it's labeled G in the spec.
           dec.arg[4] = InstA(inst);
-        // fallthrough
+          FALLTHROUGH_INTENDED;
         case 4:
           dec.arg[3] = (regList >> 12) & 0x0f;
-        // fallthrough
+          FALLTHROUGH_INTENDED;
         case 3:
           dec.arg[2] = (regList >> 8) & 0x0f;
-        // fallthrough
+          FALLTHROUGH_INTENDED;
         case 2:
           dec.arg[1] = (regList >> 4) & 0x0f;
-        // fallthrough
+          FALLTHROUGH_INTENDED;
         case 1:
           dec.vC = dec.arg[0] = regList & 0x0f;
-        // fallthrough
+          FALLTHROUGH_INTENDED;
         case 0:
           // Valid, but no need to do anything
-          break;
-        default:
-          SLICER_CHECK(!"Invalid arg count in 35c/35ms/35mi");
-          break;
+          return dec;
       }
-    } break;
-    case kFmt3rc:   // op {vCCCC .. v(CCCC+AA-1)}, meth@BBBB
-    case kFmt3rms:  // [opt] invoke-virtual+super/range
-    case kFmt3rmi:  // [opt] execute-inline/range
+    }
+      SLICER_CHECK(!"Invalid arg count in 35c/35ms/35mi");
+    case k3rc:   // op {vCCCC .. v(CCCC+AA-1)}, meth@BBBB
+    case k3rms:  // [opt] invoke-virtual+super/range
+    case k3rmi:  // [opt] execute-inline/range
       dec.vA = InstAA(inst);
       dec.vB = bytecode[1];
       dec.vC = bytecode[2];
-      break;
-    case kFmt51l:  // op vAA, #+BBBBBBBBBBBBBBBB
+      return dec;
+    case k45cc: {
+      // AG op BBBB FEDC HHHH
+      dec.vA = InstB(inst);  // This is labelled A in the spec.
+      dec.vB = bytecode[1];  // vB meth@BBBB
+
+      u2 regList = bytecode[2];
+      dec.vC = regList & 0xf;
+      dec.arg[0] = (regList >> 4) & 0xf;  // vD
+      dec.arg[1] = (regList >> 8) & 0xf;  // vE
+      dec.arg[2] = (regList >> 12);       // vF
+      dec.arg[3] = InstA(inst);           // vG
+      dec.arg[4] = bytecode[3];           // vH proto@HHHH
+    }
+      return dec;
+    case k4rcc:
+      // AA op BBBB CCCC HHHH
+      dec.vA = InstAA(inst);
+      dec.vB = bytecode[1];
+      dec.vC = bytecode[2];
+      dec.arg[4] = bytecode[3];  // vH proto@HHHH
+      return dec;
+    case k51l:  // op vAA, #+BBBBBBBBBBBBBBBB
       dec.vA = InstAA(inst);
       dec.vB_wide = FetchU8(bytecode + 1);
-      break;
-    default:
-      SLICER_FATAL("Can't decode unexpected format 0x%02x", format);
+      return dec;
   }
 
-  return dec;
+  std::stringstream ss;
+  ss << "Can't decode unexpected format " << format << " for " << opcode;
+  SLICER_FATAL(ss.str());
+}
+
+static inline std::string HexByte(int value) {
+  std::stringstream ss;
+  ss << "0x" << std::setw(2) << std::setfill('0') << std::hex << value;
+  return ss.str();
+}
+
+std::ostream& operator<<(std::ostream& os, Opcode opcode) {
+  return os << "[" << HexByte(opcode) << "] " << gOpcodeNames[opcode];
+}
+
+std::ostream& operator<<(std::ostream& os, InstructionFormat format) {
+  switch (format) {
+  #define EMIT_INSTRUCTION_FORMAT_NAME(name) \
+    case InstructionFormat::k##name: return os << #name;
+  #include "export/slicer/dex_instruction_list.h"
+  DEX_INSTRUCTION_FORMAT_LIST(EMIT_INSTRUCTION_FORMAT_NAME)
+  #undef EMIT_INSTRUCTION_FORMAT_NAME
+  #undef DEX_INSTRUCTION_FORMAT_LIST
+  #undef DEX_INSTRUCTION_LIST
+  }
+  return os << "[" << HexByte(format) << "] " << "Unknown";
 }
 
 }  // namespace dex

--- a/modules/mockk-agent-android/external/slicer/dex_ir.cc
+++ b/modules/mockk-agent-android/external/slicer/dex_ir.cc
@@ -15,17 +15,16 @@
  */
 
 #include "slicer/dex_ir.h"
+
 #include "slicer/chronometer.h"
 #include "slicer/dex_utf8.h"
 #include "slicer/dex_format.h"
 
-#include <algorithm>
 #include <cstdint>
-#include <map>
+#include <algorithm>
 #include <memory>
-#include <vector>
 #include <sstream>
-#include <functional>
+#include <vector>
 
 namespace ir {
 
@@ -109,6 +108,15 @@ std::string Proto::Signature() const {
   return ss.str();
 }
 
+bool MethodHandle::IsField(){
+  return (
+    method_handle_type == dex::METHOD_HANDLE_TYPE_STATIC_PUT ||
+    method_handle_type == dex::METHOD_HANDLE_TYPE_STATIC_GET ||
+    method_handle_type == dex::METHOD_HANDLE_TYPE_INSTANCE_PUT ||
+    method_handle_type == dex::METHOD_HANDLE_TYPE_INSTANCE_GET
+  );
+}
+
 // Helper for IR normalization
 // (it sorts items and update the numeric idexes to match)
 template <class T, class C>
@@ -140,7 +148,7 @@ void DexFile::TopSortClassIndex(Class* irClass, dex::u4* nextIndex) {
       }
     }
 
-    SLICER_CHECK(*nextIndex < classes.size());
+    SLICER_CHECK_LT(*nextIndex, classes.size());
     irClass->index = (*nextIndex)++;
   }
 }
@@ -256,8 +264,8 @@ void DexFile::Normalize() {
   SortClassIndexes();
 
   IndexItems(classes, [&](const own<Class>& a, const own<Class>& b) {
-    SLICER_CHECK(a->index < classes.size());
-    SLICER_CHECK(b->index < classes.size());
+    SLICER_CHECK_LT(a->index, classes.size());
+    SLICER_CHECK_LT(b->index, classes.size());
     SLICER_CHECK(a->index != b->index || a == b);
     return a->index < b->index;
   });

--- a/modules/mockk-agent-android/external/slicer/dex_ir_builder.cc
+++ b/modules/mockk-agent-android/external/slicer/dex_ir_builder.cc
@@ -78,7 +78,7 @@ String* Builder::GetAsciiString(const char* cstr) {
   // update the index -> ir node map
   auto new_index = dex_ir_->strings_indexes.AllocateIndex();
   auto& ir_node = dex_ir_->strings_map[new_index];
-  SLICER_CHECK(ir_node == nullptr);
+  SLICER_CHECK_EQ(ir_node, nullptr);
   ir_node = ir_string;
   ir_string->orig_index = new_index;
 
@@ -106,7 +106,7 @@ Type* Builder::GetType(String* descriptor) {
   // update the index -> ir node map
   auto new_index = dex_ir_->types_indexes.AllocateIndex();
   auto& ir_node = dex_ir_->types_map[new_index];
-  SLICER_CHECK(ir_node == nullptr);
+  SLICER_CHECK_EQ(ir_node, nullptr);
   ir_node = ir_type;
   ir_type->orig_index = new_index;
 
@@ -165,7 +165,7 @@ Proto* Builder::GetProto(Type* return_type, TypeList* param_types) {
   // update the index -> ir node map
   auto new_index = dex_ir_->protos_indexes.AllocateIndex();
   auto& ir_node = dex_ir_->protos_map[new_index];
-  SLICER_CHECK(ir_node == nullptr);
+  SLICER_CHECK_EQ(ir_node, nullptr);
   ir_node = ir_proto;
   ir_proto->orig_index = new_index;
 
@@ -194,7 +194,7 @@ FieldDecl* Builder::GetFieldDecl(String* name, Type* type, Type* parent) {
   // update the index -> ir node map
   auto new_index = dex_ir_->fields_indexes.AllocateIndex();
   auto& ir_node = dex_ir_->fields_map[new_index];
-  SLICER_CHECK(ir_node == nullptr);
+  SLICER_CHECK_EQ(ir_node, nullptr);
   ir_node = ir_field;
   ir_field->orig_index = new_index;
 
@@ -220,7 +220,7 @@ MethodDecl* Builder::GetMethodDecl(String* name, Proto* proto, Type* parent) {
   // update the index -> ir node map
   auto new_index = dex_ir_->methods_indexes.AllocateIndex();
   auto& ir_node = dex_ir_->methods_map[new_index];
-  SLICER_CHECK(ir_node == nullptr);
+  SLICER_CHECK_EQ(ir_node, nullptr);
   ir_node = ir_method;
   ir_method->orig_index = new_index;
 

--- a/modules/mockk-agent-android/external/slicer/export/slicer/arrayview.h
+++ b/modules/mockk-agent-android/external/slicer/export/slicer/arrayview.h
@@ -39,7 +39,7 @@ class ArrayView {
   T* data() const { return begin_; }
 
   T& operator[](size_t i) const {
-    SLICER_CHECK(i < size());
+    SLICER_CHECK_LT(i, size());
     return *(begin_ + i);
   }
 

--- a/modules/mockk-agent-android/external/slicer/export/slicer/buffer.h
+++ b/modules/mockk-agent-android/external/slicer/export/slicer/buffer.h
@@ -16,10 +16,10 @@
 
 #pragma once
 
-#include "common.h"
 #include "arrayview.h"
-#include "memview.h"
+#include "common.h"
 #include "dex_leb128.h"
+#include "memview.h"
 
 #include <assert.h>
 #include <string>
@@ -73,7 +73,7 @@ class Buffer {
   //
   template <class T>
   T* ptr(size_t offset) {
-    SLICER_CHECK(offset + sizeof(T) <= size_);
+    SLICER_CHECK_LE(offset + sizeof(T), size_);
     return reinterpret_cast<T*>(buff_ + offset);
   }
 
@@ -115,7 +115,7 @@ class Buffer {
   }
 
   size_t Push(const Buffer& buff) {
-    SLICER_CHECK(&buff != this);
+    SLICER_CHECK_NE(&buff, this);
     return Push(buff.data(), buff.size());
   }
 
@@ -153,7 +153,7 @@ class Buffer {
   }
 
   const dex::u1* data() const {
-    SLICER_CHECK(buff_ != nullptr);
+    SLICER_CHECK_NE(buff_, nullptr);
     return buff_;
   }
 
@@ -163,7 +163,7 @@ class Buffer {
     if (size_ + size > capacity_) {
       capacity_ = std::max(size_t(capacity_ * 1.5), size_ + size);
       buff_ = static_cast<dex::u1*>(::realloc(buff_, capacity_));
-      SLICER_CHECK(buff_ != nullptr);
+      SLICER_CHECK_NE(buff_, nullptr);
     }
     size_ += size;
   }

--- a/modules/mockk-agent-android/external/slicer/export/slicer/bytecode_encoder.h
+++ b/modules/mockk-agent-android/external/slicer/export/slicer/bytecode_encoder.h
@@ -16,10 +16,10 @@
 
 #pragma once
 
+#include "buffer.h"
 #include "common.h"
 #include "code_ir.h"
 #include "dex_ir.h"
-#include "buffer.h"
 
 #include <assert.h>
 #include <vector>

--- a/modules/mockk-agent-android/external/slicer/export/slicer/chronometer.h
+++ b/modules/mockk-agent-android/external/slicer/export/slicer/chronometer.h
@@ -26,7 +26,7 @@ class Chronometer {
 
  public:
   // elapsed time is in milliseconds
-  Chronometer(double& elapsed, bool cumulative = false) :
+  explicit Chronometer(double& elapsed, bool cumulative = false) :
               elapsed_(elapsed), cumulative_(cumulative) {
     start_time_ = Clock::now();
   }

--- a/modules/mockk-agent-android/external/slicer/export/slicer/code_ir.h
+++ b/modules/mockk-agent-android/external/slicer/export/slicer/code_ir.h
@@ -16,6 +16,12 @@
 
 #pragma once
 
+#if defined(__clang__)
+  #if __has_feature(cxx_rtti)
+    #define RTTI_ENABLED 1
+  #endif
+#endif
+
 #include "common.h"
 #include "memview.h"
 #include "dex_bytecode.h"
@@ -60,6 +66,8 @@ struct String;
 struct Type;
 struct Field;
 struct Method;
+struct MethodHandle;
+struct Proto;
 struct DbgInfoHeader;
 struct LineNumber;
 struct DbgInfoAnnotation;
@@ -96,7 +104,9 @@ class Visitor {
   virtual bool Visit(Type* type) { return false; }
   virtual bool Visit(Field* field) { return false; }
   virtual bool Visit(Method* method) { return false; }
+  virtual bool Visit(Proto* proto) { return false; }
   virtual bool Visit(LineNumber* line) { return false; }
+  virtual bool Visit(MethodHandle* mh) { return false; }
 };
 
 // The root of the polymorphic code IR nodes hierarchy
@@ -114,11 +124,6 @@ struct Node {
   Node& operator=(const Node&) = delete;
 
   virtual bool Accept(Visitor* visitor) { return false; }
-
-  template<class T>
-  bool IsA() const {
-    return dynamic_cast<const T*>(this) != nullptr;
-  }
 };
 
 struct Operand : public Node {};
@@ -130,7 +135,7 @@ struct Const32 : public Operand {
     float float_value;
   } u;
 
-  Const32(dex::u4 value) { u.u4_value = value; }
+  explicit Const32(dex::u4 value) { u.u4_value = value; }
 
   virtual bool Accept(Visitor* visitor) override { return visitor->Visit(this); }
 };
@@ -142,7 +147,7 @@ struct Const64 : public Operand {
     double double_value;
   } u;
 
-  Const64(dex::u8 value) { u.u8_value = value; }
+  explicit Const64(dex::u8 value) { u.u8_value = value; }
 
   virtual bool Accept(Visitor* visitor) override { return visitor->Visit(this); }
 };
@@ -150,7 +155,7 @@ struct Const64 : public Operand {
 struct VReg : public Operand {
   dex::u4 reg;
 
-  VReg(dex::u4 reg) : reg(reg) {}
+  explicit VReg(dex::u4 reg) : reg(reg) {}
 
   virtual bool Accept(Visitor* visitor) override { return visitor->Visit(this); }
 };
@@ -158,7 +163,7 @@ struct VReg : public Operand {
 struct VRegPair : public Operand {
   dex::u4 base_reg;
 
-  VRegPair(dex::u4 base_reg) : base_reg(base_reg) {}
+  explicit VRegPair(dex::u4 base_reg) : base_reg(base_reg) {}
 
   virtual bool Accept(Visitor* visitor) override { return visitor->Visit(this); }
 };
@@ -181,7 +186,7 @@ struct VRegRange : public Operand {
 struct IndexedOperand : public Operand {
   dex::u4 index;
 
-  IndexedOperand(dex::u4 index) : index(index) {}
+  explicit IndexedOperand(dex::u4 index) : index(index) {}
 };
 
 struct String : public IndexedOperand {
@@ -211,7 +216,27 @@ struct Field : public IndexedOperand {
 struct Method : public IndexedOperand {
   ir::MethodDecl* ir_method;
 
-  Method(ir::MethodDecl* ir_method, dex::u4 index) : IndexedOperand(index), ir_method(ir_method) {}
+  Method(ir::MethodDecl* ir_method, dex::u4 index) : IndexedOperand(index), ir_method(ir_method) {
+    SLICER_CHECK_NE(ir_method, nullptr);
+  }
+
+  virtual bool Accept(Visitor* visitor) override { return visitor->Visit(this); }
+};
+
+struct MethodHandle : public IndexedOperand {
+  ir::MethodHandle* ir_method_handle;
+
+  MethodHandle(ir::MethodHandle* ir_method_handle, dex::u4 index) : IndexedOperand(index), ir_method_handle(ir_method_handle) {
+    SLICER_CHECK_NE(ir_method_handle, nullptr);
+  }
+
+  virtual bool Accept(Visitor* visitor) override { return visitor->Visit(this); }
+};
+
+struct Proto : public IndexedOperand {
+  ir::Proto* ir_proto;
+
+  Proto(ir::Proto* ir_proto, dex::u4 index) : IndexedOperand(index), ir_proto(ir_proto) {}
 
   virtual bool Accept(Visitor* visitor) override { return visitor->Visit(this); }
 };
@@ -219,7 +244,7 @@ struct Method : public IndexedOperand {
 struct CodeLocation : public Operand {
   Label* label;
 
-  CodeLocation(Label* label) : label(label) {}
+  explicit CodeLocation(Label* label) : label(label) {}
 
   virtual bool Accept(Visitor* visitor) override { return visitor->Visit(this); }
 };
@@ -235,15 +260,82 @@ struct Instruction : public Node {
 
 using InstructionsList = slicer::IntrusiveList<Instruction>;
 
+namespace detail {
+
+template<class T>
+inline T* CastOperand(Operand* op) {
+#ifdef RTTI_ENABLED
+  T* operand = dynamic_cast<T*>(op);
+  SLICER_CHECK_NE(operand, nullptr);
+  return operand;
+#else
+  SLICER_CHECK_NE(op, nullptr);
+  struct CastVisitor : public Visitor {
+    T* converted = nullptr;
+    bool Visit(T* val) override {
+      converted = val;
+      return true;
+    }
+  };
+  CastVisitor cv;
+  op->Accept(&cv);
+  SLICER_CHECK_NE(cv.converted, nullptr);
+  return cv.converted;
+#endif
+}
+
+// Special-case for IndexedOperand.
+template<>
+inline IndexedOperand* CastOperand<IndexedOperand>(Operand* op) {
+#ifdef RTTI_ENABLED
+  IndexedOperand* operand = dynamic_cast<IndexedOperand*>(op);
+  SLICER_CHECK_NE(operand, nullptr);
+  return operand;
+#else
+  SLICER_CHECK_NE(op, nullptr);
+  struct CastVisitor : public Visitor {
+    IndexedOperand* converted = nullptr;
+    bool Visit(String* val) override {
+      converted = val;
+      return true;
+    }
+    bool Visit(Type* val) override {
+      converted = val;
+      return true;
+    }
+    bool Visit(Field* val) override {
+      converted = val;
+      return true;
+    }
+    bool Visit(Method* val) override {
+      converted = val;
+      return true;
+    }
+    bool Visit(MethodHandle* val) override {
+      converted = val;
+      return true;
+    }
+    bool Visit(Proto* val) override {
+      converted = val;
+      return true;
+    }
+  };
+  CastVisitor cv;
+  op->Accept(&cv);
+  SLICER_CHECK_NE(cv.converted, nullptr);
+  return cv.converted;
+#endif
+}
+
+}  // namespace detail
+
 struct Bytecode : public Instruction {
   dex::Opcode opcode = dex::OP_NOP;
   std::vector<Operand*> operands;
 
   template<class T>
   T* CastOperand(int index) const {
-    T* operand = dynamic_cast<T*>(operands[index]);
-    SLICER_CHECK(operand != nullptr);
-    return operand;
+    return detail::CastOperand<T>(operands[index]);
   }
 
   virtual bool Accept(Visitor* visitor) override { return visitor->Visit(this); }
@@ -278,7 +370,7 @@ struct Label : public Instruction {
   int refCount = 0;
   bool aligned = false;
 
-  Label(dex::u4 offset) { this->offset = offset; }
+  explicit Label(dex::u4 offset) { this->offset = offset; }
 
   virtual bool Accept(Visitor* visitor) override { return visitor->Visit(this); }
 };
@@ -311,8 +403,8 @@ struct DbgInfoHeader : public Instruction {
 struct LineNumber : public Operand {
   int line = 0;
 
-  LineNumber(int line) : line(line) {
-    SLICER_WEAK_CHECK(line > 0);
+  explicit LineNumber(int line) : line(line) {
+    SLICER_WEAK_CHECK(line >= 0);
   }
 
   virtual bool Accept(Visitor* visitor) override { return visitor->Visit(this); }
@@ -322,13 +414,11 @@ struct DbgInfoAnnotation : public Instruction {
   dex::u1 dbg_opcode = 0;
   std::vector<Operand*> operands;
 
-  DbgInfoAnnotation(dex::u1 dbg_opcode) : dbg_opcode(dbg_opcode) {}
+  explicit DbgInfoAnnotation(dex::u1 dbg_opcode) : dbg_opcode(dbg_opcode) {}
 
   template<class T>
   T* CastOperand(int index) const {
-    T* operand = dynamic_cast<T*>(operands[index]);
-    SLICER_CHECK(operand != nullptr);
-    return operand;
+    return detail::CastOperand<T>(operands[index]);
   }
 
   virtual bool Accept(Visitor* visitor) override { return visitor->Visit(this); }
@@ -345,7 +435,7 @@ struct CodeIr {
  public:
   CodeIr(ir::EncodedMethod* ir_method, std::shared_ptr<ir::DexFile> dex_ir)
       : ir_method(ir_method), dex_ir(dex_ir) {
-    Dissasemble();
+    Disassemble();
   }
 
   // No copy/move semantics
@@ -368,10 +458,10 @@ struct CodeIr {
   }
 
  private:
-  void Dissasemble();
-  void DissasembleBytecode(const ir::Code* ir_code);
-  void DissasembleTryBlocks(const ir::Code* ir_code);
-  void DissasembleDebugInfo(const ir::DebugInfo* ir_debug_info);
+  void Disassemble();
+  void DisassembleBytecode(const ir::Code* ir_code);
+  void DisassembleTryBlocks(const ir::Code* ir_code);
+  void DisassembleDebugInfo(const ir::DebugInfo* ir_debug_info);
 
   void FixupSwitches();
   void FixupPackedSwitch(PackedSwitchPayload* instr, dex::u4 base_offset, const dex::u2* ptr);
@@ -383,6 +473,7 @@ struct CodeIr {
   Bytecode* DecodeBytecode(const dex::u2* ptr, dex::u4 offset);
 
   IndexedOperand* GetIndexedOperand(dex::InstructionIndexType index_type, dex::u4 index);
+  IndexedOperand* GetSecondIndexedOperand(dex::InstructionIndexType index_type, dex::u4 index);
 
   Type* GetType(dex::u4 index);
   String* GetString(dex::u4 index);

--- a/modules/mockk-agent-android/external/slicer/export/slicer/common.h
+++ b/modules/mockk-agent-android/external/slicer/export/slicer/common.h
@@ -16,12 +16,39 @@
 
 #pragma once
 
+#include <stdint.h>
+#include <string>
+
 namespace slicer {
 
 // Encapsulate the runtime check and error reporting policy.
 // (currently a simple fail-fast but the the intention is to allow customization)
 void _checkFailed(const char* expr, int line, const char* file) __attribute__((noreturn));
 #define SLICER_CHECK(expr) do { if(!(expr)) slicer::_checkFailed(#expr, __LINE__, __FILE__); } while(false)
+
+// Helper methods for SLICER_CHECK_OP macro.
+void _checkFailedOp(const void* lhs, const void* rhs, const char* op, const char* suffix,
+                    int line, const char* file)
+  __attribute__((noreturn));
+void _checkFailedOp(uint32_t lhs, uint32_t rhs, const char* op, const char* suffix, int line,
+                    const char* file)
+  __attribute__((noreturn));
+
+#define SLICER_CHECK_OP(lhs, rhs, op, suffix) \
+  do { \
+    if (!((lhs) op (rhs))) { \
+      slicer::_checkFailedOp(lhs, rhs, #op, suffix, __LINE__, __FILE__); \
+    } \
+  } while(false)
+
+// Macros that check the binary relation between two values. If the relation is not true,
+// the values are logged and the process aborts.
+#define SLICER_CHECK_EQ(a, b) SLICER_CHECK_OP(a, b, ==, "EQ")
+#define SLICER_CHECK_NE(a, b) SLICER_CHECK_OP(a, b, !=, "NE")
+#define SLICER_CHECK_LT(a, b) SLICER_CHECK_OP(a, b,  <, "LT")
+#define SLICER_CHECK_LE(a, b) SLICER_CHECK_OP(a, b, <=, "LE")
+#define SLICER_CHECK_GT(a, b) SLICER_CHECK_OP(a, b,  >, "GT")
+#define SLICER_CHECK_GE(a, b) SLICER_CHECK_OP(a, b, >=, "GE")
 
 // A modal check: if the strict mode is enabled, it behaves as a SLICER_CHECK,
 // otherwise it will only log a warning and continue
@@ -34,8 +61,8 @@ void _weakCheckFailed(const char* expr, int line, const char* file);
 #define SLICER_WEAK_CHECK(expr) do { if(!(expr)) slicer::_weakCheckFailed(#expr, __LINE__, __FILE__); } while(false)
 
 // Report a fatal condition with a printf-formatted message
-void _fatal(const char* format, ...) __attribute__((noreturn));
-#define SLICER_FATAL(format, ...) slicer::_fatal("\nSLICER_FATAL: " format "\n\n", ##__VA_ARGS__);
+void _fatal(const std::string& msg) __attribute__((noreturn));
+#define SLICER_FATAL(msg) slicer::_fatal(msg)
 
 // Annotation customization point for extra validation / state.
 #ifdef NDEBUG
@@ -43,6 +70,20 @@ void _fatal(const char* format, ...) __attribute__((noreturn));
 #else
 #define SLICER_EXTRA(x) x
 #endif
+
+#ifndef FALLTHROUGH_INTENDED
+#ifdef __clang__
+#define FALLTHROUGH_INTENDED [[clang::fallthrough]]
+#else
+#define FALLTHROUGH_INTENDED
+#endif // __clang__
+#endif // FALLTHROUGH_INTENDED
+
+typedef void (*logger_type)(const std::string&);
+
+// By default, slicer prints error messages to stdout. Users can set their own
+// callback.
+void set_logger(const logger_type new_logger);
 
 } // namespace slicer
 

--- a/modules/mockk-agent-android/external/slicer/export/slicer/control_flow_graph.h
+++ b/modules/mockk-agent-android/external/slicer/export/slicer/control_flow_graph.h
@@ -16,8 +16,8 @@
 
 #pragma once
 
-#include "common.h"
 #include "code_ir.h"
+#include "common.h"
 
 #include <vector>
 

--- a/modules/mockk-agent-android/external/slicer/export/slicer/debuginfo_encoder.h
+++ b/modules/mockk-agent-android/external/slicer/export/slicer/debuginfo_encoder.h
@@ -16,11 +16,11 @@
 
 #pragma once
 
+#include "buffer.h"
+#include "chronometer.h"
 #include "common.h"
 #include "code_ir.h"
 #include "dex_ir.h"
-#include "buffer.h"
-#include "chronometer.h"
 
 #include <vector>
 

--- a/modules/mockk-agent-android/external/slicer/export/slicer/dex_bytecode.h
+++ b/modules/mockk-agent-android/external/slicer/export/slicer/dex_bytecode.h
@@ -18,6 +18,7 @@
 
 #include "dex_format.h"
 
+#include <iosfwd>
 #include <stddef.h>
 
 // .dex bytecode definitions and helpers:
@@ -35,338 +36,98 @@ constexpr u2 kPackedSwitchSignature = 0x0100;
 constexpr u2 kSparseSwitchSignature = 0x0200;
 constexpr u2 kArrayDataSignature = 0x0300;
 
+// Include for  DEX_INSTRUCTION_LIST and DEX_INSTRUCTION_FORMAT_LIST
+#include "dex_instruction_list.h"
+
 // Enumeration of all Dalvik opcodes
 enum Opcode : u1 {
-  OP_NOP = 0x00,
-  OP_MOVE = 0x01,
-  OP_MOVE_FROM16 = 0x02,
-  OP_MOVE_16 = 0x03,
-  OP_MOVE_WIDE = 0x04,
-  OP_MOVE_WIDE_FROM16 = 0x05,
-  OP_MOVE_WIDE_16 = 0x06,
-  OP_MOVE_OBJECT = 0x07,
-  OP_MOVE_OBJECT_FROM16 = 0x08,
-  OP_MOVE_OBJECT_16 = 0x09,
-  OP_MOVE_RESULT = 0x0a,
-  OP_MOVE_RESULT_WIDE = 0x0b,
-  OP_MOVE_RESULT_OBJECT = 0x0c,
-  OP_MOVE_EXCEPTION = 0x0d,
-  OP_RETURN_VOID = 0x0e,
-  OP_RETURN = 0x0f,
-  OP_RETURN_WIDE = 0x10,
-  OP_RETURN_OBJECT = 0x11,
-  OP_CONST_4 = 0x12,
-  OP_CONST_16 = 0x13,
-  OP_CONST = 0x14,
-  OP_CONST_HIGH16 = 0x15,
-  OP_CONST_WIDE_16 = 0x16,
-  OP_CONST_WIDE_32 = 0x17,
-  OP_CONST_WIDE = 0x18,
-  OP_CONST_WIDE_HIGH16 = 0x19,
-  OP_CONST_STRING = 0x1a,
-  OP_CONST_STRING_JUMBO = 0x1b,
-  OP_CONST_CLASS = 0x1c,
-  OP_MONITOR_ENTER = 0x1d,
-  OP_MONITOR_EXIT = 0x1e,
-  OP_CHECK_CAST = 0x1f,
-  OP_INSTANCE_OF = 0x20,
-  OP_ARRAY_LENGTH = 0x21,
-  OP_NEW_INSTANCE = 0x22,
-  OP_NEW_ARRAY = 0x23,
-  OP_FILLED_NEW_ARRAY = 0x24,
-  OP_FILLED_NEW_ARRAY_RANGE = 0x25,
-  OP_FILL_ARRAY_DATA = 0x26,
-  OP_THROW = 0x27,
-  OP_GOTO = 0x28,
-  OP_GOTO_16 = 0x29,
-  OP_GOTO_32 = 0x2a,
-  OP_PACKED_SWITCH = 0x2b,
-  OP_SPARSE_SWITCH = 0x2c,
-  OP_CMPL_FLOAT = 0x2d,
-  OP_CMPG_FLOAT = 0x2e,
-  OP_CMPL_DOUBLE = 0x2f,
-  OP_CMPG_DOUBLE = 0x30,
-  OP_CMP_LONG = 0x31,
-  OP_IF_EQ = 0x32,
-  OP_IF_NE = 0x33,
-  OP_IF_LT = 0x34,
-  OP_IF_GE = 0x35,
-  OP_IF_GT = 0x36,
-  OP_IF_LE = 0x37,
-  OP_IF_EQZ = 0x38,
-  OP_IF_NEZ = 0x39,
-  OP_IF_LTZ = 0x3a,
-  OP_IF_GEZ = 0x3b,
-  OP_IF_GTZ = 0x3c,
-  OP_IF_LEZ = 0x3d,
-  OP_UNUSED_3E = 0x3e,
-  OP_UNUSED_3F = 0x3f,
-  OP_UNUSED_40 = 0x40,
-  OP_UNUSED_41 = 0x41,
-  OP_UNUSED_42 = 0x42,
-  OP_UNUSED_43 = 0x43,
-  OP_AGET = 0x44,
-  OP_AGET_WIDE = 0x45,
-  OP_AGET_OBJECT = 0x46,
-  OP_AGET_BOOLEAN = 0x47,
-  OP_AGET_BYTE = 0x48,
-  OP_AGET_CHAR = 0x49,
-  OP_AGET_SHORT = 0x4a,
-  OP_APUT = 0x4b,
-  OP_APUT_WIDE = 0x4c,
-  OP_APUT_OBJECT = 0x4d,
-  OP_APUT_BOOLEAN = 0x4e,
-  OP_APUT_BYTE = 0x4f,
-  OP_APUT_CHAR = 0x50,
-  OP_APUT_SHORT = 0x51,
-  OP_IGET = 0x52,
-  OP_IGET_WIDE = 0x53,
-  OP_IGET_OBJECT = 0x54,
-  OP_IGET_BOOLEAN = 0x55,
-  OP_IGET_BYTE = 0x56,
-  OP_IGET_CHAR = 0x57,
-  OP_IGET_SHORT = 0x58,
-  OP_IPUT = 0x59,
-  OP_IPUT_WIDE = 0x5a,
-  OP_IPUT_OBJECT = 0x5b,
-  OP_IPUT_BOOLEAN = 0x5c,
-  OP_IPUT_BYTE = 0x5d,
-  OP_IPUT_CHAR = 0x5e,
-  OP_IPUT_SHORT = 0x5f,
-  OP_SGET = 0x60,
-  OP_SGET_WIDE = 0x61,
-  OP_SGET_OBJECT = 0x62,
-  OP_SGET_BOOLEAN = 0x63,
-  OP_SGET_BYTE = 0x64,
-  OP_SGET_CHAR = 0x65,
-  OP_SGET_SHORT = 0x66,
-  OP_SPUT = 0x67,
-  OP_SPUT_WIDE = 0x68,
-  OP_SPUT_OBJECT = 0x69,
-  OP_SPUT_BOOLEAN = 0x6a,
-  OP_SPUT_BYTE = 0x6b,
-  OP_SPUT_CHAR = 0x6c,
-  OP_SPUT_SHORT = 0x6d,
-  OP_INVOKE_VIRTUAL = 0x6e,
-  OP_INVOKE_SUPER = 0x6f,
-  OP_INVOKE_DIRECT = 0x70,
-  OP_INVOKE_STATIC = 0x71,
-  OP_INVOKE_INTERFACE = 0x72,
-  OP_UNUSED_73 = 0x73,
-  OP_INVOKE_VIRTUAL_RANGE = 0x74,
-  OP_INVOKE_SUPER_RANGE = 0x75,
-  OP_INVOKE_DIRECT_RANGE = 0x76,
-  OP_INVOKE_STATIC_RANGE = 0x77,
-  OP_INVOKE_INTERFACE_RANGE = 0x78,
-  OP_UNUSED_79 = 0x79,
-  OP_UNUSED_7A = 0x7a,
-  OP_NEG_INT = 0x7b,
-  OP_NOT_INT = 0x7c,
-  OP_NEG_LONG = 0x7d,
-  OP_NOT_LONG = 0x7e,
-  OP_NEG_FLOAT = 0x7f,
-  OP_NEG_DOUBLE = 0x80,
-  OP_INT_TO_LONG = 0x81,
-  OP_INT_TO_FLOAT = 0x82,
-  OP_INT_TO_DOUBLE = 0x83,
-  OP_LONG_TO_INT = 0x84,
-  OP_LONG_TO_FLOAT = 0x85,
-  OP_LONG_TO_DOUBLE = 0x86,
-  OP_FLOAT_TO_INT = 0x87,
-  OP_FLOAT_TO_LONG = 0x88,
-  OP_FLOAT_TO_DOUBLE = 0x89,
-  OP_DOUBLE_TO_INT = 0x8a,
-  OP_DOUBLE_TO_LONG = 0x8b,
-  OP_DOUBLE_TO_FLOAT = 0x8c,
-  OP_INT_TO_BYTE = 0x8d,
-  OP_INT_TO_CHAR = 0x8e,
-  OP_INT_TO_SHORT = 0x8f,
-  OP_ADD_INT = 0x90,
-  OP_SUB_INT = 0x91,
-  OP_MUL_INT = 0x92,
-  OP_DIV_INT = 0x93,
-  OP_REM_INT = 0x94,
-  OP_AND_INT = 0x95,
-  OP_OR_INT = 0x96,
-  OP_XOR_INT = 0x97,
-  OP_SHL_INT = 0x98,
-  OP_SHR_INT = 0x99,
-  OP_USHR_INT = 0x9a,
-  OP_ADD_LONG = 0x9b,
-  OP_SUB_LONG = 0x9c,
-  OP_MUL_LONG = 0x9d,
-  OP_DIV_LONG = 0x9e,
-  OP_REM_LONG = 0x9f,
-  OP_AND_LONG = 0xa0,
-  OP_OR_LONG = 0xa1,
-  OP_XOR_LONG = 0xa2,
-  OP_SHL_LONG = 0xa3,
-  OP_SHR_LONG = 0xa4,
-  OP_USHR_LONG = 0xa5,
-  OP_ADD_FLOAT = 0xa6,
-  OP_SUB_FLOAT = 0xa7,
-  OP_MUL_FLOAT = 0xa8,
-  OP_DIV_FLOAT = 0xa9,
-  OP_REM_FLOAT = 0xaa,
-  OP_ADD_DOUBLE = 0xab,
-  OP_SUB_DOUBLE = 0xac,
-  OP_MUL_DOUBLE = 0xad,
-  OP_DIV_DOUBLE = 0xae,
-  OP_REM_DOUBLE = 0xaf,
-  OP_ADD_INT_2ADDR = 0xb0,
-  OP_SUB_INT_2ADDR = 0xb1,
-  OP_MUL_INT_2ADDR = 0xb2,
-  OP_DIV_INT_2ADDR = 0xb3,
-  OP_REM_INT_2ADDR = 0xb4,
-  OP_AND_INT_2ADDR = 0xb5,
-  OP_OR_INT_2ADDR = 0xb6,
-  OP_XOR_INT_2ADDR = 0xb7,
-  OP_SHL_INT_2ADDR = 0xb8,
-  OP_SHR_INT_2ADDR = 0xb9,
-  OP_USHR_INT_2ADDR = 0xba,
-  OP_ADD_LONG_2ADDR = 0xbb,
-  OP_SUB_LONG_2ADDR = 0xbc,
-  OP_MUL_LONG_2ADDR = 0xbd,
-  OP_DIV_LONG_2ADDR = 0xbe,
-  OP_REM_LONG_2ADDR = 0xbf,
-  OP_AND_LONG_2ADDR = 0xc0,
-  OP_OR_LONG_2ADDR = 0xc1,
-  OP_XOR_LONG_2ADDR = 0xc2,
-  OP_SHL_LONG_2ADDR = 0xc3,
-  OP_SHR_LONG_2ADDR = 0xc4,
-  OP_USHR_LONG_2ADDR = 0xc5,
-  OP_ADD_FLOAT_2ADDR = 0xc6,
-  OP_SUB_FLOAT_2ADDR = 0xc7,
-  OP_MUL_FLOAT_2ADDR = 0xc8,
-  OP_DIV_FLOAT_2ADDR = 0xc9,
-  OP_REM_FLOAT_2ADDR = 0xca,
-  OP_ADD_DOUBLE_2ADDR = 0xcb,
-  OP_SUB_DOUBLE_2ADDR = 0xcc,
-  OP_MUL_DOUBLE_2ADDR = 0xcd,
-  OP_DIV_DOUBLE_2ADDR = 0xce,
-  OP_REM_DOUBLE_2ADDR = 0xcf,
-  OP_ADD_INT_LIT16 = 0xd0,
-  OP_RSUB_INT = 0xd1,
-  OP_MUL_INT_LIT16 = 0xd2,
-  OP_DIV_INT_LIT16 = 0xd3,
-  OP_REM_INT_LIT16 = 0xd4,
-  OP_AND_INT_LIT16 = 0xd5,
-  OP_OR_INT_LIT16 = 0xd6,
-  OP_XOR_INT_LIT16 = 0xd7,
-  OP_ADD_INT_LIT8 = 0xd8,
-  OP_RSUB_INT_LIT8 = 0xd9,
-  OP_MUL_INT_LIT8 = 0xda,
-  OP_DIV_INT_LIT8 = 0xdb,
-  OP_REM_INT_LIT8 = 0xdc,
-  OP_AND_INT_LIT8 = 0xdd,
-  OP_OR_INT_LIT8 = 0xde,
-  OP_XOR_INT_LIT8 = 0xdf,
-  OP_SHL_INT_LIT8 = 0xe0,
-  OP_SHR_INT_LIT8 = 0xe1,
-  OP_USHR_INT_LIT8 = 0xe2,
-  OP_IGET_VOLATILE = 0xe3,
-  OP_IPUT_VOLATILE = 0xe4,
-  OP_SGET_VOLATILE = 0xe5,
-  OP_SPUT_VOLATILE = 0xe6,
-  OP_IGET_OBJECT_VOLATILE = 0xe7,
-  OP_IGET_WIDE_VOLATILE = 0xe8,
-  OP_IPUT_WIDE_VOLATILE = 0xe9,
-  OP_SGET_WIDE_VOLATILE = 0xea,
-  OP_SPUT_WIDE_VOLATILE = 0xeb,
-  OP_BREAKPOINT = 0xec,
-  OP_THROW_VERIFICATION_ERROR = 0xed,
-  OP_EXECUTE_INLINE = 0xee,
-  OP_EXECUTE_INLINE_RANGE = 0xef,
-  OP_INVOKE_OBJECT_INIT_RANGE = 0xf0,
-  OP_RETURN_VOID_BARRIER = 0xf1,
-  OP_IGET_QUICK = 0xf2,
-  OP_IGET_WIDE_QUICK = 0xf3,
-  OP_IGET_OBJECT_QUICK = 0xf4,
-  OP_IPUT_QUICK = 0xf5,
-  OP_IPUT_WIDE_QUICK = 0xf6,
-  OP_IPUT_OBJECT_QUICK = 0xf7,
-  OP_INVOKE_VIRTUAL_QUICK = 0xf8,
-  OP_INVOKE_VIRTUAL_QUICK_RANGE = 0xf9,
-  OP_INVOKE_SUPER_QUICK = 0xfa,
-  OP_INVOKE_SUPER_QUICK_RANGE = 0xfb,
-  OP_IPUT_OBJECT_VOLATILE = 0xfc,
-  OP_SGET_OBJECT_VOLATILE = 0xfd,
-  OP_SPUT_OBJECT_VOLATILE = 0xfe,
-  OP_UNUSED_FF = 0xff,
+#define INSTRUCTION_ENUM(opcode, cname, ...) OP_##cname = (opcode),
+  DEX_INSTRUCTION_LIST(INSTRUCTION_ENUM)
+#undef INSTRUCTION_ENUM
 };
 
 // Instruction formats associated with Dalvik opcodes
 enum InstructionFormat : u1 {
-  kFmt00x = 0,  // unknown format (also used for "breakpoint" opcode)
-  kFmt10x,      // op
-  kFmt12x,      // op vA, vB
-  kFmt11n,      // op vA, #+B
-  kFmt11x,      // op vAA
-  kFmt10t,      // op +AA
-  kFmt20bc,     // [opt] op AA, thing@BBBB
-  kFmt20t,      // op +AAAA
-  kFmt22x,      // op vAA, vBBBB
-  kFmt21t,      // op vAA, +BBBB
-  kFmt21s,      // op vAA, #+BBBB
-  kFmt21h,      // op vAA, #+BBBB00000[00000000]
-  kFmt21c,      // op vAA, thing@BBBB
-  kFmt23x,      // op vAA, vBB, vCC
-  kFmt22b,      // op vAA, vBB, #+CC
-  kFmt22t,      // op vA, vB, +CCCC
-  kFmt22s,      // op vA, vB, #+CCCC
-  kFmt22c,      // op vA, vB, thing@CCCC
-  kFmt22cs,     // [opt] op vA, vB, field offset CCCC
-  kFmt30t,      // op +AAAAAAAA
-  kFmt32x,      // op vAAAA, vBBBB
-  kFmt31i,      // op vAA, #+BBBBBBBB
-  kFmt31t,      // op vAA, +BBBBBBBB
-  kFmt31c,      // op vAA, string@BBBBBBBB
-  kFmt35c,      // op {vC,vD,vE,vF,vG}, thing@BBBB
-  kFmt35ms,     // [opt] invoke-virtual+super
-  kFmt3rc,      // op {vCCCC .. v(CCCC+AA-1)}, thing@BBBB
-  kFmt3rms,     // [opt] invoke-virtual+super/range
-  kFmt51l,      // op vAA, #+BBBBBBBBBBBBBBBB
-  kFmt35mi,     // [opt] inline invoke
-  kFmt3rmi,     // [opt] inline invoke/range
+#define INSTRUCTION_FORMAT_ENUM(name) k##name,
+#include "dex_instruction_list.h"
+  DEX_INSTRUCTION_FORMAT_LIST(INSTRUCTION_FORMAT_ENUM)
+#undef INSTRUCTION_FORMAT_ENUM
 };
 
-using OpcodeFlags = u4;
+#undef DEX_INSTRUCTION_FORMAT_LIST
+#undef DEX_INSTRUCTION_LIST
 
+using OpcodeFlags = u1;
 enum : OpcodeFlags {
-  kInstrCanBranch     = 1 << 0,   // conditional or unconditional branch
-  kInstrCanContinue   = 1 << 1,   // flow can continue to next statement
-  kInstrCanSwitch     = 1 << 2,   // switch statement
-  kInstrCanThrow      = 1 << 3,   // could cause an exception to be thrown
-  kInstrCanReturn     = 1 << 4,   // returns, no additional statements
-  kInstrInvoke        = 1 << 5,   // a flavor of invoke
-  kInstrWideRegA      = 1 << 6,   // wide (64bit) vA
-  kInstrWideRegB      = 1 << 7,   // wide (64bit) vB
-  kInstrWideRegC      = 1 << 8,   // wide (64bit) vC
+  kBranch = 0x01,         // conditional or unconditional branch
+  kContinue = 0x02,       // flow can continue to next statement
+  kSwitch = 0x04,         // switch statement
+  kThrow = 0x08,          // could cause an exception to be thrown
+  kReturn = 0x10,         // returns, no additional statements
+  kInvoke = 0x20,         // a flavor of invoke
+  kUnconditional = 0x40,  // unconditional branch
+  kExperimental = 0x80,   // is an experimental opcode
+};
+
+using VerifyFlags = u4;
+enum : VerifyFlags {
+  kVerifyNothing = 0x0000000,
+  kVerifyRegA = 0x0000001,
+  kVerifyRegAWide = 0x0000002,
+  kVerifyRegB = 0x0000004,
+  kVerifyRegBField = 0x0000008,
+  kVerifyRegBMethod = 0x0000010,
+  kVerifyRegBNewInstance = 0x0000020,
+  kVerifyRegBString = 0x0000040,
+  kVerifyRegBType = 0x0000080,
+  kVerifyRegBWide = 0x0000100,
+  kVerifyRegC = 0x0000200,
+  kVerifyRegCField = 0x0000400,
+  kVerifyRegCNewArray = 0x0000800,
+  kVerifyRegCType = 0x0001000,
+  kVerifyRegCWide = 0x0002000,
+  kVerifyArrayData = 0x0004000,
+  kVerifyBranchTarget = 0x0008000,
+  kVerifySwitchTargets = 0x0010000,
+  kVerifyVarArg = 0x0020000,
+  kVerifyVarArgNonZero = 0x0040000,
+  kVerifyVarArgRange = 0x0080000,
+  kVerifyVarArgRangeNonZero = 0x0100000,
+  kVerifyRuntimeOnly = 0x0200000,
+  kVerifyError = 0x0400000,
+  kVerifyRegHPrototype = 0x0800000,
+  kVerifyRegBCallSite = 0x1000000,
+  kVerifyRegBMethodHandle = 0x2000000,
+  kVerifyRegBPrototype = 0x4000000,
 };
 
 // Types of indexed reference that are associated with opcodes whose
 // formats include such an indexed reference (e.g., 21c and 35c).
 enum InstructionIndexType : u1 {
   kIndexUnknown = 0,
-  kIndexNone,          // has no index
-  kIndexVaries,        // "It depends." Used for throw-verification-error
-  kIndexTypeRef,       // type reference index
-  kIndexStringRef,     // string reference index
-  kIndexMethodRef,     // method reference index
-  kIndexFieldRef,      // field reference index
-  kIndexInlineMethod,  // inline method index (for inline linked methods)
-  kIndexVtableOffset,  // vtable offset (for static linked methods)
-  kIndexFieldOffset    // field offset (for static linked fields)
+  kIndexNone,               // has no index
+  kIndexVaries,             // "It depends." Used for throw-verification-error
+  kIndexTypeRef,            // type reference index
+  kIndexStringRef,          // string reference index
+  kIndexMethodRef,          // method reference index
+  kIndexFieldRef,           // field reference index
+  kIndexInlineMethod,       // inline method index (for inline linked methods)
+  kIndexVtableOffset,       // vtable offset (for static linked methods)
+  kIndexFieldOffset,        // field offset (for static linked fields)
+  kIndexMethodAndProtoRef,  // method index and proto index
+  kIndexCallSiteRef,        // call site index
+  kIndexMethodHandleRef,    // constant method handle reference index
+  kIndexProtoRef,           // constant prototype reference index
 };
 
 // Holds the contents of a decoded instruction.
 struct Instruction {
-  u4 vA;                // the A field of the instruction
-  u4 vB;                // the B field of the instruction
-  u8 vB_wide;           // 64bit version of the B field (for kFmt51l)
-  u4 vC;                // the C field of the instruction
-  u4 arg[5];            // vC/D/E/F/G in invoke or filled-new-array
-  Opcode opcode;        // instruction opcode
+  u4 vA;          // the A field of the instruction
+  u4 vB;          // the B field of the instruction
+  u8 vB_wide;     // 64bit version of the B field (for k51l)
+  u4 vC;          // the C field of the instruction
+  u4 arg[5];      // vC/D/E/F/G in invoke or filled-new-array
+  Opcode opcode;  // instruction opcode
 };
 
 // "packed-switch-payload" format
@@ -392,6 +153,14 @@ struct ArrayData {
   u1 data[];
 };
 
+// Collect the enums in a struct for better locality.
+struct InstructionDescriptor {
+  u4 verify_flags;  // Set of VerifyFlag.
+  InstructionFormat format;
+  InstructionIndexType index_type;
+  u1 flags;  // Set of Flags.
+};
+
 // Extracts the opcode from a Dalvik code unit (bytecode)
 Opcode OpcodeFromBytecode(u2 bytecode);
 
@@ -407,8 +176,11 @@ InstructionFormat GetFormatFromOpcode(Opcode opcode);
 // Returns the flags for the specified opcode
 OpcodeFlags GetFlagsFromOpcode(Opcode opcode);
 
-// Returns the instruction width for the specified opcode
-size_t GetWidthFromOpcode(Opcode opcode);
+// Returns the verify flags for the specified opcode
+VerifyFlags GetVerifyFlagsFromOpcode(Opcode opcode);
+
+// Returns the instruction width for the specified opcode format
+size_t GetWidthFromFormat(InstructionFormat format);
 
 // Return the width of the specified instruction, or 0 if not defined.  Also
 // works for special OP_NOP entries, including switch statement data tables
@@ -417,5 +189,11 @@ size_t GetWidthFromBytecode(const u2* bytecode);
 
 // Decode a .dex bytecode
 Instruction DecodeInstruction(const u2* bytecode);
+
+// Writes a hex formatted opcode to an output stream.
+std::ostream& operator<<(std::ostream& os, Opcode opcode);
+
+// Writes name of format to an outputstream.
+std::ostream& operator<<(std::ostream& os, InstructionFormat format);
 
 }  // namespace dex

--- a/modules/mockk-agent-android/external/slicer/export/slicer/dex_instruction_list.h
+++ b/modules/mockk-agent-android/external/slicer/export/slicer/dex_instruction_list.h
@@ -1,0 +1,318 @@
+/*
+ * Copyright (C) 2019 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef ART_LIBDEXFILE_DEX_DEX_INSTRUCTION_LIST_H_
+#define ART_LIBDEXFILE_DEX_DEX_INSTRUCTION_LIST_H_
+
+/**
+ * Cloned from //art/libdexfile/dex/dex_instruction_list.h.
+ */
+
+// V(opcode, instruction_code, name, format, index, flags, extended_flags, verifier_flags);
+#define DEX_INSTRUCTION_LIST(V) \
+  V(0x00, NOP, "nop", k10x, kIndexNone, kContinue, 0, kVerifyNothing) \
+  V(0x01, MOVE, "move", k12x, kIndexNone, kContinue, 0, kVerifyRegA | kVerifyRegB) \
+  V(0x02, MOVE_FROM16, "move/from16", k22x, kIndexNone, kContinue, 0, kVerifyRegA | kVerifyRegB) \
+  V(0x03, MOVE_16, "move/16", k32x, kIndexNone, kContinue, 0, kVerifyRegA | kVerifyRegB) \
+  V(0x04, MOVE_WIDE, "move-wide", k12x, kIndexNone, kContinue, 0, kVerifyRegAWide | kVerifyRegBWide) \
+  V(0x05, MOVE_WIDE_FROM16, "move-wide/from16", k22x, kIndexNone, kContinue, 0, kVerifyRegAWide | kVerifyRegBWide) \
+  V(0x06, MOVE_WIDE_16, "move-wide/16", k32x, kIndexNone, kContinue, 0, kVerifyRegAWide | kVerifyRegBWide) \
+  V(0x07, MOVE_OBJECT, "move-object", k12x, kIndexNone, kContinue, 0, kVerifyRegA | kVerifyRegB) \
+  V(0x08, MOVE_OBJECT_FROM16, "move-object/from16", k22x, kIndexNone, kContinue, 0, kVerifyRegA | kVerifyRegB) \
+  V(0x09, MOVE_OBJECT_16, "move-object/16", k32x, kIndexNone, kContinue, 0, kVerifyRegA | kVerifyRegB) \
+  V(0x0A, MOVE_RESULT, "move-result", k11x, kIndexNone, kContinue, 0, kVerifyRegA) \
+  V(0x0B, MOVE_RESULT_WIDE, "move-result-wide", k11x, kIndexNone, kContinue, 0, kVerifyRegAWide) \
+  V(0x0C, MOVE_RESULT_OBJECT, "move-result-object", k11x, kIndexNone, kContinue, 0, kVerifyRegA) \
+  V(0x0D, MOVE_EXCEPTION, "move-exception", k11x, kIndexNone, kContinue, 0, kVerifyRegA) \
+  V(0x0E, RETURN_VOID, "return-void", k10x, kIndexNone, kReturn, 0, kVerifyNothing) \
+  V(0x0F, RETURN, "return", k11x, kIndexNone, kReturn, 0, kVerifyRegA) \
+  V(0x10, RETURN_WIDE, "return-wide", k11x, kIndexNone, kReturn, 0, kVerifyRegAWide) \
+  V(0x11, RETURN_OBJECT, "return-object", k11x, kIndexNone, kReturn, 0, kVerifyRegA) \
+  V(0x12, CONST_4, "const/4", k11n, kIndexNone, kContinue, kRegBFieldOrConstant, kVerifyRegA) \
+  V(0x13, CONST_16, "const/16", k21s, kIndexNone, kContinue, kRegBFieldOrConstant, kVerifyRegA) \
+  V(0x14, CONST, "const", k31i, kIndexNone, kContinue, kRegBFieldOrConstant, kVerifyRegA) \
+  V(0x15, CONST_HIGH16, "const/high16", k21h, kIndexNone, kContinue, kRegBFieldOrConstant, kVerifyRegA) \
+  V(0x16, CONST_WIDE_16, "const-wide/16", k21s, kIndexNone, kContinue, kRegBFieldOrConstant, kVerifyRegAWide) \
+  V(0x17, CONST_WIDE_32, "const-wide/32", k31i, kIndexNone, kContinue, kRegBFieldOrConstant, kVerifyRegAWide) \
+  V(0x18, CONST_WIDE, "const-wide", k51l, kIndexNone, kContinue, kRegBFieldOrConstant, kVerifyRegAWide) \
+  V(0x19, CONST_WIDE_HIGH16, "const-wide/high16", k21h, kIndexNone, kContinue, kRegBFieldOrConstant, kVerifyRegAWide) \
+  V(0x1A, CONST_STRING, "const-string", k21c, kIndexStringRef, kContinue | kThrow, 0, kVerifyRegA | kVerifyRegBString) \
+  V(0x1B, CONST_STRING_JUMBO, "const-string/jumbo", k31c, kIndexStringRef, kContinue | kThrow, 0, kVerifyRegA | kVerifyRegBString) \
+  V(0x1C, CONST_CLASS, "const-class", k21c, kIndexTypeRef, kContinue | kThrow, 0, kVerifyRegA | kVerifyRegBType) \
+  V(0x1D, MONITOR_ENTER, "monitor-enter", k11x, kIndexNone, kContinue | kThrow, kClobber, kVerifyRegA) \
+  V(0x1E, MONITOR_EXIT, "monitor-exit", k11x, kIndexNone, kContinue | kThrow, kClobber, kVerifyRegA) \
+  V(0x1F, CHECK_CAST, "check-cast", k21c, kIndexTypeRef, kContinue | kThrow, 0, kVerifyRegA | kVerifyRegBType) \
+  V(0x20, INSTANCE_OF, "instance-of", k22c, kIndexTypeRef, kContinue | kThrow, 0, kVerifyRegA | kVerifyRegB | kVerifyRegCType) \
+  V(0x21, ARRAY_LENGTH, "array-length", k12x, kIndexNone, kContinue | kThrow, 0, kVerifyRegA | kVerifyRegB) \
+  V(0x22, NEW_INSTANCE, "new-instance", k21c, kIndexTypeRef, kContinue | kThrow, kClobber, kVerifyRegA | kVerifyRegBNewInstance) \
+  V(0x23, NEW_ARRAY, "new-array", k22c, kIndexTypeRef, kContinue | kThrow, kClobber, kVerifyRegA | kVerifyRegB | kVerifyRegCNewArray) \
+  V(0x24, FILLED_NEW_ARRAY, "filled-new-array", k35c, kIndexTypeRef, kContinue | kThrow, kClobber, kVerifyRegBType | kVerifyVarArg) \
+  V(0x25, FILLED_NEW_ARRAY_RANGE, "filled-new-array/range", k3rc, kIndexTypeRef, kContinue | kThrow, kClobber, kVerifyRegBType | kVerifyVarArgRange) \
+  V(0x26, FILL_ARRAY_DATA, "fill-array-data", k31t, kIndexNone, kContinue | kThrow, kClobber, kVerifyRegA | kVerifyArrayData) \
+  V(0x27, THROW, "throw", k11x, kIndexNone, kThrow, 0, kVerifyRegA) \
+  V(0x28, GOTO, "goto", k10t, kIndexNone, kBranch | kUnconditional, 0, kVerifyBranchTarget) \
+  V(0x29, GOTO_16, "goto/16", k20t, kIndexNone, kBranch | kUnconditional, 0, kVerifyBranchTarget) \
+  V(0x2A, GOTO_32, "goto/32", k30t, kIndexNone, kBranch | kUnconditional, 0, kVerifyBranchTarget) \
+  V(0x2B, PACKED_SWITCH, "packed-switch", k31t, kIndexNone, kContinue | kSwitch, 0, kVerifyRegA | kVerifySwitchTargets) \
+  V(0x2C, SPARSE_SWITCH, "sparse-switch", k31t, kIndexNone, kContinue | kSwitch, 0, kVerifyRegA | kVerifySwitchTargets) \
+  V(0x2D, CMPL_FLOAT, "cmpl-float", k23x, kIndexNone, kContinue, 0, kVerifyRegA | kVerifyRegB | kVerifyRegC) \
+  V(0x2E, CMPG_FLOAT, "cmpg-float", k23x, kIndexNone, kContinue, 0, kVerifyRegA | kVerifyRegB | kVerifyRegC) \
+  V(0x2F, CMPL_DOUBLE, "cmpl-double", k23x, kIndexNone, kContinue, 0, kVerifyRegA | kVerifyRegBWide | kVerifyRegCWide) \
+  V(0x30, CMPG_DOUBLE, "cmpg-double", k23x, kIndexNone, kContinue, 0, kVerifyRegA | kVerifyRegBWide | kVerifyRegCWide) \
+  V(0x31, CMP_LONG, "cmp-long", k23x, kIndexNone, kContinue, 0, kVerifyRegA | kVerifyRegBWide | kVerifyRegCWide) \
+  V(0x32, IF_EQ, "if-eq", k22t, kIndexNone, kContinue | kBranch, 0, kVerifyRegA | kVerifyRegB | kVerifyBranchTarget) \
+  V(0x33, IF_NE, "if-ne", k22t, kIndexNone, kContinue | kBranch, 0, kVerifyRegA | kVerifyRegB | kVerifyBranchTarget) \
+  V(0x34, IF_LT, "if-lt", k22t, kIndexNone, kContinue | kBranch, 0, kVerifyRegA | kVerifyRegB | kVerifyBranchTarget) \
+  V(0x35, IF_GE, "if-ge", k22t, kIndexNone, kContinue | kBranch, 0, kVerifyRegA | kVerifyRegB | kVerifyBranchTarget) \
+  V(0x36, IF_GT, "if-gt", k22t, kIndexNone, kContinue | kBranch, 0, kVerifyRegA | kVerifyRegB | kVerifyBranchTarget) \
+  V(0x37, IF_LE, "if-le", k22t, kIndexNone, kContinue | kBranch, 0, kVerifyRegA | kVerifyRegB | kVerifyBranchTarget) \
+  V(0x38, IF_EQZ, "if-eqz", k21t, kIndexNone, kContinue | kBranch, 0, kVerifyRegA | kVerifyBranchTarget) \
+  V(0x39, IF_NEZ, "if-nez", k21t, kIndexNone, kContinue | kBranch, 0, kVerifyRegA | kVerifyBranchTarget) \
+  V(0x3A, IF_LTZ, "if-ltz", k21t, kIndexNone, kContinue | kBranch, 0, kVerifyRegA | kVerifyBranchTarget) \
+  V(0x3B, IF_GEZ, "if-gez", k21t, kIndexNone, kContinue | kBranch, 0, kVerifyRegA | kVerifyBranchTarget) \
+  V(0x3C, IF_GTZ, "if-gtz", k21t, kIndexNone, kContinue | kBranch, 0, kVerifyRegA | kVerifyBranchTarget) \
+  V(0x3D, IF_LEZ, "if-lez", k21t, kIndexNone, kContinue | kBranch, 0, kVerifyRegA | kVerifyBranchTarget) \
+  V(0x3E, UNUSED_3E, "unused-3e", k10x, kIndexUnknown, 0, 0, kVerifyError) \
+  V(0x3F, UNUSED_3F, "unused-3f", k10x, kIndexUnknown, 0, 0, kVerifyError) \
+  V(0x40, UNUSED_40, "unused-40", k10x, kIndexUnknown, 0, 0, kVerifyError) \
+  V(0x41, UNUSED_41, "unused-41", k10x, kIndexUnknown, 0, 0, kVerifyError) \
+  V(0x42, UNUSED_42, "unused-42", k10x, kIndexUnknown, 0, 0, kVerifyError) \
+  V(0x43, UNUSED_43, "unused-43", k10x, kIndexUnknown, 0, 0, kVerifyError) \
+  V(0x44, AGET, "aget", k23x, kIndexNone, kContinue | kThrow, kLoad, kVerifyRegA | kVerifyRegB | kVerifyRegC) \
+  V(0x45, AGET_WIDE, "aget-wide", k23x, kIndexNone, kContinue | kThrow, kLoad, kVerifyRegAWide | kVerifyRegB | kVerifyRegC) \
+  V(0x46, AGET_OBJECT, "aget-object", k23x, kIndexNone, kContinue | kThrow, kLoad, kVerifyRegA | kVerifyRegB | kVerifyRegC) \
+  V(0x47, AGET_BOOLEAN, "aget-boolean", k23x, kIndexNone, kContinue | kThrow, kLoad, kVerifyRegA | kVerifyRegB | kVerifyRegC) \
+  V(0x48, AGET_BYTE, "aget-byte", k23x, kIndexNone, kContinue | kThrow, kLoad, kVerifyRegA | kVerifyRegB | kVerifyRegC) \
+  V(0x49, AGET_CHAR, "aget-char", k23x, kIndexNone, kContinue | kThrow, kLoad, kVerifyRegA | kVerifyRegB | kVerifyRegC) \
+  V(0x4A, AGET_SHORT, "aget-short", k23x, kIndexNone, kContinue | kThrow, kLoad, kVerifyRegA | kVerifyRegB | kVerifyRegC) \
+  V(0x4B, APUT, "aput", k23x, kIndexNone, kContinue | kThrow, kStore, kVerifyRegA | kVerifyRegB | kVerifyRegC) \
+  V(0x4C, APUT_WIDE, "aput-wide", k23x, kIndexNone, kContinue | kThrow, kStore, kVerifyRegAWide | kVerifyRegB | kVerifyRegC) \
+  V(0x4D, APUT_OBJECT, "aput-object", k23x, kIndexNone, kContinue | kThrow, kStore, kVerifyRegA | kVerifyRegB | kVerifyRegC) \
+  V(0x4E, APUT_BOOLEAN, "aput-boolean", k23x, kIndexNone, kContinue | kThrow, kStore, kVerifyRegA | kVerifyRegB | kVerifyRegC) \
+  V(0x4F, APUT_BYTE, "aput-byte", k23x, kIndexNone, kContinue | kThrow, kStore, kVerifyRegA | kVerifyRegB | kVerifyRegC) \
+  V(0x50, APUT_CHAR, "aput-char", k23x, kIndexNone, kContinue | kThrow, kStore, kVerifyRegA | kVerifyRegB | kVerifyRegC) \
+  V(0x51, APUT_SHORT, "aput-short", k23x, kIndexNone, kContinue | kThrow, kStore, kVerifyRegA | kVerifyRegB | kVerifyRegC) \
+  V(0x52, IGET, "iget", k22c, kIndexFieldRef, kContinue | kThrow, kLoad | kRegCFieldOrConstant, kVerifyRegA | kVerifyRegB | kVerifyRegCField) \
+  V(0x53, IGET_WIDE, "iget-wide", k22c, kIndexFieldRef, kContinue | kThrow, kLoad | kRegCFieldOrConstant, kVerifyRegAWide | kVerifyRegB | kVerifyRegCField) \
+  V(0x54, IGET_OBJECT, "iget-object", k22c, kIndexFieldRef, kContinue | kThrow, kLoad | kRegCFieldOrConstant, kVerifyRegA | kVerifyRegB | kVerifyRegCField) \
+  V(0x55, IGET_BOOLEAN, "iget-boolean", k22c, kIndexFieldRef, kContinue | kThrow, kLoad | kRegCFieldOrConstant, kVerifyRegA | kVerifyRegB | kVerifyRegCField) \
+  V(0x56, IGET_BYTE, "iget-byte", k22c, kIndexFieldRef, kContinue | kThrow, kLoad | kRegCFieldOrConstant, kVerifyRegA | kVerifyRegB | kVerifyRegCField) \
+  V(0x57, IGET_CHAR, "iget-char", k22c, kIndexFieldRef, kContinue | kThrow, kLoad | kRegCFieldOrConstant, kVerifyRegA | kVerifyRegB | kVerifyRegCField) \
+  V(0x58, IGET_SHORT, "iget-short", k22c, kIndexFieldRef, kContinue | kThrow, kLoad | kRegCFieldOrConstant, kVerifyRegA | kVerifyRegB | kVerifyRegCField) \
+  V(0x59, IPUT, "iput", k22c, kIndexFieldRef, kContinue | kThrow, kStore | kRegCFieldOrConstant, kVerifyRegA | kVerifyRegB | kVerifyRegCField) \
+  V(0x5A, IPUT_WIDE, "iput-wide", k22c, kIndexFieldRef, kContinue | kThrow, kStore | kRegCFieldOrConstant, kVerifyRegAWide | kVerifyRegB | kVerifyRegCField) \
+  V(0x5B, IPUT_OBJECT, "iput-object", k22c, kIndexFieldRef, kContinue | kThrow, kStore | kRegCFieldOrConstant, kVerifyRegA | kVerifyRegB | kVerifyRegCField) \
+  V(0x5C, IPUT_BOOLEAN, "iput-boolean", k22c, kIndexFieldRef, kContinue | kThrow, kStore | kRegCFieldOrConstant, kVerifyRegA | kVerifyRegB | kVerifyRegCField) \
+  V(0x5D, IPUT_BYTE, "iput-byte", k22c, kIndexFieldRef, kContinue | kThrow, kStore | kRegCFieldOrConstant, kVerifyRegA | kVerifyRegB | kVerifyRegCField) \
+  V(0x5E, IPUT_CHAR, "iput-char", k22c, kIndexFieldRef, kContinue | kThrow, kStore | kRegCFieldOrConstant, kVerifyRegA | kVerifyRegB | kVerifyRegCField) \
+  V(0x5F, IPUT_SHORT, "iput-short", k22c, kIndexFieldRef, kContinue | kThrow, kStore | kRegCFieldOrConstant, kVerifyRegA | kVerifyRegB | kVerifyRegCField) \
+  V(0x60, SGET, "sget", k21c, kIndexFieldRef, kContinue | kThrow, kLoad | kRegBFieldOrConstant, kVerifyRegA | kVerifyRegBField) \
+  V(0x61, SGET_WIDE, "sget-wide", k21c, kIndexFieldRef, kContinue | kThrow, kLoad | kRegBFieldOrConstant, kVerifyRegAWide | kVerifyRegBField) \
+  V(0x62, SGET_OBJECT, "sget-object", k21c, kIndexFieldRef, kContinue | kThrow, kLoad | kRegBFieldOrConstant, kVerifyRegA | kVerifyRegBField) \
+  V(0x63, SGET_BOOLEAN, "sget-boolean", k21c, kIndexFieldRef, kContinue | kThrow, kLoad | kRegBFieldOrConstant, kVerifyRegA | kVerifyRegBField) \
+  V(0x64, SGET_BYTE, "sget-byte", k21c, kIndexFieldRef, kContinue | kThrow, kLoad | kRegBFieldOrConstant, kVerifyRegA | kVerifyRegBField) \
+  V(0x65, SGET_CHAR, "sget-char", k21c, kIndexFieldRef, kContinue | kThrow, kLoad | kRegBFieldOrConstant, kVerifyRegA | kVerifyRegBField) \
+  V(0x66, SGET_SHORT, "sget-short", k21c, kIndexFieldRef, kContinue | kThrow, kLoad | kRegBFieldOrConstant, kVerifyRegA | kVerifyRegBField) \
+  V(0x67, SPUT, "sput", k21c, kIndexFieldRef, kContinue | kThrow, kStore | kRegBFieldOrConstant, kVerifyRegA | kVerifyRegBField) \
+  V(0x68, SPUT_WIDE, "sput-wide", k21c, kIndexFieldRef, kContinue | kThrow, kStore | kRegBFieldOrConstant, kVerifyRegAWide | kVerifyRegBField) \
+  V(0x69, SPUT_OBJECT, "sput-object", k21c, kIndexFieldRef, kContinue | kThrow, kStore | kRegBFieldOrConstant, kVerifyRegA | kVerifyRegBField) \
+  V(0x6A, SPUT_BOOLEAN, "sput-boolean", k21c, kIndexFieldRef, kContinue | kThrow, kStore | kRegBFieldOrConstant, kVerifyRegA | kVerifyRegBField) \
+  V(0x6B, SPUT_BYTE, "sput-byte", k21c, kIndexFieldRef, kContinue | kThrow, kStore | kRegBFieldOrConstant, kVerifyRegA | kVerifyRegBField) \
+  V(0x6C, SPUT_CHAR, "sput-char", k21c, kIndexFieldRef, kContinue | kThrow, kStore | kRegBFieldOrConstant, kVerifyRegA | kVerifyRegBField) \
+  V(0x6D, SPUT_SHORT, "sput-short", k21c, kIndexFieldRef, kContinue | kThrow, kStore | kRegBFieldOrConstant, kVerifyRegA | kVerifyRegBField) \
+  V(0x6E, INVOKE_VIRTUAL, "invoke-virtual", k35c, kIndexMethodRef, kContinue | kThrow | kInvoke, 0, kVerifyRegBMethod | kVerifyVarArgNonZero) \
+  V(0x6F, INVOKE_SUPER, "invoke-super", k35c, kIndexMethodRef, kContinue | kThrow | kInvoke, 0, kVerifyRegBMethod | kVerifyVarArgNonZero) \
+  V(0x70, INVOKE_DIRECT, "invoke-direct", k35c, kIndexMethodRef, kContinue | kThrow | kInvoke, 0, kVerifyRegBMethod | kVerifyVarArgNonZero) \
+  V(0x71, INVOKE_STATIC, "invoke-static", k35c, kIndexMethodRef, kContinue | kThrow | kInvoke, 0, kVerifyRegBMethod | kVerifyVarArg) \
+  V(0x72, INVOKE_INTERFACE, "invoke-interface", k35c, kIndexMethodRef, kContinue | kThrow | kInvoke, 0, kVerifyRegBMethod | kVerifyVarArgNonZero) \
+  V(0x73, RETURN_VOID_NO_BARRIER, "return-void-no-barrier", k10x, kIndexNone, kReturn, 0, kVerifyNothing) \
+  V(0x74, INVOKE_VIRTUAL_RANGE, "invoke-virtual/range", k3rc, kIndexMethodRef, kContinue | kThrow | kInvoke, 0, kVerifyRegBMethod | kVerifyVarArgRangeNonZero) \
+  V(0x75, INVOKE_SUPER_RANGE, "invoke-super/range", k3rc, kIndexMethodRef, kContinue | kThrow | kInvoke, 0, kVerifyRegBMethod | kVerifyVarArgRangeNonZero) \
+  V(0x76, INVOKE_DIRECT_RANGE, "invoke-direct/range", k3rc, kIndexMethodRef, kContinue | kThrow | kInvoke, 0, kVerifyRegBMethod | kVerifyVarArgRangeNonZero) \
+  V(0x77, INVOKE_STATIC_RANGE, "invoke-static/range", k3rc, kIndexMethodRef, kContinue | kThrow | kInvoke, 0, kVerifyRegBMethod | kVerifyVarArgRange) \
+  V(0x78, INVOKE_INTERFACE_RANGE, "invoke-interface/range", k3rc, kIndexMethodRef, kContinue | kThrow | kInvoke, 0, kVerifyRegBMethod | kVerifyVarArgRangeNonZero) \
+  V(0x79, UNUSED_79, "unused-79", k10x, kIndexUnknown, 0, 0, kVerifyError) \
+  V(0x7A, UNUSED_7A, "unused-7a", k10x, kIndexUnknown, 0, 0, kVerifyError) \
+  V(0x7B, NEG_INT, "neg-int", k12x, kIndexNone, kContinue, 0, kVerifyRegA | kVerifyRegB) \
+  V(0x7C, NOT_INT, "not-int", k12x, kIndexNone, kContinue, 0, kVerifyRegA | kVerifyRegB) \
+  V(0x7D, NEG_LONG, "neg-long", k12x, kIndexNone, kContinue, 0, kVerifyRegAWide | kVerifyRegBWide) \
+  V(0x7E, NOT_LONG, "not-long", k12x, kIndexNone, kContinue, 0, kVerifyRegAWide | kVerifyRegBWide) \
+  V(0x7F, NEG_FLOAT, "neg-float", k12x, kIndexNone, kContinue, 0, kVerifyRegA | kVerifyRegB) \
+  V(0x80, NEG_DOUBLE, "neg-double", k12x, kIndexNone, kContinue, 0, kVerifyRegAWide | kVerifyRegBWide) \
+  V(0x81, INT_TO_LONG, "int-to-long", k12x, kIndexNone, kContinue, kCast, kVerifyRegAWide | kVerifyRegB) \
+  V(0x82, INT_TO_FLOAT, "int-to-float", k12x, kIndexNone, kContinue, kCast, kVerifyRegA | kVerifyRegB) \
+  V(0x83, INT_TO_DOUBLE, "int-to-double", k12x, kIndexNone, kContinue, kCast, kVerifyRegAWide | kVerifyRegB) \
+  V(0x84, LONG_TO_INT, "long-to-int", k12x, kIndexNone, kContinue, kCast, kVerifyRegA | kVerifyRegBWide) \
+  V(0x85, LONG_TO_FLOAT, "long-to-float", k12x, kIndexNone, kContinue, kCast, kVerifyRegA | kVerifyRegBWide) \
+  V(0x86, LONG_TO_DOUBLE, "long-to-double", k12x, kIndexNone, kContinue, kCast, kVerifyRegAWide | kVerifyRegBWide) \
+  V(0x87, FLOAT_TO_INT, "float-to-int", k12x, kIndexNone, kContinue, kCast, kVerifyRegA | kVerifyRegB) \
+  V(0x88, FLOAT_TO_LONG, "float-to-long", k12x, kIndexNone, kContinue, kCast, kVerifyRegAWide | kVerifyRegB) \
+  V(0x89, FLOAT_TO_DOUBLE, "float-to-double", k12x, kIndexNone, kContinue, kCast, kVerifyRegAWide | kVerifyRegB) \
+  V(0x8A, DOUBLE_TO_INT, "double-to-int", k12x, kIndexNone, kContinue, kCast, kVerifyRegA | kVerifyRegBWide) \
+  V(0x8B, DOUBLE_TO_LONG, "double-to-long", k12x, kIndexNone, kContinue, kCast, kVerifyRegAWide | kVerifyRegBWide) \
+  V(0x8C, DOUBLE_TO_FLOAT, "double-to-float", k12x, kIndexNone, kContinue, kCast, kVerifyRegA | kVerifyRegBWide) \
+  V(0x8D, INT_TO_BYTE, "int-to-byte", k12x, kIndexNone, kContinue, kCast, kVerifyRegA | kVerifyRegB) \
+  V(0x8E, INT_TO_CHAR, "int-to-char", k12x, kIndexNone, kContinue, kCast, kVerifyRegA | kVerifyRegB) \
+  V(0x8F, INT_TO_SHORT, "int-to-short", k12x, kIndexNone, kContinue, kCast, kVerifyRegA | kVerifyRegB) \
+  V(0x90, ADD_INT, "add-int", k23x, kIndexNone, kContinue, kAdd, kVerifyRegA | kVerifyRegB | kVerifyRegC) \
+  V(0x91, SUB_INT, "sub-int", k23x, kIndexNone, kContinue, kSubtract, kVerifyRegA | kVerifyRegB | kVerifyRegC) \
+  V(0x92, MUL_INT, "mul-int", k23x, kIndexNone, kContinue, kMultiply, kVerifyRegA | kVerifyRegB | kVerifyRegC) \
+  V(0x93, DIV_INT, "div-int", k23x, kIndexNone, kContinue | kThrow, kDivide, kVerifyRegA | kVerifyRegB | kVerifyRegC) \
+  V(0x94, REM_INT, "rem-int", k23x, kIndexNone, kContinue | kThrow, kRemainder, kVerifyRegA | kVerifyRegB | kVerifyRegC) \
+  V(0x95, AND_INT, "and-int", k23x, kIndexNone, kContinue, kAnd, kVerifyRegA | kVerifyRegB | kVerifyRegC) \
+  V(0x96, OR_INT, "or-int", k23x, kIndexNone, kContinue, kOr, kVerifyRegA | kVerifyRegB | kVerifyRegC) \
+  V(0x97, XOR_INT, "xor-int", k23x, kIndexNone, kContinue, kXor, kVerifyRegA | kVerifyRegB | kVerifyRegC) \
+  V(0x98, SHL_INT, "shl-int", k23x, kIndexNone, kContinue, kShl, kVerifyRegA | kVerifyRegB | kVerifyRegC) \
+  V(0x99, SHR_INT, "shr-int", k23x, kIndexNone, kContinue, kShr, kVerifyRegA | kVerifyRegB | kVerifyRegC) \
+  V(0x9A, USHR_INT, "ushr-int", k23x, kIndexNone, kContinue, kUshr, kVerifyRegA | kVerifyRegB | kVerifyRegC) \
+  V(0x9B, ADD_LONG, "add-long", k23x, kIndexNone, kContinue, kAdd, kVerifyRegAWide | kVerifyRegBWide | kVerifyRegCWide) \
+  V(0x9C, SUB_LONG, "sub-long", k23x, kIndexNone, kContinue, kSubtract, kVerifyRegAWide | kVerifyRegBWide | kVerifyRegCWide) \
+  V(0x9D, MUL_LONG, "mul-long", k23x, kIndexNone, kContinue, kMultiply, kVerifyRegAWide | kVerifyRegBWide | kVerifyRegCWide) \
+  V(0x9E, DIV_LONG, "div-long", k23x, kIndexNone, kContinue | kThrow, kDivide, kVerifyRegAWide | kVerifyRegBWide | kVerifyRegCWide) \
+  V(0x9F, REM_LONG, "rem-long", k23x, kIndexNone, kContinue | kThrow, kRemainder, kVerifyRegAWide | kVerifyRegBWide | kVerifyRegCWide) \
+  V(0xA0, AND_LONG, "and-long", k23x, kIndexNone, kContinue, kAnd, kVerifyRegAWide | kVerifyRegBWide | kVerifyRegCWide) \
+  V(0xA1, OR_LONG, "or-long", k23x, kIndexNone, kContinue, kOr, kVerifyRegAWide | kVerifyRegBWide | kVerifyRegCWide) \
+  V(0xA2, XOR_LONG, "xor-long", k23x, kIndexNone, kContinue, kXor, kVerifyRegAWide | kVerifyRegBWide | kVerifyRegCWide) \
+  V(0xA3, SHL_LONG, "shl-long", k23x, kIndexNone, kContinue, kShl, kVerifyRegAWide | kVerifyRegBWide | kVerifyRegC) \
+  V(0xA4, SHR_LONG, "shr-long", k23x, kIndexNone, kContinue, kShr, kVerifyRegAWide | kVerifyRegBWide | kVerifyRegC) \
+  V(0xA5, USHR_LONG, "ushr-long", k23x, kIndexNone, kContinue, kUshr, kVerifyRegAWide | kVerifyRegBWide | kVerifyRegC) \
+  V(0xA6, ADD_FLOAT, "add-float", k23x, kIndexNone, kContinue, kAdd, kVerifyRegA | kVerifyRegB | kVerifyRegC) \
+  V(0xA7, SUB_FLOAT, "sub-float", k23x, kIndexNone, kContinue, kSubtract, kVerifyRegA | kVerifyRegB | kVerifyRegC) \
+  V(0xA8, MUL_FLOAT, "mul-float", k23x, kIndexNone, kContinue, kMultiply, kVerifyRegA | kVerifyRegB | kVerifyRegC) \
+  V(0xA9, DIV_FLOAT, "div-float", k23x, kIndexNone, kContinue, kDivide, kVerifyRegA | kVerifyRegB | kVerifyRegC) \
+  V(0xAA, REM_FLOAT, "rem-float", k23x, kIndexNone, kContinue, kRemainder, kVerifyRegA | kVerifyRegB | kVerifyRegC) \
+  V(0xAB, ADD_DOUBLE, "add-double", k23x, kIndexNone, kContinue, kAdd, kVerifyRegAWide | kVerifyRegBWide | kVerifyRegCWide) \
+  V(0xAC, SUB_DOUBLE, "sub-double", k23x, kIndexNone, kContinue, kSubtract, kVerifyRegAWide | kVerifyRegBWide | kVerifyRegCWide) \
+  V(0xAD, MUL_DOUBLE, "mul-double", k23x, kIndexNone, kContinue, kMultiply, kVerifyRegAWide | kVerifyRegBWide | kVerifyRegCWide) \
+  V(0xAE, DIV_DOUBLE, "div-double", k23x, kIndexNone, kContinue, kDivide, kVerifyRegAWide | kVerifyRegBWide | kVerifyRegCWide) \
+  V(0xAF, REM_DOUBLE, "rem-double", k23x, kIndexNone, kContinue, kRemainder, kVerifyRegAWide | kVerifyRegBWide | kVerifyRegCWide) \
+  V(0xB0, ADD_INT_2ADDR, "add-int/2addr", k12x, kIndexNone, kContinue, kAdd, kVerifyRegA | kVerifyRegB) \
+  V(0xB1, SUB_INT_2ADDR, "sub-int/2addr", k12x, kIndexNone, kContinue, kSubtract, kVerifyRegA | kVerifyRegB) \
+  V(0xB2, MUL_INT_2ADDR, "mul-int/2addr", k12x, kIndexNone, kContinue, kMultiply, kVerifyRegA | kVerifyRegB) \
+  V(0xB3, DIV_INT_2ADDR, "div-int/2addr", k12x, kIndexNone, kContinue | kThrow, kDivide, kVerifyRegA | kVerifyRegB) \
+  V(0xB4, REM_INT_2ADDR, "rem-int/2addr", k12x, kIndexNone, kContinue | kThrow, kRemainder, kVerifyRegA | kVerifyRegB) \
+  V(0xB5, AND_INT_2ADDR, "and-int/2addr", k12x, kIndexNone, kContinue, kAnd, kVerifyRegA | kVerifyRegB) \
+  V(0xB6, OR_INT_2ADDR, "or-int/2addr", k12x, kIndexNone, kContinue, kOr, kVerifyRegA | kVerifyRegB) \
+  V(0xB7, XOR_INT_2ADDR, "xor-int/2addr", k12x, kIndexNone, kContinue, kXor, kVerifyRegA | kVerifyRegB) \
+  V(0xB8, SHL_INT_2ADDR, "shl-int/2addr", k12x, kIndexNone, kContinue, kShl, kVerifyRegA | kVerifyRegB) \
+  V(0xB9, SHR_INT_2ADDR, "shr-int/2addr", k12x, kIndexNone, kContinue, kShr, kVerifyRegA | kVerifyRegB) \
+  V(0xBA, USHR_INT_2ADDR, "ushr-int/2addr", k12x, kIndexNone, kContinue, kUshr, kVerifyRegA | kVerifyRegB) \
+  V(0xBB, ADD_LONG_2ADDR, "add-long/2addr", k12x, kIndexNone, kContinue, kAdd, kVerifyRegAWide | kVerifyRegBWide) \
+  V(0xBC, SUB_LONG_2ADDR, "sub-long/2addr", k12x, kIndexNone, kContinue, kSubtract, kVerifyRegAWide | kVerifyRegBWide) \
+  V(0xBD, MUL_LONG_2ADDR, "mul-long/2addr", k12x, kIndexNone, kContinue, kMultiply, kVerifyRegAWide | kVerifyRegBWide) \
+  V(0xBE, DIV_LONG_2ADDR, "div-long/2addr", k12x, kIndexNone, kContinue | kThrow, kDivide, kVerifyRegAWide | kVerifyRegBWide) \
+  V(0xBF, REM_LONG_2ADDR, "rem-long/2addr", k12x, kIndexNone, kContinue | kThrow, kRemainder, kVerifyRegAWide | kVerifyRegBWide) \
+  V(0xC0, AND_LONG_2ADDR, "and-long/2addr", k12x, kIndexNone, kContinue, kAnd, kVerifyRegAWide | kVerifyRegBWide) \
+  V(0xC1, OR_LONG_2ADDR, "or-long/2addr", k12x, kIndexNone, kContinue, kOr, kVerifyRegAWide | kVerifyRegBWide) \
+  V(0xC2, XOR_LONG_2ADDR, "xor-long/2addr", k12x, kIndexNone, kContinue, kXor, kVerifyRegAWide | kVerifyRegBWide) \
+  V(0xC3, SHL_LONG_2ADDR, "shl-long/2addr", k12x, kIndexNone, kContinue, kShl, kVerifyRegAWide | kVerifyRegB) \
+  V(0xC4, SHR_LONG_2ADDR, "shr-long/2addr", k12x, kIndexNone, kContinue, kShr, kVerifyRegAWide | kVerifyRegB) \
+  V(0xC5, USHR_LONG_2ADDR, "ushr-long/2addr", k12x, kIndexNone, kContinue, kUshr, kVerifyRegAWide | kVerifyRegB) \
+  V(0xC6, ADD_FLOAT_2ADDR, "add-float/2addr", k12x, kIndexNone, kContinue, kAdd, kVerifyRegA | kVerifyRegB) \
+  V(0xC7, SUB_FLOAT_2ADDR, "sub-float/2addr", k12x, kIndexNone, kContinue, kSubtract, kVerifyRegA | kVerifyRegB) \
+  V(0xC8, MUL_FLOAT_2ADDR, "mul-float/2addr", k12x, kIndexNone, kContinue, kMultiply, kVerifyRegA | kVerifyRegB) \
+  V(0xC9, DIV_FLOAT_2ADDR, "div-float/2addr", k12x, kIndexNone, kContinue, kDivide, kVerifyRegA | kVerifyRegB) \
+  V(0xCA, REM_FLOAT_2ADDR, "rem-float/2addr", k12x, kIndexNone, kContinue, kRemainder, kVerifyRegA | kVerifyRegB) \
+  V(0xCB, ADD_DOUBLE_2ADDR, "add-double/2addr", k12x, kIndexNone, kContinue, kAdd, kVerifyRegAWide | kVerifyRegBWide) \
+  V(0xCC, SUB_DOUBLE_2ADDR, "sub-double/2addr", k12x, kIndexNone, kContinue, kSubtract, kVerifyRegAWide | kVerifyRegBWide) \
+  V(0xCD, MUL_DOUBLE_2ADDR, "mul-double/2addr", k12x, kIndexNone, kContinue, kMultiply, kVerifyRegAWide | kVerifyRegBWide) \
+  V(0xCE, DIV_DOUBLE_2ADDR, "div-double/2addr", k12x, kIndexNone, kContinue, kDivide, kVerifyRegAWide | kVerifyRegBWide) \
+  V(0xCF, REM_DOUBLE_2ADDR, "rem-double/2addr", k12x, kIndexNone, kContinue, kRemainder, kVerifyRegAWide | kVerifyRegBWide) \
+  V(0xD0, ADD_INT_LIT16, "add-int/lit16", k22s, kIndexNone, kContinue, kAdd | kRegCFieldOrConstant, kVerifyRegA | kVerifyRegB) \
+  V(0xD1, RSUB_INT, "rsub-int", k22s, kIndexNone, kContinue, kSubtract | kRegCFieldOrConstant, kVerifyRegA | kVerifyRegB) \
+  V(0xD2, MUL_INT_LIT16, "mul-int/lit16", k22s, kIndexNone, kContinue, kMultiply | kRegCFieldOrConstant, kVerifyRegA | kVerifyRegB) \
+  V(0xD3, DIV_INT_LIT16, "div-int/lit16", k22s, kIndexNone, kContinue | kThrow, kDivide | kRegCFieldOrConstant, kVerifyRegA | kVerifyRegB) \
+  V(0xD4, REM_INT_LIT16, "rem-int/lit16", k22s, kIndexNone, kContinue | kThrow, kRemainder | kRegCFieldOrConstant, kVerifyRegA | kVerifyRegB) \
+  V(0xD5, AND_INT_LIT16, "and-int/lit16", k22s, kIndexNone, kContinue, kAnd | kRegCFieldOrConstant, kVerifyRegA | kVerifyRegB) \
+  V(0xD6, OR_INT_LIT16, "or-int/lit16", k22s, kIndexNone, kContinue, kOr | kRegCFieldOrConstant, kVerifyRegA | kVerifyRegB) \
+  V(0xD7, XOR_INT_LIT16, "xor-int/lit16", k22s, kIndexNone, kContinue, kXor | kRegCFieldOrConstant, kVerifyRegA | kVerifyRegB) \
+  V(0xD8, ADD_INT_LIT8, "add-int/lit8", k22b, kIndexNone, kContinue, kAdd | kRegCFieldOrConstant, kVerifyRegA | kVerifyRegB) \
+  V(0xD9, RSUB_INT_LIT8, "rsub-int/lit8", k22b, kIndexNone, kContinue, kSubtract | kRegCFieldOrConstant, kVerifyRegA | kVerifyRegB) \
+  V(0xDA, MUL_INT_LIT8, "mul-int/lit8", k22b, kIndexNone, kContinue, kMultiply | kRegCFieldOrConstant, kVerifyRegA | kVerifyRegB) \
+  V(0xDB, DIV_INT_LIT8, "div-int/lit8", k22b, kIndexNone, kContinue | kThrow, kDivide | kRegCFieldOrConstant, kVerifyRegA | kVerifyRegB) \
+  V(0xDC, REM_INT_LIT8, "rem-int/lit8", k22b, kIndexNone, kContinue | kThrow, kRemainder | kRegCFieldOrConstant, kVerifyRegA | kVerifyRegB) \
+  V(0xDD, AND_INT_LIT8, "and-int/lit8", k22b, kIndexNone, kContinue, kAnd | kRegCFieldOrConstant, kVerifyRegA | kVerifyRegB) \
+  V(0xDE, OR_INT_LIT8, "or-int/lit8", k22b, kIndexNone, kContinue, kOr | kRegCFieldOrConstant, kVerifyRegA | kVerifyRegB) \
+  V(0xDF, XOR_INT_LIT8, "xor-int/lit8", k22b, kIndexNone, kContinue, kXor | kRegCFieldOrConstant, kVerifyRegA | kVerifyRegB) \
+  V(0xE0, SHL_INT_LIT8, "shl-int/lit8", k22b, kIndexNone, kContinue, kShl | kRegCFieldOrConstant, kVerifyRegA | kVerifyRegB) \
+  V(0xE1, SHR_INT_LIT8, "shr-int/lit8", k22b, kIndexNone, kContinue, kShr | kRegCFieldOrConstant, kVerifyRegA | kVerifyRegB) \
+  V(0xE2, USHR_INT_LIT8, "ushr-int/lit8", k22b, kIndexNone, kContinue, kUshr | kRegCFieldOrConstant, kVerifyRegA | kVerifyRegB) \
+  V(0xE3, IGET_QUICK, "iget-quick", k22c, kIndexFieldOffset, kContinue | kThrow, kLoad | kRegCFieldOrConstant, kVerifyRegA | kVerifyRegB | kVerifyRuntimeOnly) \
+  V(0xE4, IGET_WIDE_QUICK, "iget-wide-quick", k22c, kIndexFieldOffset, kContinue | kThrow, kLoad | kRegCFieldOrConstant, kVerifyRegAWide | kVerifyRegB | kVerifyRuntimeOnly) \
+  V(0xE5, IGET_OBJECT_QUICK, "iget-object-quick", k22c, kIndexFieldOffset, kContinue | kThrow, kLoad | kRegCFieldOrConstant, kVerifyRegA | kVerifyRegB | kVerifyRuntimeOnly) \
+  V(0xE6, IPUT_QUICK, "iput-quick", k22c, kIndexFieldOffset, kContinue | kThrow, kStore | kRegCFieldOrConstant, kVerifyRegA | kVerifyRegB | kVerifyRuntimeOnly) \
+  V(0xE7, IPUT_WIDE_QUICK, "iput-wide-quick", k22c, kIndexFieldOffset, kContinue | kThrow, kStore | kRegCFieldOrConstant, kVerifyRegAWide | kVerifyRegB | kVerifyRuntimeOnly) \
+  V(0xE8, IPUT_OBJECT_QUICK, "iput-object-quick", k22c, kIndexFieldOffset, kContinue | kThrow, kStore | kRegCFieldOrConstant, kVerifyRegA | kVerifyRegB | kVerifyRuntimeOnly) \
+  V(0xE9, INVOKE_VIRTUAL_QUICK, "invoke-virtual-quick", k35c, kIndexVtableOffset, kContinue | kThrow | kInvoke, 0, kVerifyVarArgNonZero | kVerifyRuntimeOnly) \
+  V(0xEA, INVOKE_VIRTUAL_RANGE_QUICK, "invoke-virtual/range-quick", k3rc, kIndexVtableOffset, kContinue | kThrow | kInvoke, 0, kVerifyVarArgRangeNonZero | kVerifyRuntimeOnly) \
+  V(0xEB, IPUT_BOOLEAN_QUICK, "iput-boolean-quick", k22c, kIndexFieldOffset, kContinue | kThrow, kStore | kRegCFieldOrConstant, kVerifyRegA | kVerifyRegB | kVerifyRuntimeOnly) \
+  V(0xEC, IPUT_BYTE_QUICK, "iput-byte-quick", k22c, kIndexFieldOffset, kContinue | kThrow, kStore | kRegCFieldOrConstant, kVerifyRegA | kVerifyRegB | kVerifyRuntimeOnly) \
+  V(0xED, IPUT_CHAR_QUICK, "iput-char-quick", k22c, kIndexFieldOffset, kContinue | kThrow, kStore | kRegCFieldOrConstant, kVerifyRegA | kVerifyRegB | kVerifyRuntimeOnly) \
+  V(0xEE, IPUT_SHORT_QUICK, "iput-short-quick", k22c, kIndexFieldOffset, kContinue | kThrow, kStore | kRegCFieldOrConstant, kVerifyRegA | kVerifyRegB | kVerifyRuntimeOnly) \
+  V(0xEF, IGET_BOOLEAN_QUICK, "iget-boolean-quick", k22c, kIndexFieldOffset, kContinue | kThrow, kLoad | kRegCFieldOrConstant, kVerifyRegA | kVerifyRegB | kVerifyRuntimeOnly) \
+  V(0xF0, IGET_BYTE_QUICK, "iget-byte-quick", k22c, kIndexFieldOffset, kContinue | kThrow, kLoad | kRegCFieldOrConstant, kVerifyRegA | kVerifyRegB | kVerifyRuntimeOnly) \
+  V(0xF1, IGET_CHAR_QUICK, "iget-char-quick", k22c, kIndexFieldOffset, kContinue | kThrow, kLoad | kRegCFieldOrConstant, kVerifyRegA | kVerifyRegB | kVerifyRuntimeOnly) \
+  V(0xF2, IGET_SHORT_QUICK, "iget-short-quick", k22c, kIndexFieldOffset, kContinue | kThrow, kLoad | kRegCFieldOrConstant, kVerifyRegA | kVerifyRegB | kVerifyRuntimeOnly) \
+  V(0xF3, UNUSED_F3, "unused-f3", k10x, kIndexUnknown, 0, 0, kVerifyError) \
+  V(0xF4, UNUSED_F4, "unused-f4", k10x, kIndexUnknown, 0, 0, kVerifyError) \
+  V(0xF5, UNUSED_F5, "unused-f5", k10x, kIndexUnknown, 0, 0, kVerifyError) \
+  V(0xF6, UNUSED_F6, "unused-f6", k10x, kIndexUnknown, 0, 0, kVerifyError) \
+  V(0xF7, UNUSED_F7, "unused-f7", k10x, kIndexUnknown, 0, 0, kVerifyError) \
+  V(0xF8, UNUSED_F8, "unused-f8", k10x, kIndexUnknown, 0, 0, kVerifyError) \
+  V(0xF9, UNUSED_F9, "unused-f9", k10x, kIndexUnknown, 0, 0, kVerifyError) \
+  V(0xFA, INVOKE_POLYMORPHIC, "invoke-polymorphic", k45cc, kIndexMethodAndProtoRef, kContinue | kThrow | kInvoke, 0, kVerifyRegBMethod | kVerifyVarArgNonZero | kVerifyRegHPrototype) \
+  V(0xFB, INVOKE_POLYMORPHIC_RANGE, "invoke-polymorphic/range", k4rcc, kIndexMethodAndProtoRef, kContinue | kThrow | kInvoke, 0, kVerifyRegBMethod | kVerifyVarArgRangeNonZero | kVerifyRegHPrototype) \
+  V(0xFC, INVOKE_CUSTOM, "invoke-custom", k35c, kIndexCallSiteRef, kContinue | kThrow, 0, kVerifyRegBCallSite | kVerifyVarArg) \
+  V(0xFD, INVOKE_CUSTOM_RANGE, "invoke-custom/range", k3rc, kIndexCallSiteRef, kContinue | kThrow, 0, kVerifyRegBCallSite | kVerifyVarArgRange) \
+  V(0xFE, CONST_METHOD_HANDLE, "const-method-handle", k21c, kIndexMethodHandleRef, kContinue | kThrow, 0, kVerifyRegA | kVerifyRegBMethodHandle) \
+  V(0xFF, CONST_METHOD_TYPE, "const-method-type", k21c, kIndexProtoRef, kContinue | kThrow, 0, kVerifyRegA | kVerifyRegBPrototype)
+
+#define DEX_INSTRUCTION_FORMAT_LIST(V) \
+  V(10x)  /* op */                                                  \
+  V(12x)  /* op vA, vB */                                           \
+  V(11n)  /* op vA, #+B */                                          \
+  V(11x)  /* op vAA */                                              \
+  V(10t)  /* op +AA */                                              \
+  V(20t)  /* op +AAAA */                                            \
+  V(20bc) /* [opt] op AA, thing@BBBB */                             \
+  V(22x)  /* op vAA, vBBBB */                                       \
+  V(21t)  /* op vAA, +BBBB */                                       \
+  V(21s)  /* op vAA, #+BBBB */                                      \
+  V(21h)  /* op vAA, #+BBBB00000[00000000] */                       \
+  V(21c)  /* op vAA, thing@BBBB */                                  \
+  V(23x)  /* op vAA, vBB, vCC */                                    \
+  V(22b)  /* op vAA, vBB, #+CC */                                   \
+  V(22t)  /* op vA, vB, +CCCC */                                    \
+  V(22s)  /* op vA, vB, #+CCCC */                                   \
+  V(22c)  /* op vA, vB, thing@CCCC */                               \
+  V(22cs) /* [opt] op vA, vB, field offset CCCC */                  \
+  V(30t)  /* op +AAAAAAAA */                                        \
+  V(32x)  /* op vAAAA, vBBBB */                                     \
+  V(31i)  /* op vAA, #+BBBBBBBB */                                  \
+  V(31t)  /* op vAA, +BBBBBBBB */                                   \
+  V(31c)  /* op vAA, string@BBBBBBBB */                             \
+  V(35c)  /* op {vC,vD,vE,vF,vG}, thing@BBBB */                     \
+  V(35ms) /* [opt] invoke-virtual+super */                          \
+  V(3rc)  /* op {vCCCC .. v(CCCC+AA-1)}, thing@BBBB */              \
+  V(3rms) /* [opt] invoke-virtual+super/range */                    \
+  V(35mi) /* [opt] inline invoke */                                 \
+  V(3rmi) /* [opt] inline invoke/range */                           \
+  V(45cc) /* op {vC, vD, vE, vF, vG}, meth@BBBB, proto@HHHH */      \
+  V(4rcc) /* op {VCCCC .. v(CCCC+AA-1)}, meth@BBBB, proto@HHHH */   \
+  V(51l)  /* op vAA, #+BBBBBBBBBBBBBBBB */
+
+#endif  // ART_LIBDEXFILE_DEX_DEX_INSTRUCTION_LIST_H_
+#undef ART_LIBDEXFILE_DEX_DEX_INSTRUCTION_LIST_H_  // the guard in this file is just for cpplint

--- a/modules/mockk-agent-android/external/slicer/export/slicer/dex_ir.h
+++ b/modules/mockk-agent-android/external/slicer/export/slicer/dex_ir.h
@@ -16,14 +16,14 @@
 
 #pragma once
 
-#include "common.h"
-#include "memview.h"
 #include "arrayview.h"
+#include "buffer.h"
+#include "common.h"
 #include "dex_format.h"
 #include "dex_leb128.h"
-#include "buffer.h"
-#include "index_map.h"
 #include "hash_table.h"
+#include "index_map.h"
+#include "memview.h"
 
 #include <stdlib.h>
 #include <map>
@@ -62,6 +62,7 @@ struct String;
 struct Type;
 struct TypeList;
 struct Proto;
+struct MethodHandle;
 struct FieldDecl;
 struct EncodedField;
 struct DebugInfo;
@@ -195,6 +196,16 @@ struct Proto : public IndexedNode {
   TypeList* param_types;
 
   std::string Signature() const;
+};
+
+struct MethodHandle : public IndexedNode {
+  SLICER_IR_INDEXED_TYPE;
+
+  dex::u2 method_handle_type;
+  MethodDecl* method;
+  FieldDecl* field;
+
+  bool IsField();
 };
 
 struct FieldDecl : public IndexedNode {
@@ -365,6 +376,7 @@ struct DexFile {
   std::vector<own<FieldDecl>> fields;
   std::vector<own<MethodDecl>> methods;
   std::vector<own<Class>> classes;
+  std::vector<own<MethodHandle>> method_handles;
 
   // data segment structures
   std::vector<own<EncodedField>> encoded_fields;
@@ -394,6 +406,7 @@ struct DexFile {
   std::map<dex::u4, FieldDecl*> fields_map;
   std::map<dex::u4, MethodDecl*> methods_map;
   std::map<dex::u4, Class*> classes_map;
+  std::map<dex::u4, MethodHandle*> method_handles_map;
 
   // original .dex header "magic" signature
   slicer::MemView magic;
@@ -406,6 +419,7 @@ struct DexFile {
   IndexMap fields_indexes;
   IndexMap methods_indexes;
   IndexMap classes_indexes;
+  IndexMap method_handle_indexes;
 
   // lookup hash tables
   StringsLookup strings_lookup;
@@ -447,6 +461,7 @@ struct DexFile {
   void Track(FieldDecl* p) { PushOwn(fields, p); }
   void Track(MethodDecl* p) { PushOwn(methods, p); }
   void Track(Class* p) { PushOwn(classes, p); }
+  void Track(MethodHandle* p) { PushOwn(method_handles, p); }
 
   void Track(EncodedField* p) { PushOwn(encoded_fields, p); }
   void Track(EncodedMethod* p) { PushOwn(encoded_methods, p); }

--- a/modules/mockk-agent-android/external/slicer/export/slicer/hash_table.h
+++ b/modules/mockk-agent-android/external/slicer/export/slicer/hash_table.h
@@ -16,9 +16,9 @@
 
 #pragma once
 
-#include <vector>
 #include <cstdint>
 #include <memory>
+#include <vector>
 
 namespace slicer {
 
@@ -124,7 +124,7 @@ HashTable<Key, T, Hash>::Partition::Partition(Index size, const Hash& hasher)
 //
 template<class Key, class T, class Hash>
 bool HashTable<Key, T, Hash>::Partition::Insert(T* value) {
-  SLICER_CHECK(value != nullptr);
+  SLICER_CHECK_NE(value, nullptr);
   // overflow?
   if (buckets_.size() + 1 > buckets_.capacity()) {
     return false;
@@ -211,7 +211,7 @@ void HashTable<Key, T, Hash>::Partition::PrintStats(const char* name, bool verbo
       ++used_buckets;
       int chain_length = 0;
       for (Index ci = i; buckets_[ci].next != kInvalidIndex; ci = buckets_[ci].next) {
-        SLICER_CHECK(buckets_[ci].value != nullptr);
+        SLICER_CHECK_NE(buckets_[ci].value, nullptr);
         ++chain_length;
         if (verbose) printf("*");
       }

--- a/modules/mockk-agent-android/external/slicer/export/slicer/intrusive_list.h
+++ b/modules/mockk-agent-android/external/slicer/export/slicer/intrusive_list.h
@@ -114,7 +114,7 @@ class IntrusiveList {
   }
 
   void Remove(T* pos) {
-    SLICER_CHECK(pos != end_);
+    SLICER_CHECK_NE(pos, end_);
     if (pos->prev != nullptr) {
       assert(pos != begin_);
       pos->prev->next = pos->next;

--- a/modules/mockk-agent-android/external/slicer/export/slicer/reader.h
+++ b/modules/mockk-agent-android/external/slicer/export/slicer/reader.h
@@ -53,6 +53,7 @@ class Reader {
   slicer::ArrayView<const dex::FieldId> FieldIds() const;
   slicer::ArrayView<const dex::MethodId> MethodIds() const;
   slicer::ArrayView<const dex::ProtoId> ProtoIds() const;
+  slicer::ArrayView<const dex::MethodHandle> MethodHandles() const;
   const dex::MapList* DexMapList() const;
 
   // IR creation interface
@@ -69,6 +70,7 @@ class Reader {
   ir::MethodDecl* GetMethodDecl(dex::u4 index);
   ir::Proto* GetProto(dex::u4 index);
   ir::String* GetString(dex::u4 index);
+  ir::MethodHandle* GetMethodHandle(dex::u4 index);
 
   // Parsing annotations
   ir::AnnotationsDirectory* ExtractAnnotations(dex::u4 offset);
@@ -80,6 +82,7 @@ class Reader {
   ir::ParamAnnotation* ParseParamAnnotation(const dex::u1** pptr);
   ir::EncodedField* ParseEncodedField(const dex::u1** pptr, dex::u4* baseIndex);
   ir::Annotation* ParseAnnotation(const dex::u1** pptr);
+  ir::MethodHandle* ParseMethodHandle(dex::u4 index);
 
   // Parse encoded values and arrays
   ir::EncodedValue* ParseEncodedValue(const dex::u1** pptr);
@@ -104,7 +107,7 @@ class Reader {
   // Convert a file pointer (absolute offset) to an in-memory pointer
   template <class T>
   const T* ptr(int offset) const {
-    SLICER_CHECK(offset >= 0 && offset + sizeof(T) <= size_);
+    SLICER_CHECK_GE(offset, 0 && offset + sizeof(T) <= size_);
     return reinterpret_cast<const T*>(image_ + offset);
   }
 
@@ -112,7 +115,7 @@ class Reader {
   // (offset should be inside the data section)
   template <class T>
   const T* dataPtr(int offset) const {
-    SLICER_CHECK(offset >= header_->data_off && offset + sizeof(T) <= size_);
+    SLICER_CHECK_GE(offset, header_->data_off && offset + sizeof(T) <= size_);
     return reinterpret_cast<const T*>(image_ + offset);
   }
 

--- a/modules/mockk-agent-android/external/slicer/export/slicer/scopeguard.h
+++ b/modules/mockk-agent-android/external/slicer/export/slicer/scopeguard.h
@@ -16,6 +16,8 @@
 
 #pragma once
 
+#include <utility>
+
 namespace slicer {
 
 // A simple and lightweight scope guard and macro

--- a/modules/mockk-agent-android/external/slicer/export/slicer/tryblocks_encoder.h
+++ b/modules/mockk-agent-android/external/slicer/export/slicer/tryblocks_encoder.h
@@ -16,11 +16,11 @@
 
 #pragma once
 
-#include "common.h"
-#include "code_ir.h"
-#include "dex_ir.h"
 #include "buffer.h"
 #include "chronometer.h"
+#include "code_ir.h"
+#include "common.h"
+#include "dex_ir.h"
 
 namespace lir {
 

--- a/modules/mockk-agent-android/external/slicer/instrumentation.cc
+++ b/modules/mockk-agent-android/external/slicer/instrumentation.cc
@@ -15,11 +15,111 @@
  */
 
 #include "slicer/instrumentation.h"
+
 #include "slicer/dex_ir_builder.h"
+
+#include <iomanip>
+#include <sstream>
 
 namespace slicer {
 
+namespace {
+
+struct BytecodeConvertingVisitor : public lir::Visitor {
+  lir::Bytecode* out = nullptr;
+  bool Visit(lir::Bytecode* bytecode) {
+    out = bytecode;
+    return true;
+  }
+};
+
+void BoxValue(lir::Bytecode* bytecode,
+              lir::CodeIr* code_ir,
+              ir::Type* type,
+              dex::u4 src_reg,
+              dex::u4 dst_reg) {
+  bool is_wide = false;
+  const char* boxed_type_name = nullptr;
+  switch (*(type->descriptor)->c_str()) {
+    case 'Z':
+      boxed_type_name = "Ljava/lang/Boolean;";
+      break;
+    case 'B':
+      boxed_type_name = "Ljava/lang/Byte;";
+      break;
+    case 'C':
+      boxed_type_name = "Ljava/lang/Character;";
+      break;
+    case 'S':
+      boxed_type_name = "Ljava/lang/Short;";
+      break;
+    case 'I':
+      boxed_type_name = "Ljava/lang/Integer;";
+      break;
+    case 'J':
+      is_wide = true;
+      boxed_type_name = "Ljava/lang/Long;";
+      break;
+    case 'F':
+      boxed_type_name = "Ljava/lang/Float;";
+      break;
+    case 'D':
+      is_wide = true;
+      boxed_type_name = "Ljava/lang/Double;";
+      break;
+  }
+  SLICER_CHECK_NE(boxed_type_name, nullptr);
+
+  ir::Builder builder(code_ir->dex_ir);
+  std::vector<ir::Type*> param_types;
+  param_types.push_back(type);
+
+  auto boxed_type = builder.GetType(boxed_type_name);
+  auto ir_proto = builder.GetProto(boxed_type, builder.GetTypeList(param_types));
+
+  auto ir_method_decl = builder.GetMethodDecl(
+      builder.GetAsciiString("valueOf"), ir_proto, boxed_type);
+
+  auto boxing_method = code_ir->Alloc<lir::Method>(ir_method_decl, ir_method_decl->orig_index);
+
+  auto args = code_ir->Alloc<lir::VRegRange>(src_reg, 1 + is_wide);
+  auto boxing_invoke = code_ir->Alloc<lir::Bytecode>();
+  boxing_invoke->opcode = dex::OP_INVOKE_STATIC_RANGE;
+  boxing_invoke->operands.push_back(args);
+  boxing_invoke->operands.push_back(boxing_method);
+  code_ir->instructions.InsertBefore(bytecode, boxing_invoke);
+
+  auto move_result = code_ir->Alloc<lir::Bytecode>();
+  move_result->opcode = dex::OP_MOVE_RESULT_OBJECT;
+  move_result->operands.push_back(code_ir->Alloc<lir::VReg>(dst_reg));
+  code_ir->instructions.InsertBefore(bytecode, move_result);
+}
+
+std::string MethodLabel(ir::EncodedMethod* ir_method) {
+  auto signature_str = ir_method->decl->prototype->Signature();
+  return ir_method->decl->parent->Decl() + "->" + ir_method->decl->name->c_str() + signature_str;
+}
+
+}  // namespace
+
 bool EntryHook::Apply(lir::CodeIr* code_ir) {
+  lir::Bytecode* bytecode = nullptr;
+  // find the first bytecode in the method body to insert the hook before it
+  for (auto instr : code_ir->instructions) {
+    BytecodeConvertingVisitor visitor;
+    instr->Accept(&visitor);
+    bytecode = visitor.out;
+    if (bytecode != nullptr) {
+      break;
+    }
+  }
+  if (bytecode == nullptr) {
+    return false;
+  }
+  if (tweak_ == Tweak::ArrayParams) {
+    return InjectArrayParamsHook(code_ir, bytecode);
+  }
+
   ir::Builder builder(code_ir->dex_ir);
   const auto ir_method = code_ir->ir_method;
 
@@ -27,10 +127,13 @@ bool EntryHook::Apply(lir::CodeIr* code_ir) {
   std::vector<ir::Type*> param_types;
   if ((ir_method->access_flags & dex::kAccStatic) == 0) {
     ir::Type* this_argument_type;
-    if (use_object_type_for_this_argument_) {
-      this_argument_type = builder.GetType("Ljava/lang/Object;");
-    } else {
-      this_argument_type = ir_method->decl->parent;
+    switch (tweak_) {
+      case Tweak::ThisAsObject:
+        this_argument_type = builder.GetType("Ljava/lang/Object;");
+        break;
+      default:
+        this_argument_type = ir_method->decl->parent;
+        break;
     }
     param_types.push_back(this_argument_type);
   }
@@ -60,28 +163,221 @@ bool EntryHook::Apply(lir::CodeIr* code_ir) {
   hook_invoke->operands.push_back(hook_method);
 
   // insert the hook before the first bytecode in the method body
-  for (auto instr : code_ir->instructions) {
-    auto bytecode = dynamic_cast<lir::Bytecode*>(instr);
-    if (bytecode == nullptr) {
-      continue;
-    }
-    code_ir->instructions.InsertBefore(bytecode, hook_invoke);
-    break;
+  code_ir->instructions.InsertBefore(bytecode, hook_invoke);
+  return true;
+}
+
+void GenerateShiftParamsCode(lir::CodeIr* code_ir, lir::Instruction* position, dex::u4 shift) {
+  const auto ir_method = code_ir->ir_method;
+
+  // Since the goal is to relocate the registers when extra scratch registers are needed,
+  // if there are no parameters this is a no-op.
+  if (ir_method->code->ins_count == 0) {
+    return;
   }
 
+  // build a param list with the explicit "this" argument for non-static methods
+  std::vector<ir::Type*> param_types;
+  if ((ir_method->access_flags & dex::kAccStatic) == 0) {
+    param_types.push_back(ir_method->decl->parent);
+  }
+  if (ir_method->decl->prototype->param_types != nullptr) {
+    const auto& orig_param_types = ir_method->decl->prototype->param_types->types;
+    param_types.insert(param_types.end(), orig_param_types.begin(), orig_param_types.end());
+  }
+
+  const dex::u4 regs = ir_method->code->registers;
+  const dex::u4 ins_count = ir_method->code->ins_count;
+  SLICER_CHECK_GE(regs, ins_count);
+
+  // generate the args "relocation" instructions
+  dex::u4 reg = regs - ins_count;
+  for (const auto& type : param_types) {
+    auto move = code_ir->Alloc<lir::Bytecode>();
+    switch (type->GetCategory()) {
+      case ir::Type::Category::Reference:
+        move->opcode = dex::OP_MOVE_OBJECT_16;
+        move->operands.push_back(code_ir->Alloc<lir::VReg>(reg - shift));
+        move->operands.push_back(code_ir->Alloc<lir::VReg>(reg));
+        reg += 1;
+        break;
+      case ir::Type::Category::Scalar:
+        move->opcode = dex::OP_MOVE_16;
+        move->operands.push_back(code_ir->Alloc<lir::VReg>(reg - shift));
+        move->operands.push_back(code_ir->Alloc<lir::VReg>(reg));
+        reg += 1;
+        break;
+      case ir::Type::Category::WideScalar:
+        move->opcode = dex::OP_MOVE_WIDE_16;
+        move->operands.push_back(code_ir->Alloc<lir::VRegPair>(reg - shift));
+        move->operands.push_back(code_ir->Alloc<lir::VRegPair>(reg));
+        reg += 2;
+        break;
+      case ir::Type::Category::Void:
+        SLICER_FATAL("void parameter type");
+    }
+    code_ir->instructions.InsertBefore(position, move);
+  }
+}
+
+bool EntryHook::InjectArrayParamsHook(lir::CodeIr* code_ir, lir::Bytecode* bytecode) {
+  ir::Builder builder(code_ir->dex_ir);
+  const auto ir_method = code_ir->ir_method;
+  auto param_types_list = ir_method->decl->prototype->param_types;
+  auto param_types = param_types_list != nullptr ? param_types_list->types : std::vector<ir::Type*>();
+  bool is_static = (ir_method->access_flags & dex::kAccStatic) != 0;
+
+  // number of registers that we need to operate
+  dex::u2 regs_count = 3;
+  auto non_param_regs = ir_method->code->registers - ir_method->code->ins_count;
+
+  // do we have enough registers to operate?
+  bool needsExtraRegs = non_param_regs < regs_count;
+  if (needsExtraRegs) {
+    // we don't have enough registers, so we allocate more, we will shift
+    // params to their original registers later.
+    code_ir->ir_method->code->registers += regs_count - non_param_regs;
+  }
+
+  // use three first registers:
+  // all three are needed when we "aput" a string/boxed-value (1) into an array (2) at an index (3)
+
+  // register that will store size of during allocation
+  // later will be reused to store index when do "aput"
+  dex::u4 array_size_reg = 0;
+  // register that will store an array that will be passed
+  // as a parameter in entry hook
+  dex::u4 array_reg = 1;
+  // stores result of boxing (if it's needed); also stores the method signature string
+  dex::u4 value_reg = 2;
+  // array size bytecode
+  auto const_size_op = code_ir->Alloc<lir::Bytecode>();
+  const_size_op->opcode = dex::OP_CONST;
+  const_size_op->operands.push_back(code_ir->Alloc<lir::VReg>(array_size_reg));
+  const_size_op->operands.push_back(code_ir->Alloc<lir::Const32>(
+      2 + param_types.size())); // method signature + params + "this" object
+  code_ir->instructions.InsertBefore(bytecode, const_size_op);
+
+  // allocate array
+  const auto obj_array_type = builder.GetType("[Ljava/lang/Object;");
+  auto allocate_array_op = code_ir->Alloc<lir::Bytecode>();
+  allocate_array_op->opcode = dex::OP_NEW_ARRAY;
+  allocate_array_op->operands.push_back(code_ir->Alloc<lir::VReg>(array_reg));
+  allocate_array_op->operands.push_back(code_ir->Alloc<lir::VReg>(array_size_reg));
+  allocate_array_op->operands.push_back(
+      code_ir->Alloc<lir::Type>(obj_array_type, obj_array_type->orig_index));
+  code_ir->instructions.InsertBefore(bytecode, allocate_array_op);
+
+  // fill the array with parameters passed into function
+
+  std::vector<ir::Type*> types;
+  types.push_back(builder.GetType("Ljava/lang/String;")); // method signature string
+  if (!is_static) {
+    types.push_back(ir_method->decl->parent); // "this" object
+  }
+
+  types.insert(types.end(), param_types.begin(), param_types.end()); // parameters
+
+  // register where params start
+  dex::u4 current_reg = ir_method->code->registers - ir_method->code->ins_count;
+  // reuse not needed anymore register to store indexes
+  dex::u4 array_index_reg = array_size_reg;
+  int i = 0;
+  for (auto type: types) {
+    dex::u4 src_reg = 0;
+    if (i == 0) { // method signature string
+      // e.g. const-string v2, "(I[Ljava/lang/String;)Ljava/lang/String;"
+      // for (int, String[]) -> String
+      auto const_str_op = code_ir->Alloc<lir::Bytecode>();
+      const_str_op->opcode = dex::OP_CONST_STRING;
+      const_str_op->operands.push_back(code_ir->Alloc<lir::VReg>(value_reg)); // dst
+      auto method_label = builder.GetAsciiString(MethodLabel(ir_method).c_str());
+      const_str_op->operands.push_back(
+          code_ir->Alloc<lir::String>(method_label, method_label->orig_index)); // src
+      code_ir->instructions.InsertBefore(bytecode, const_str_op);
+      src_reg = value_reg;
+    } else if (type->GetCategory() != ir::Type::Category::Reference) {
+      BoxValue(bytecode, code_ir, type, current_reg, value_reg);
+      src_reg = value_reg;
+      current_reg += 1 + (type->GetCategory() == ir::Type::Category::WideScalar);
+    } else {
+      src_reg = current_reg;
+      current_reg++;
+    }
+
+    auto index_const_op = code_ir->Alloc<lir::Bytecode>();
+    index_const_op->opcode = dex::OP_CONST;
+    index_const_op->operands.push_back(code_ir->Alloc<lir::VReg>(array_index_reg));
+    index_const_op->operands.push_back(code_ir->Alloc<lir::Const32>(i++));
+    code_ir->instructions.InsertBefore(bytecode, index_const_op);
+
+    auto aput_op = code_ir->Alloc<lir::Bytecode>();
+    aput_op->opcode = dex::OP_APUT_OBJECT;
+    aput_op->operands.push_back(code_ir->Alloc<lir::VReg>(src_reg));
+    aput_op->operands.push_back(code_ir->Alloc<lir::VReg>(array_reg));
+    aput_op->operands.push_back(code_ir->Alloc<lir::VReg>(array_index_reg));
+    code_ir->instructions.InsertBefore(bytecode, aput_op);
+
+    // if function is static, then jumping over index 1
+    //  since null should be be passed in this case
+    if (i == 1 && is_static) i++;
+  }
+
+  std::vector<ir::Type*> hook_param_types;
+  hook_param_types.push_back(obj_array_type);
+
+  auto ir_proto = builder.GetProto(builder.GetType("V"),
+                                   builder.GetTypeList(hook_param_types));
+
+  auto ir_method_decl = builder.GetMethodDecl(
+      builder.GetAsciiString(hook_method_id_.method_name), ir_proto,
+      builder.GetType(hook_method_id_.class_descriptor));
+
+  auto hook_method = code_ir->Alloc<lir::Method>(ir_method_decl, ir_method_decl->orig_index);
+  auto args = code_ir->Alloc<lir::VRegRange>(array_reg, 1);
+  auto hook_invoke = code_ir->Alloc<lir::Bytecode>();
+  hook_invoke->opcode = dex::OP_INVOKE_STATIC_RANGE;
+  hook_invoke->operands.push_back(args);
+  hook_invoke->operands.push_back(hook_method);
+  code_ir->instructions.InsertBefore(bytecode, hook_invoke);
+
+  // clean up registries used by us
+  // registers are assigned to a marker value 0xFE_FE_FE_FE (decimal
+  // value: -16843010) to help identify use of uninitialized registers.
+  for (dex::u2 i = 0; i < regs_count; ++i) {
+    auto cleanup = code_ir->Alloc<lir::Bytecode>();
+    cleanup->opcode = dex::OP_CONST;
+    cleanup->operands.push_back(code_ir->Alloc<lir::VReg>(i));
+    cleanup->operands.push_back(code_ir->Alloc<lir::Const32>(0xFEFEFEFE));
+    code_ir->instructions.InsertBefore(bytecode, cleanup);
+  }
+
+  // now we have to shift params to their original registers
+  if (needsExtraRegs) {
+    GenerateShiftParamsCode(code_ir, bytecode, regs_count - non_param_regs);
+  }
   return true;
 }
 
 bool ExitHook::Apply(lir::CodeIr* code_ir) {
   ir::Builder builder(code_ir->dex_ir);
   const auto ir_method = code_ir->ir_method;
-  const auto return_type = ir_method->decl->prototype->return_type;
-
+  const auto declared_return_type = ir_method->decl->prototype->return_type;
+  bool return_as_object = (tweak_ & Tweak::ReturnAsObject) != 0;
   // do we have a void-return method?
-  bool return_void = (::strcmp(return_type->descriptor->c_str(), "V") == 0);
+  bool return_void = (::strcmp(declared_return_type->descriptor->c_str(), "V") == 0);
+  // returnAsObject supports only object return type;
+  SLICER_CHECK(!return_as_object ||
+      (declared_return_type->GetCategory() == ir::Type::Category::Reference));
+  const auto return_type = return_as_object ? builder.GetType("Ljava/lang/Object;")
+      : declared_return_type;
 
+  bool pass_method_signature = (tweak_ & Tweak::PassMethodSignature) != 0;
   // construct the hook method declaration
   std::vector<ir::Type*> param_types;
+  if (pass_method_signature) {
+    param_types.push_back(builder.GetType("Ljava/lang/String;"));
+  }
   if (!return_void) {
     param_types.push_back(return_type);
   }
@@ -96,7 +392,9 @@ bool ExitHook::Apply(lir::CodeIr* code_ir) {
 
   // find and instrument all return instructions
   for (auto instr : code_ir->instructions) {
-    auto bytecode = dynamic_cast<lir::Bytecode*>(instr);
+    BytecodeConvertingVisitor visitor;
+    instr->Accept(&visitor);
+    auto bytecode = visitor.out;
     if (bytecode == nullptr) {
       continue;
     }
@@ -104,7 +402,6 @@ bool ExitHook::Apply(lir::CodeIr* code_ir) {
     dex::Opcode move_result_opcode = dex::OP_NOP;
     dex::u4 reg = 0;
     int reg_count = 0;
-
     switch (bytecode->opcode) {
       case dex::OP_RETURN_VOID:
         SLICER_CHECK(return_void);
@@ -132,8 +429,65 @@ bool ExitHook::Apply(lir::CodeIr* code_ir) {
         continue;
     }
 
-    // invoke hook bytecode
-    auto args = code_ir->Alloc<lir::VRegRange>(reg, reg_count);
+    dex::u4 scratch_reg = 0;
+    // load method signature into scratch_reg
+    if (pass_method_signature) {
+      // is there a register that can be overtaken
+      bool needsScratchReg = ir_method->code->registers < reg_count + 1;
+      if (needsScratchReg) {
+        // don't renumber registers underneath us
+        slicer::AllocateScratchRegs alloc_regs(1, false);
+        alloc_regs.Apply(code_ir);
+      }
+
+      // we need use one register before results to put signature there
+      // however result starts in register 0, thefore it is shifted
+      // to register 1
+      if (reg == 0 && bytecode->opcode != dex::OP_RETURN_VOID) {
+        auto move_op = code_ir->Alloc<lir::Bytecode>();
+        switch (bytecode->opcode) {
+          case dex::OP_RETURN_OBJECT:
+            move_op->opcode = dex::OP_MOVE_OBJECT_16;
+            move_op->operands.push_back(code_ir->Alloc<lir::VReg>(reg + 1));
+            move_op->operands.push_back(code_ir->Alloc<lir::VReg>(reg));
+            break;
+          case dex::OP_RETURN:
+            move_op->opcode = dex::OP_MOVE_16;
+            move_op->operands.push_back(code_ir->Alloc<lir::VReg>(reg + 1));
+            move_op->operands.push_back(code_ir->Alloc<lir::VReg>(reg));
+            break;
+          case dex::OP_RETURN_WIDE:
+            move_op->opcode = dex::OP_MOVE_WIDE_16;
+            move_op->operands.push_back(code_ir->Alloc<lir::VRegPair>(reg + 1));
+            move_op->operands.push_back(code_ir->Alloc<lir::VRegPair>(reg));
+            break;
+          default: {
+              std::stringstream ss;
+              ss <<"Unexpected bytecode opcode: " << bytecode->opcode;
+              SLICER_FATAL(ss.str());
+            }
+        }
+        code_ir->instructions.InsertBefore(bytecode, move_op);
+        // return is the last call, return is shifted to one, so taking over 0 registry
+        scratch_reg = 0;
+      } else {
+        // return is the last call, so we're taking over previous registry
+        scratch_reg = bytecode->opcode == dex::OP_RETURN_VOID ? 0 : reg - 1;
+      }
+
+
+      // return is the last call, so we're taking over previous registry
+      auto method_label = builder.GetAsciiString(MethodLabel(ir_method).c_str());
+      auto const_str_op = code_ir->Alloc<lir::Bytecode>();
+      const_str_op->opcode = dex::OP_CONST_STRING;
+      const_str_op->operands.push_back(code_ir->Alloc<lir::VReg>(scratch_reg)); // dst
+      const_str_op->operands.push_back(code_ir->Alloc<lir::String>(method_label, method_label->orig_index)); // src
+      code_ir->instructions.InsertBefore(bytecode, const_str_op);
+    }
+
+    auto args = pass_method_signature
+        ? code_ir->Alloc<lir::VRegRange>(scratch_reg, reg_count + 1)
+        : code_ir->Alloc<lir::VRegRange>(reg, reg_count);
     auto hook_invoke = code_ir->Alloc<lir::Bytecode>();
     hook_invoke->opcode = dex::OP_INVOKE_STATIC_RANGE;
     hook_invoke->operands.push_back(args);
@@ -152,35 +506,37 @@ bool ExitHook::Apply(lir::CodeIr* code_ir) {
       move_result->opcode = move_result_opcode;
       move_result->operands.push_back(bytecode->operands[0]);
       code_ir->instructions.InsertBefore(bytecode, move_result);
+
+      if ((tweak_ & Tweak::ReturnAsObject) != 0) {
+        auto check_cast = code_ir->Alloc<lir::Bytecode>();
+        check_cast->opcode = dex::OP_CHECK_CAST;
+        check_cast->operands.push_back(code_ir->Alloc<lir::VReg>(reg));
+        check_cast->operands.push_back(
+            code_ir->Alloc<lir::Type>(declared_return_type, declared_return_type->orig_index));
+        code_ir->instructions.InsertBefore(bytecode, check_cast);
+      }
     }
   }
 
   return true;
 }
 
-bool DetourVirtualInvoke::Apply(lir::CodeIr* code_ir) {
+bool DetourHook::Apply(lir::CodeIr* code_ir) {
   ir::Builder builder(code_ir->dex_ir);
 
   // search for matching invoke-virtual[/range] bytecodes
   for (auto instr : code_ir->instructions) {
-    auto bytecode = dynamic_cast<lir::Bytecode*>(instr);
+    BytecodeConvertingVisitor visitor;
+    instr->Accept(&visitor);
+    auto bytecode = visitor.out;
     if (bytecode == nullptr) {
       continue;
     }
 
-    dex::Opcode new_call_opcode = dex::OP_NOP;
-    switch (bytecode->opcode) {
-      case dex::OP_INVOKE_VIRTUAL:
-        new_call_opcode = dex::OP_INVOKE_STATIC;
-        break;
-      case dex::OP_INVOKE_VIRTUAL_RANGE:
-        new_call_opcode = dex::OP_INVOKE_STATIC_RANGE;
-        break;
-      default:
-        // skip instruction ...
-        continue;
+    dex::Opcode new_call_opcode = GetNewOpcode(bytecode->opcode);
+    if (new_call_opcode == dex::OP_NOP) {
+      continue;
     }
-    assert(new_call_opcode != dex::OP_NOP);
 
     auto orig_method = bytecode->CastOperand<lir::Method>(1)->ir_method;
     if (!orig_method_id_.Match(orig_method)) {
@@ -194,7 +550,8 @@ bool DetourVirtualInvoke::Apply(lir::CodeIr* code_ir) {
     param_types.push_back(orig_method->parent);
     if (orig_method->prototype->param_types != nullptr) {
       const auto& orig_param_types = orig_method->prototype->param_types->types;
-      param_types.insert(param_types.end(), orig_param_types.begin(), orig_param_types.end());
+      param_types.insert(param_types.end(), orig_param_types.begin(),
+                         orig_param_types.end());
     }
 
     auto ir_proto = builder.GetProto(orig_method->prototype->return_type,
@@ -204,7 +561,8 @@ bool DetourVirtualInvoke::Apply(lir::CodeIr* code_ir) {
         builder.GetAsciiString(detour_method_id_.method_name), ir_proto,
         builder.GetType(detour_method_id_.class_descriptor));
 
-    auto detour_method = code_ir->Alloc<lir::Method>(ir_method_decl, ir_method_decl->orig_index);
+    auto detour_method =
+        code_ir->Alloc<lir::Method>(ir_method_decl, ir_method_decl->orig_index);
 
     // We mutate the original invoke bytecode in-place: this is ok
     // because lir::Instructions can't be shared (referenced multiple times)
@@ -217,12 +575,36 @@ bool DetourVirtualInvoke::Apply(lir::CodeIr* code_ir) {
   return true;
 }
 
+dex::Opcode DetourVirtualInvoke::GetNewOpcode(dex::Opcode opcode) {
+  switch (opcode) {
+    case dex::OP_INVOKE_VIRTUAL:
+      return dex::OP_INVOKE_STATIC;
+    case dex::OP_INVOKE_VIRTUAL_RANGE:
+      return dex::OP_INVOKE_STATIC_RANGE;
+    default:
+      // skip instruction ...
+      return dex::OP_NOP;
+  }
+}
+
+dex::Opcode DetourInterfaceInvoke::GetNewOpcode(dex::Opcode opcode) {
+  switch (opcode) {
+    case dex::OP_INVOKE_INTERFACE:
+      return dex::OP_INVOKE_STATIC;
+    case dex::OP_INVOKE_INTERFACE_RANGE:
+      return dex::OP_INVOKE_STATIC_RANGE;
+    default:
+      // skip instruction ...
+      return dex::OP_NOP;
+  }
+}
+
 // Register re-numbering visitor
 // (renumbers vN to vN+shift)
 class RegsRenumberVisitor : public lir::Visitor {
  public:
-  RegsRenumberVisitor(int shift) : shift_(shift) {
-    SLICER_CHECK(shift > 0);
+  explicit RegsRenumberVisitor(int shift) : shift_(shift) {
+    SLICER_CHECK_GT(shift, 0);
   }
 
  private:
@@ -272,7 +654,7 @@ class RegsRenumberVisitor : public lir::Visitor {
 //  make existing bytecodes "unencodable" (if they have 4 bit reg fields)
 //
 void AllocateScratchRegs::RegsRenumbering(lir::CodeIr* code_ir) {
-  SLICER_CHECK(left_to_allocate_ > 0);
+  SLICER_CHECK_GT(left_to_allocate_, 0);
   int delta = std::min(left_to_allocate_,
                        16 - static_cast<int>(code_ir->ir_method->code->registers));
   if (delta < 1) {
@@ -301,57 +683,15 @@ void AllocateScratchRegs::RegsRenumbering(lir::CodeIr* code_ir) {
 //
 void AllocateScratchRegs::ShiftParams(lir::CodeIr* code_ir) {
   const auto ir_method = code_ir->ir_method;
-  SLICER_CHECK(ir_method->code->ins_count > 0);
-  SLICER_CHECK(left_to_allocate_ > 0);
-
-  // build a param list with the explicit "this" argument for non-static methods
-  std::vector<ir::Type*> param_types;
-  if ((ir_method->access_flags & dex::kAccStatic) == 0) {
-    param_types.push_back(ir_method->decl->parent);
-  }
-  if (ir_method->decl->prototype->param_types != nullptr) {
-    const auto& orig_param_types = ir_method->decl->prototype->param_types->types;
-    param_types.insert(param_types.end(), orig_param_types.begin(), orig_param_types.end());
-  }
+  SLICER_CHECK_GT(left_to_allocate_, 0);
 
   const dex::u4 shift = left_to_allocate_;
-
   Allocate(code_ir, ir_method->code->registers, left_to_allocate_);
   assert(left_to_allocate_ == 0);
 
-  const dex::u4 regs = ir_method->code->registers;
-  const dex::u4 ins_count = ir_method->code->ins_count;
-  SLICER_CHECK(regs >= ins_count);
-
   // generate the args "relocation" instructions
-  auto first_instr = code_ir->instructions.begin();
-  dex::u4 reg = regs - ins_count;
-  for (const auto& type : param_types) {
-    auto move = code_ir->Alloc<lir::Bytecode>();
-    switch (type->GetCategory()) {
-      case ir::Type::Category::Reference:
-        move->opcode = dex::OP_MOVE_OBJECT_16;
-        move->operands.push_back(code_ir->Alloc<lir::VReg>(reg - shift));
-        move->operands.push_back(code_ir->Alloc<lir::VReg>(reg));
-        reg += 1;
-        break;
-      case ir::Type::Category::Scalar:
-        move->opcode = dex::OP_MOVE_16;
-        move->operands.push_back(code_ir->Alloc<lir::VReg>(reg - shift));
-        move->operands.push_back(code_ir->Alloc<lir::VReg>(reg));
-        reg += 1;
-        break;
-      case ir::Type::Category::WideScalar:
-        move->opcode = dex::OP_MOVE_WIDE_16;
-        move->operands.push_back(code_ir->Alloc<lir::VRegPair>(reg - shift));
-        move->operands.push_back(code_ir->Alloc<lir::VRegPair>(reg));
-        reg += 2;
-        break;
-      case ir::Type::Category::Void:
-        SLICER_FATAL("void parameter type");
-    }
-    code_ir->instructions.insert(first_instr, move);
-  }
+  auto first_instr = *(code_ir->instructions.begin());
+  GenerateShiftParamsCode(code_ir, first_instr, shift);
 }
 
 // Mark [first_reg, first_reg + count) as scratch registers
@@ -374,7 +714,7 @@ void AllocateScratchRegs::Allocate(lir::CodeIr* code_ir, dex::u4 first_reg, int 
 bool AllocateScratchRegs::Apply(lir::CodeIr* code_ir) {
   const auto code = code_ir->ir_method->code;
   // .dex bytecode allows up to 64k vregs
-  SLICER_CHECK(code->registers + allocate_count_ <= (1 << 16));
+  SLICER_CHECK_LE(code->registers + allocate_count_, (1 << 16));
 
   scratch_regs_.clear();
   left_to_allocate_ = allocate_count_;
@@ -402,7 +742,7 @@ bool AllocateScratchRegs::Apply(lir::CodeIr* code_ir) {
 }
 
 bool MethodInstrumenter::InstrumentMethod(ir::EncodedMethod* ir_method) {
-  SLICER_CHECK(ir_method != nullptr);
+  SLICER_CHECK_NE(ir_method, nullptr);
   if (ir_method->code == nullptr) {
     // can't instrument abstract methods
     return false;

--- a/modules/mockk-agent-android/external/slicer/tests/src/slicer_test.cpp
+++ b/modules/mockk-agent-android/external/slicer/tests/src/slicer_test.cpp
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <iostream>
+#include <string>
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+#include "slicer/common.h"
+#include "slicer/dex_bytecode.h"
+
+static std::string customLoggerMsg;
+static void testCustomLogger(const std::string& msg) {
+  customLoggerMsg = msg;
+}
+
+TEST(Slicer, CustomLogger) {
+  slicer::set_logger(testCustomLogger);
+  slicer::_weakCheckFailed("expr1", 1, "file");
+  std::string expected("\nSLICER_WEAK_CHECK failed [expr1] at file:1\n\n");
+  ASSERT_EQ(customLoggerMsg, expected);
+}
+
+TEST(Slicer, OpcodeToStringStream) {
+  std::stringstream ss;
+  ss << dex::Opcode::OP_IF_GTZ;
+  ASSERT_EQ("[0x3c] if-gtz", ss.str());
+}
+
+TEST(Slicer, KnownInstructionFormatToStringStream) {
+  std::stringstream ss;
+  ss << dex::InstructionFormat::k20bc;
+  ASSERT_EQ("20bc", ss.str());
+}
+
+TEST(Slicer, UnknownInstructionFormatToStringStream) {
+  std::stringstream ss;
+  ss << static_cast<dex::InstructionFormat>(0xfe);
+  ASSERT_EQ("[0xfe] Unknown", ss.str());
+}


### PR DESCRIPTION
Updates slicer DEX bytecode manipulation tools to latest AOSP version (previous was from 2018).

The DEX file format header changed between Android API 35 and 36, which resulted in crashes when running instrumented tests on Android API 36+ emulator.