### PR TITLE
Fix issue 1475: nullable value class verification

### DIFF
--- a/modules/mockk-core/api/mockk-core.api
+++ b/modules/mockk-core/api/mockk-core.api
@@ -2,6 +2,8 @@ public final class io/mockk/core/ValueClassSupport {
 	public static final field INSTANCE Lio/mockk/core/ValueClassSupport;
 	public final fun getBoxedClass (Lkotlin/reflect/KClass;)Lkotlin/reflect/KClass;
 	public final fun getBoxedValue (Ljava/lang/Object;)Ljava/lang/Object;
+	public final fun innermostBoxedClass (Lkotlin/reflect/KClass;I)Lkotlin/reflect/KClass;
+	public static synthetic fun innermostBoxedClass$default (Lio/mockk/core/ValueClassSupport;Lkotlin/reflect/KClass;IILjava/lang/Object;)Lkotlin/reflect/KClass;
 	public final fun maybeUnboxValueForMethodReturn (Ljava/lang/Object;Ljava/lang/reflect/Method;)Ljava/lang/Object;
 }
 

--- a/modules/mockk-core/src/jvmMain/kotlin/io/mockk/core/ValueClassSupport.kt
+++ b/modules/mockk-core/src/jvmMain/kotlin/io/mockk/core/ValueClassSupport.kt
@@ -109,7 +109,7 @@ actual object ValueClassSupport {
      *
      * @param maxDepth Maximum recursion depth (default 10)
      */
-    private fun KClass<*>.innermostBoxedClass(maxDepth: Int = 10): KClass<*> {
+    fun KClass<*>.innermostBoxedClass(maxDepth: Int = 10): KClass<*> {
         if (maxDepth <= 0 || !this.isValue_safe) {
             return this
         }


### PR DESCRIPTION
After merging https://github.com/mockk/mockk/pull/1449, we noticed a new issue involving JvmMockFactoryHelper, where verification does not work with nullable value classes.

We now use innermostBoxedClass() for all value classes (nullable and non-nullable). This function:
- Has built-in recursion protection (max depth of 10)
- Properly unwraps nested value classes
- Works correctly for both nullable and non-nullable types

All tests pass, so we hopefully don't introduce regressions this time.

Thanks to @nishatoma for the issue description and solution suggestion!