### PR TITLE
Enable ktlint unused-imports rule and clean up code

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -4,9 +4,13 @@ root = true
 insert_final_newline = true
 
 [{*.kt,*.kts}]
+# IntelliJ
 ij_kotlin_code_style_defaults = KOTLIN_OFFICIAL
 
 #  Disable wildcard imports entirely
 ij_kotlin_name_count_to_use_star_import = 2147483647
 ij_kotlin_name_count_to_use_star_import_for_members = 2147483647
 ij_kotlin_packages_to_use_import_on_demand = unset
+
+# ktlint
+ktlint_standard_no-unused-imports = enabled

--- a/modules/mockk-dsl/src/jsMain/kotlin/io/mockk/InternalPlatformDsl.kt
+++ b/modules/mockk-dsl/src/jsMain/kotlin/io/mockk/InternalPlatformDsl.kt
@@ -1,7 +1,6 @@
 package io.mockk
 
 import kotlin.coroutines.Continuation
-import kotlin.reflect.KCallable
 import kotlin.reflect.KClass
 
 actual object InternalPlatformDsl {

--- a/test-modules/performance-tests/build.gradle.kts
+++ b/test-modules/performance-tests/build.gradle.kts
@@ -1,4 +1,3 @@
-import buildsrc.config.Deps
 import kotlinx.benchmark.gradle.JvmBenchmarkTarget
 import kotlinx.benchmark.gradle.benchmark
 


### PR DESCRIPTION
This pull request activates the no-unused-imports rule in ktlint and removes existing unused imports across the project to ensure consistent linting and cleaner code.