### PR TITLE
Add List injection support for @InjectMockKs (#1356)

### DIFF
--- a/modules/mockk/src/commonTest/kotlin/io/mockk/it/InjectMocksTest.kt
+++ b/modules/mockk/src/commonTest/kotlin/io/mockk/it/InjectMocksTest.kt
@@ -66,7 +66,7 @@ class InjectMocksListTest {
     }
 
     class Bar(
-        val foos: List<IFoo>
+        val foos: List<IFoo>,
     )
 
     @MockK

--- a/modules/mockk/src/jvmMain/kotlin/io/mockk/impl/annotations/MockInjector.kt
+++ b/modules/mockk/src/jvmMain/kotlin/io/mockk/impl/annotations/MockInjector.kt
@@ -126,11 +126,14 @@ class MockInjector(
         }
     }
 
-    private fun isListType(classifier: KClassifier?): Boolean =
-        classifier == List::class
+    private fun isListType(classifier: KClassifier?): Boolean = classifier == List::class
 
     private fun listElementType(param: KParameter): KClass<*>? {
-        val typeArg = param.type.arguments.firstOrNull()?.type?.classifier
+        val typeArg =
+            param.type.arguments
+                .firstOrNull()
+                ?.type
+                ?.classifier
         return typeArg as? KClass<*>
     }
 
@@ -140,10 +143,11 @@ class MockInjector(
 
         val elementType = listElementType(param) ?: return null
 
-        val mocks = mockHolder::class
-            .memberProperties
-            .filter { isMatchingType(it, elementType) }
-            .mapNotNull { it.getAnyIfLateNull(mockHolder) }
+        val mocks =
+            mockHolder::class
+                .memberProperties
+                .filter { isMatchingType(it, elementType) }
+                .mapNotNull { it.getAnyIfLateNull(mockHolder) }
 
         return mocks.takeIf { it.isNotEmpty() }
     }


### PR DESCRIPTION
Fixes #1356

### Problem
Spring Boot allows injecting a list of implementations via constructor, but currently `@InjectMockKs` cannot handle `List<T>` parameters. It throws an exception or fails to match the parameter.

### Solution
This PR adds support for List injection by collecting all mocks that match the element type of the list.

### Changes
- Introduced `lookupListValues()` to find all matching mocks for `List<T>` based on the generic type.
- Updated `matchParameter()` and `tryMatchingParameters()` to utilize list lookup logic.
- Added unit tests (`InjectMocksListTest`) to verify list injection behavior.

### Note
List injection works only when **Type Lookup** is enabled (which is the default behavior). If lookup is restricted to name-only, list injection is skipped.