### PR TITLE
Bump dokka to 2.2.0-Beta

### DIFF
--- a/buildSrc/src/main/kotlin/buildsrc/convention/dokka.gradle.kts
+++ b/buildSrc/src/main/kotlin/buildsrc/convention/dokka.gradle.kts
@@ -5,9 +5,13 @@ plugins {
 }
 
 dokka {
+    pluginsConfiguration.html {
+        homepageLink = "https://mockk.io"
+        footerMessage = "© 2026 MockK Authors"
+    }
+
     dokkaSourceSets.configureEach {
         sourceLink {
-            // Read docs for more details: https://kotlinlang.org/docs/dokka-gradle.html#source-link-configuration
             remoteUrl("https://github.com/mockk/mockk/tree/master")
             localDirectory.set(rootDir)
         }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,7 +5,7 @@ coroutines = "1.10.2"
 android-gradle = "8.13.2"
 
 kover = "0.9.3"
-dokka = "2.1.0"
+dokka = "2.2.0-Beta"
 binary-compatibility-validator = "0.18.1"
 jreleaser = "1.21.0"
 


### PR DESCRIPTION
bump dokka to 2.2.0-Beta to fix "ERROR CLASS: Symbol not found" in generated dokka
add homepage link and footer to dokka