### PR TITLE
feat(dsl): Add context parameters support module (#1431)

### DIFF
--- a/modules/mockk-context-parameters/build.gradle.kts
+++ b/modules/mockk-context-parameters/build.gradle.kts
@@ -1,0 +1,53 @@
+plugins {
+    buildsrc.convention.`kotlin-multiplatform`
+    buildsrc.convention.`mockk-publishing`
+}
+
+description = "MockK DSL extensions for Kotlin context parameters"
+
+// Provides `withContext` helper functions for stubbing and verifying
+// functions that use Kotlin context parameters.
+// This is a separate module to avoid breaking compatibility with Kotlin < 2.3.
+
+val mavenName: String by extra("MockK Context Parameters")
+val mavenDescription: String by extra("${project.description}")
+
+kotlin {
+    jvm()
+
+    sourceSets {
+        val commonMain by getting {
+            dependencies {
+                implementation(dependencies.platform(libs.kotlin.coroutines.bom))
+                implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core")
+                implementation(kotlin("reflect"))
+                implementation(projects.modules.mockkCore)
+                implementation(projects.modules.mockkDsl)
+                implementation(projects.modules.mockk)
+            }
+        }
+        val commonTest by getting {
+            dependencies {
+                implementation(kotlin("test"))
+            }
+        }
+        val jvmMain by getting {
+            dependencies {
+            }
+        }
+        val jvmTest by getting {
+            dependencies {
+                implementation(kotlin("test-junit5"))
+                implementation(dependencies.platform(libs.junit.bom))
+                implementation("org.junit.jupiter:junit-jupiter")
+                runtimeOnly("org.junit.platform:junit-platform-launcher")
+            }
+        }
+    }
+}
+
+tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().configureEach {
+    compilerOptions {
+        freeCompilerArgs.add("-Xcontext-receivers")
+    }
+}

--- a/modules/mockk-context-parameters/src/commonMain/kotlin/io/mockk/context/ContextParameters.kt
+++ b/modules/mockk-context-parameters/src/commonMain/kotlin/io/mockk/context/ContextParameters.kt
@@ -1,0 +1,70 @@
+@file:Suppress("CONTEXT_RECEIVERS_DEPRECATED", "SUBTYPING_BETWEEN_CONTEXT_RECEIVERS")
+
+package io.mockk.context
+
+import io.mockk.MockKMatcherScope
+
+/**
+ * Helper functions for stubbing and verifying functions that use Kotlin context parameters.
+ *
+ * When a function under test uses context parameters, MockK needs matchers for those
+ * context arguments. These `withContext` overloads supply `any()` matchers for context
+ * parameters while keeping the stub/verify block readable.
+ *
+ * ## Usage
+ *
+ * Given a function with context parameters:
+ * ```kotlin
+ * context(Logger, Raise<DomainError>)
+ * fun fetchUser(id: String): User { ... }
+ * ```
+ *
+ * Stub it:
+ * ```kotlin
+ * every {
+ *     withContext<Logger, Raise<DomainError>> {
+ *         fetchUser("123")
+ *     }
+ * } returns mockUser
+ * ```
+ *
+ * Verify it:
+ * ```kotlin
+ * verify {
+ *     withContext<Logger, Raise<DomainError>> {
+ *         fetchUser("123")
+ *     }
+ * }
+ * ```
+ *
+ * ## How it works
+ *
+ * Context receivers compile to regular function parameters at the JVM level.
+ * A `context(C1) () -> Any?` lambda is `Function1<C1, Any?>` in bytecode.
+ * These helpers invoke the lambda with `any()` matchers, letting MockK record the call.
+ */
+
+/** Provides a single context parameter matcher. */
+inline fun <reified C1 : Any> MockKMatcherScope.withContext(
+    noinline stubBlock: context(C1) () -> Any?
+): Any? = stubBlock(any())
+
+/** Provides two context parameter matchers. */
+inline fun <reified C1 : Any, reified C2 : Any> MockKMatcherScope.withContext(
+    noinline stubBlock: context(C1, C2) () -> Any?
+): Any? = stubBlock(any(), any())
+
+/** Provides three context parameter matchers. */
+inline fun <reified C1 : Any, reified C2 : Any, reified C3 : Any> MockKMatcherScope.withContext(
+    noinline stubBlock: context(C1, C2, C3) () -> Any?
+): Any? = stubBlock(any(), any(), any())
+
+/** Provides four context parameter matchers. */
+inline fun <reified C1 : Any, reified C2 : Any, reified C3 : Any, reified C4 : Any> MockKMatcherScope.withContext(
+    noinline stubBlock: context(C1, C2, C3, C4) () -> Any?
+): Any? = stubBlock(any(), any(), any(), any())
+
+/** Provides five context parameter matchers. */
+inline fun <reified C1 : Any, reified C2 : Any, reified C3 : Any, reified C4 : Any, reified C5 : Any> MockKMatcherScope.withContext(
+    noinline stubBlock: context(C1, C2, C3, C4, C5) () -> Any?
+): Any? = stubBlock(any(), any(), any(), any(), any())

--- a/modules/mockk-context-parameters/src/commonMain/kotlin/io/mockk/context/ContextParameters.kt
+++ b/modules/mockk-context-parameters/src/commonMain/kotlin/io/mockk/context/ContextParameters.kt
@@ -44,7 +44,7 @@ import io.mockk.MockKMatcherScope
  * These helpers invoke the lambda with `any()` matchers, letting MockK record the call.
  */
 
-/** Provides a single context parameter matcher. */
+// Provides a single context parameter matcher.
 inline fun <reified C1 : Any> MockKMatcherScope.withContext(
     noinline stubBlock: context(C1) () -> Any?,
 ): Any? = stubBlock(any())

--- a/modules/mockk-context-parameters/src/commonMain/kotlin/io/mockk/context/ContextParameters.kt
+++ b/modules/mockk-context-parameters/src/commonMain/kotlin/io/mockk/context/ContextParameters.kt
@@ -44,7 +44,6 @@ import io.mockk.MockKMatcherScope
  * These helpers invoke the lambda with `any()` matchers, letting MockK record the call.
  */
 
-// Provides a single context parameter matcher.
 inline fun <reified C1 : Any> MockKMatcherScope.withContext(
     noinline stubBlock: context(C1) () -> Any?,
 ): Any? = stubBlock(any())

--- a/modules/mockk-context-parameters/src/commonMain/kotlin/io/mockk/context/ContextParameters.kt
+++ b/modules/mockk-context-parameters/src/commonMain/kotlin/io/mockk/context/ContextParameters.kt
@@ -44,9 +44,7 @@ import io.mockk.MockKMatcherScope
  * These helpers invoke the lambda with `any()` matchers, letting MockK record the call.
  */
 
-inline fun <reified C1 : Any> MockKMatcherScope.withContext(
-    noinline stubBlock: context(C1) () -> Any?,
-): Any? = stubBlock(any())
+inline fun <reified C1 : Any> MockKMatcherScope.withContext(noinline stubBlock: context(C1) () -> Any?): Any? = stubBlock(any())
 
 /** Provides two context parameter matchers. */
 inline fun <

--- a/modules/mockk-context-parameters/src/commonMain/kotlin/io/mockk/context/ContextParameters.kt
+++ b/modules/mockk-context-parameters/src/commonMain/kotlin/io/mockk/context/ContextParameters.kt
@@ -46,25 +46,43 @@ import io.mockk.MockKMatcherScope
 
 /** Provides a single context parameter matcher. */
 inline fun <reified C1 : Any> MockKMatcherScope.withContext(
-    noinline stubBlock: context(C1) () -> Any?
+    noinline stubBlock: context(C1) () -> Any?,
 ): Any? = stubBlock(any())
 
 /** Provides two context parameter matchers. */
-inline fun <reified C1 : Any, reified C2 : Any> MockKMatcherScope.withContext(
-    noinline stubBlock: context(C1, C2) () -> Any?
+inline fun <
+    reified C1 : Any,
+    reified C2 : Any,
+> MockKMatcherScope.withContext(
+    noinline stubBlock: context(C1, C2) () -> Any?,
 ): Any? = stubBlock(any(), any())
 
 /** Provides three context parameter matchers. */
-inline fun <reified C1 : Any, reified C2 : Any, reified C3 : Any> MockKMatcherScope.withContext(
-    noinline stubBlock: context(C1, C2, C3) () -> Any?
+inline fun <
+    reified C1 : Any,
+    reified C2 : Any,
+    reified C3 : Any,
+> MockKMatcherScope.withContext(
+    noinline stubBlock: context(C1, C2, C3) () -> Any?,
 ): Any? = stubBlock(any(), any(), any())
 
 /** Provides four context parameter matchers. */
-inline fun <reified C1 : Any, reified C2 : Any, reified C3 : Any, reified C4 : Any> MockKMatcherScope.withContext(
-    noinline stubBlock: context(C1, C2, C3, C4) () -> Any?
+inline fun <
+    reified C1 : Any,
+    reified C2 : Any,
+    reified C3 : Any,
+    reified C4 : Any,
+> MockKMatcherScope.withContext(
+    noinline stubBlock: context(C1, C2, C3, C4) () -> Any?,
 ): Any? = stubBlock(any(), any(), any(), any())
 
 /** Provides five context parameter matchers. */
-inline fun <reified C1 : Any, reified C2 : Any, reified C3 : Any, reified C4 : Any, reified C5 : Any> MockKMatcherScope.withContext(
-    noinline stubBlock: context(C1, C2, C3, C4, C5) () -> Any?
+inline fun <
+    reified C1 : Any,
+    reified C2 : Any,
+    reified C3 : Any,
+    reified C4 : Any,
+    reified C5 : Any,
+> MockKMatcherScope.withContext(
+    noinline stubBlock: context(C1, C2, C3, C4, C5) () -> Any?,
 ): Any? = stubBlock(any(), any(), any(), any(), any())

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -24,6 +24,7 @@ include(
     ":modules:mockk-core",
     ":modules:mockk-dsl",
     ":modules:mockk-bdd",
+    ":modules:mockk-context-parameters",
     ":modules:dokka",
 
     ":test-modules:client-tests",


### PR DESCRIPTION
## Summary

Adds a new `mockk-context-parameters` module with `withContext` extension functions for stubbing and verifying functions that use Kotlin context receivers/parameters. This follows the approach discussed in #1431 — a separate opt-in module to avoid breaking backward compatibility with Kotlin < 2.3.

## Related Issue

Closes #1431

## Changes

### New module: `mockk-context-parameters`
- **`ContextParameters.kt`** — 5 overloads of `MockKMatcherScope.withContext<C1, ..., C5>` for 1-5 context parameters
- **`build.gradle.kts`** — Kotlin multiplatform module with `-Xcontext-receivers` compiler flag, depends on `mockk-core`, `mockk-dsl`, and `mockk`
- **`settings.gradle.kts`** — Module registered

### How it works
Context receivers compile to regular function parameters at the JVM level. A `context(C1) () -> Any?` lambda is `Function1<C1, Any?>` in bytecode. The `withContext` helpers invoke the lambda with `any()` matchers, letting MockK record the call properly.

### Usage
```kotlin
// Given a function with context parameters:
context(Logger, Raise<DomainError>)
fun fetchUser(id: String): User { ... }

// Stub it:
every {
    withContext<Logger, Raise<DomainError>> {
        fetchUser("123")
    }
} returns mockUser

// Verify it:
verify {
    withContext<Logger, Raise<DomainError>> {
        fetchUser("123")
    }
}
```

### Gradle dependency (for users)
```kotlin
testImplementation("io.mockk:mockk-context-parameters:$mockkVersion")
```

## Design Decisions

- **Separate module** (per @Raibaz's guidance): Users on Kotlin < 2.3 aren't affected. Users who want context parameter support add this module explicitly.
- **`-Xcontext-receivers` compiler flag**: Enables the feature in this module only. When Kotlin 2.3+ becomes the project minimum, this module can be merged into `mockk-dsl`.
- **`noinline` lambdas**: Required so we can invoke them as `FunctionN` at the JVM level.
- **Up to 5 context parameters**: Covers the vast majority of real-world use cases.

## Testing

- Module compiles successfully: `./gradlew :modules:mockk-context-parameters:compileKotlinJvm`
- Follows the same structure as `mockk-bdd` module (separate opt-in extension)

## Checklist

- [x] Code follows project style guidelines
- [x] No unrelated changes included
- [x] Commit messages follow project conventions
- [x] Build compiles successfully
- [x] Separate module for backward compatibility (per maintainer guidance)