### PR TITLE
Fix UnsupportedOperationException during class retransformation

### DIFF
--- a/modules/mockk-agent/src/jvmMain/kotlin/io/mockk/proxy/jvm/transformation/InliningClassTransformer.kt
+++ b/modules/mockk-agent/src/jvmMain/kotlin/io/mockk/proxy/jvm/transformation/InliningClassTransformer.kt
@@ -16,11 +16,11 @@ import net.bytebuddy.description.ModifierReviewable.OfByteCodeElement
 import net.bytebuddy.description.method.MethodDescription
 import net.bytebuddy.dynamic.ClassFileLocator.Simple.of
 import net.bytebuddy.dynamic.VisibilityBridgeStrategy
+import net.bytebuddy.dynamic.scaffold.MethodGraph
 import net.bytebuddy.matcher.ElementMatchers.isAnnotatedWith
 import net.bytebuddy.matcher.ElementMatchers.isConstructor
 import net.bytebuddy.matcher.ElementMatchers.isDeclaredBy
 import net.bytebuddy.matcher.ElementMatchers.isDefaultFinalizer
-import net.bytebuddy.matcher.ElementMatchers.isDefaultMethod
 import net.bytebuddy.matcher.ElementMatchers.isFinal
 import net.bytebuddy.matcher.ElementMatchers.isMethod
 import net.bytebuddy.matcher.ElementMatchers.isPublic
@@ -87,8 +87,8 @@ internal class InliningClassTransformer(
         try {
             val builder =
                 byteBuddy
-                    // Work around for https://bugs.openjdk.org/browse/JDK-8136614
-                    .with(VisibilityBridgeStrategy { not(isDefaultMethod()).matches(it) })
+                    .with(VisibilityBridgeStrategy.Default.NEVER)
+                    .with(MethodGraph.Compiler.ForDeclaredMethods.INSTANCE)
                     .redefine(classBeingRedefined, of(classBeingRedefined.name, classfileBuffer))
                     .visit(FixParameterNamesVisitor(classBeingRedefined))
 

--- a/test-modules/client-tests/src/jvmTest/kotlin/io/mockk/test/InlineRetransformBridgeMethodTest.kt
+++ b/test-modules/client-tests/src/jvmTest/kotlin/io/mockk/test/InlineRetransformBridgeMethodTest.kt
@@ -1,0 +1,131 @@
+package io.mockk.test
+
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+
+/**
+ * Regression tests for issues #255, #477, #1118, #1487.
+ *
+ * When MockK uses Instrumentation.retransformClasses() via ByteBuddy, the JVM
+ * prohibits adding or removing methods. ByteBuddy's redefine() can generate
+ * bridge methods (visibility bridges, covariant return type bridges, generic
+ * erasure bridges) that didn't exist in the original class, violating this
+ * constraint and throwing UnsupportedOperationException.
+ *
+ * These tests exercise class hierarchies that would trigger bridge method
+ * generation to ensure inline retransformation works correctly.
+ */
+class InlineRetransformBridgeMethodTest {
+
+    // --- Covariant return type hierarchy ---
+
+    abstract class BaseProducer {
+        abstract fun produce(): Any
+    }
+
+    class StringProducer : BaseProducer() {
+        override fun produce(): String = "original"
+    }
+
+    @Test
+    fun `mock class with covariant return type`() {
+        val mock = mockk<StringProducer>()
+        every { mock.produce() } returns "mocked"
+        assertEquals("mocked", mock.produce())
+        verify { mock.produce() }
+    }
+
+    // --- Generic class hierarchy (erasure bridges) ---
+
+    abstract class GenericBase<T> {
+        abstract fun process(input: T): T
+    }
+
+    class StringProcessor : GenericBase<String>() {
+        override fun process(input: String): String = input.uppercase()
+    }
+
+    @Test
+    fun `mock class extending generic base`() {
+        val mock = mockk<StringProcessor>()
+        every { mock.process(any()) } returns "mocked"
+        assertEquals("mocked", mock.process("input"))
+        verify { mock.process("input") }
+    }
+
+    // --- Interface with default method + implementing class ---
+
+    interface Greetable {
+        fun greet(): String = "hello"
+    }
+
+    open class GreetableImpl : Greetable {
+        override fun greet(): String = "hi"
+    }
+
+    @Test
+    fun `mock class implementing interface with default method`() {
+        val mock = mockk<GreetableImpl>()
+        every { mock.greet() } returns "mocked"
+        assertEquals("mocked", mock.greet())
+        verify { mock.greet() }
+    }
+
+    // --- Multi-level covariant hierarchy ---
+
+    interface Producer<out T> {
+        fun get(): T
+    }
+
+    abstract class AbstractStringProducer : Producer<String>
+
+    class ConcreteStringProducer : AbstractStringProducer() {
+        override fun get(): String = "concrete"
+    }
+
+    @Test
+    fun `mock class with multi-level covariant hierarchy`() {
+        val mock = mockk<ConcreteStringProducer>()
+        every { mock.get() } returns "mocked"
+        assertEquals("mocked", mock.get())
+        verify { mock.get() }
+    }
+
+    // --- Abstract class with suspend function ---
+
+    abstract class AbstractService {
+        abstract suspend fun fetch(): String
+    }
+
+    class ConcreteService : AbstractService() {
+        override suspend fun fetch(): String = "data"
+    }
+
+    @Test
+    fun `mock class extending abstract class with suspend function`() {
+        val mock = mockk<ConcreteService>()
+        every { mock.toString() } returns "ConcreteService-mock"
+        assertEquals("ConcreteService-mock", mock.toString())
+    }
+
+    // --- Final class (inline-only mocking) with covariant parent ---
+
+    open class OpenBaseWithReturn {
+        open fun value(): Any = "base"
+    }
+
+    class FinalChildWithCovariantReturn : OpenBaseWithReturn() {
+        override fun value(): String = "child"
+    }
+
+    @Test
+    fun `mock final class with covariant return extending open class`() {
+        val mock = mockk<FinalChildWithCovariantReturn>()
+        every { mock.value() } returns "mocked"
+        assertEquals("mocked", mock.value())
+        verify { mock.value() }
+    }
+}


### PR DESCRIPTION
## Summary

- Suppress all bridge method generation during inline class retransformation to prevent `UnsupportedOperationException: class redefinition failed: attempted to add a method`
- Replace the partial `VisibilityBridgeStrategy` (only suppressed default method bridges for JDK-8136614) with `VisibilityBridgeStrategy.Default.NEVER` + `MethodGraph.Compiler.ForDeclaredMethods.INSTANCE` to prevent all bridge types (visibility, covariant return, generic erasure)
- Add regression tests covering covariant returns, generic erasure, default methods, multi-level hierarchies, suspend functions, and final classes

## Context

When MockK uses `Instrumentation.retransformClasses()` via ByteBuddy, the JVM prohibits adding or removing methods — only method body changes are allowed. ByteBuddy's `redefine()` can generate bridge methods (visibility bridges, covariant return type bridges, generic erasure bridges) that didn't exist in the original class, violating this constraint.

PR #1366 partially fixed this by adding a `VisibilityBridgeStrategy` that suppressed bridges for default methods, but the general case (Kotlin suspend functions on abstract classes, covariant return types, generic type hierarchies) remained broken.

This fix uses two ByteBuddy settings on the retransformation builder (via `.with()`, so the shared instance is unaffected):
1. `VisibilityBridgeStrategy.Default.NEVER` — no visibility bridges
2. `MethodGraph.Compiler.ForDeclaredMethods.INSTANCE` — prevents ByteBuddy from computing the full type hierarchy method graph, eliminating covariant/erasure bridges

Fixes #255, #477, #1118, #1487

## Test plan

- [x] All existing `mockk:jvmTest` tests pass
- [x] All existing `client-tests:jvmTest` tests pass
- [x] New `InlineRetransformBridgeMethodTest` with 6 test cases covering bridge-generating hierarchies

🤖 Generated with [Claude Code](https://claude.com/claude-code)