### PR TITLE
fix: resolve @InjectMockKs dependency order for list injection

### DIFF
--- a/modules/mockk/src/commonTest/kotlin/io/mockk/it/InjectMocksTest.kt
+++ b/modules/mockk/src/commonTest/kotlin/io/mockk/it/InjectMocksTest.kt
@@ -90,7 +90,7 @@ class InjectMocksListTest {
 }
 
 /**
- * See issue #1496, #1523
+ * See issue #1496, #1523, #1524
  * Test for @InjectMockKs dependency order resolution using topological sort.
  *
  * Problem: MockK previously processed @InjectMockKs fields in reflection order,
@@ -152,6 +152,10 @@ class InjectMocksDependencyOrderTest {
 
     class InterfaceConsumer(
         val dependency: InterfaceDependency,
+    )
+
+    class ListInterfaceConsumer(
+        val dependencies: List<InterfaceDependency>,
     )
 
     // Circular dependency (intentionally no "Circular" in class name for test accuracy)
@@ -314,7 +318,39 @@ class InjectMocksDependencyOrderTest {
         kotlin.test.assertSame(obj.implementation, obj.consumer.dependency, "InterfaceConsumer should receive the implementation")
     }
 
-    // ========== Test 5: Circular dependency detection ==========
+    // ========== Test 5: List dependency ==========
+
+    class ListDependencyTestTarget {
+        @InjectMockKs
+        lateinit var consumer: ListInterfaceConsumer
+
+        @InjectMockKs
+        lateinit var implementation1: InterfaceDependencyImpl
+
+        @InjectMockKs
+        lateinit var implementation2: InterfaceDependencyImpl
+    }
+
+    @Test
+    fun listDependency() {
+        val obj = ListDependencyTestTarget()
+        MockKAnnotations.init(obj, useDependencyOrder = true)
+
+        kotlin.test.assertNotNull(obj.implementation1, "The first InterfaceDependencyImpl should be created")
+        kotlin.test.assertNotNull(obj.implementation2, "The second InterfaceDependencyImpl should be created")
+        kotlin.test.assertNotNull(obj.consumer, "ListInterfaceConsumer should be created")
+        kotlin.test.assertEquals(2, obj.consumer.dependencies.size, "ListInterfaceConsumer should receive two implementations")
+        kotlin.test.assertTrue(
+            obj.consumer.dependencies.contains(obj.implementation1),
+            "ListInterfaceConsumer should receive the first implementation",
+        )
+        kotlin.test.assertTrue(
+            obj.consumer.dependencies.contains(obj.implementation2),
+            "ListInterfaceConsumer should receive the second implementation",
+        )
+    }
+
+    // ========== Test 6: Circular dependency detection ==========
 
     class CircularTestTarget {
         @InjectMockKs

--- a/modules/mockk/src/jvmMain/kotlin/io/mockk/impl/annotations/InjectionHelpers.kt
+++ b/modules/mockk/src/jvmMain/kotlin/io/mockk/impl/annotations/InjectionHelpers.kt
@@ -2,6 +2,7 @@ package io.mockk.impl.annotations
 
 import java.lang.reflect.InvocationTargetException
 import kotlin.reflect.KClass
+import kotlin.reflect.KClassifier
 import kotlin.reflect.KMutableProperty1
 import kotlin.reflect.KProperty
 import kotlin.reflect.KProperty1
@@ -64,9 +65,20 @@ internal object InjectionHelpers {
 
     fun KType.getKClass(): KClass<*>? = classifier as? KClass<*>
 
-    fun KClass<*>.getConstructorParameterTypes(): Set<KClass<*>> =
+    fun KClass<*>.getConstructorParameterTypes(): Set<KType> =
         constructors
             .flatMap { constructor ->
-                constructor.parameters.mapNotNull { it.type.getKClass() }
+                constructor.parameters.map { it.type }
             }.toSet()
+
+    fun isListType(classifier: KClassifier?): Boolean = classifier == List::class
+
+    fun getListElementType(type: KType): KClass<*>? {
+        val typeArg =
+            type.arguments
+                .firstOrNull()
+                ?.type
+                ?.classifier
+        return typeArg as? KClass<*>
+    }
 }

--- a/modules/mockk/src/jvmMain/kotlin/io/mockk/impl/annotations/JvmMockInitializer.kt
+++ b/modules/mockk/src/jvmMain/kotlin/io/mockk/impl/annotations/JvmMockInitializer.kt
@@ -6,7 +6,10 @@ import io.mockk.MockKException
 import io.mockk.MockKGateway
 import io.mockk.impl.annotations.InjectionHelpers.getAnyIfLateNull
 import io.mockk.impl.annotations.InjectionHelpers.getConstructorParameterTypes
+import io.mockk.impl.annotations.InjectionHelpers.getKClass
+import io.mockk.impl.annotations.InjectionHelpers.getListElementType
 import io.mockk.impl.annotations.InjectionHelpers.getReturnTypeKClass
+import io.mockk.impl.annotations.InjectionHelpers.isListType
 import kotlin.reflect.KClass
 import kotlin.reflect.KMutableProperty1
 import kotlin.reflect.KProperty
@@ -127,16 +130,45 @@ class JvmMockInitializer(
         return properties.associateWith { property ->
             val clazz = property.getReturnTypeKClass() ?: return@associateWith emptySet()
 
+            val dependencies = mutableSetOf<KProperty1<Any, Any>>()
             clazz
                 .getConstructorParameterTypes()
-                .mapNotNull { paramType ->
-                    typeToProperty[paramType]
-                        ?: typeToProperty.entries
-                            .firstOrNull { (providerType, _) -> providerType.isSubclassOf(paramType) }
-                            ?.value
-                }.toSet()
+                .forEach { paramType ->
+                    val paramClass = paramType.getKClass() ?: return@forEach
+
+                    if (isListType(paramClass)) {
+                        val elementType = getListElementType(paramType) ?: return@forEach
+
+                        lookupPropertiesByType(properties, elementType)
+                            .also { dependencies.addAll(it) }
+                    } else {
+                        lookupPropertyByType(typeToProperty, paramClass)
+                            ?.also { dependencies.add(it) }
+                    }
+                }
+            dependencies
         }
     }
+
+    private fun lookupPropertiesByType(
+        properties: List<KProperty1<Any, Any>>,
+        type: KClass<*>,
+    ): List<KProperty1<Any, Any>> =
+        properties.filter {
+            it
+                .getReturnTypeKClass()
+                ?.isSubclassOf(type)
+                ?: false
+        }
+
+    private fun lookupPropertyByType(
+        typeToProperty: Map<KClass<*>, KProperty1<Any, Any>>,
+        type: KClass<*>,
+    ): KProperty1<Any, Any>? =
+        typeToProperty[type]
+            ?: typeToProperty.entries
+                .firstOrNull { (providerType, _) -> providerType.isSubclassOf(type) }
+                ?.value
 
     /**
      * Performs topological sort using Kahn's algorithm.

--- a/modules/mockk/src/jvmMain/kotlin/io/mockk/impl/annotations/MockInjector.kt
+++ b/modules/mockk/src/jvmMain/kotlin/io/mockk/impl/annotations/MockInjector.kt
@@ -2,6 +2,8 @@ package io.mockk.impl.annotations
 
 import io.mockk.MockKException
 import io.mockk.impl.annotations.InjectionHelpers.getAnyIfLateNull
+import io.mockk.impl.annotations.InjectionHelpers.getListElementType
+import io.mockk.impl.annotations.InjectionHelpers.isListType
 import io.mockk.impl.annotations.InjectionHelpers.setAny
 import io.mockk.impl.annotations.InjectionHelpers.setImmutableAny
 import kotlin.reflect.KClass
@@ -126,22 +128,11 @@ class MockInjector(
         }
     }
 
-    private fun isListType(classifier: KClassifier?): Boolean = classifier == List::class
-
-    private fun listElementType(param: KParameter): KClass<*>? {
-        val typeArg =
-            param.type.arguments
-                .firstOrNull()
-                ?.type
-                ?.classifier
-        return typeArg as? KClass<*>
-    }
-
     private fun lookupListValues(param: KParameter): List<Any>? {
         if (!isListType(param.type.classifier)) return null
         if (!lookupType.byType) return null
 
-        val elementType = listElementType(param) ?: return null
+        val elementType = getListElementType(param.type) ?: return null
 
         val mocks =
             mockHolder::class


### PR DESCRIPTION
Fixes: #1524

### Problem

`MockKAnnotations.init(useDependencyOrder = true)` does not resolve dependencies for `@InjectMockKs` properties if they depend on a `List` of other properties.

### Solution

For each dependency on `List<T>` added lookup for all properties of type `T` in `JvmMockInitializer.buildDependencyGraph()`.

### Changes

* Added utility functions in `InjectionHelpers` to work with properties of `List` type.
* Changed return type of internal `InjectionHelpers.getConstructorParameterTypes()`.