### PR TITLE
fix: support OpenJ9 in JvmAutoHinter

### DIFF
--- a/modules/mockk/src/jvmMain/kotlin/io/mockk/impl/recording/JvmAutoHinter.kt
+++ b/modules/mockk/src/jvmMain/kotlin/io/mockk/impl/recording/JvmAutoHinter.kt
@@ -50,11 +50,14 @@ class JvmAutoHinter : AutoHinter() {
         } ?: throw ex
 
     companion object {
-        // JDK 8: net.bytebuddy.renamed.java.lang.Object$ByteBuddy$As29nsJf$ByteBuddy$877l7O7D cannot be cast to io.mockk.impl.recording.states.CallRecordingState
-        // JDK 9:
-        // JDK 10:
-        // JDK 11: class net.bytebuddy.renamed.java.lang.Object$ByteBuddy$rpycQEYo$ByteBuddy$bHEk1ADY cannot be cast to class java.lang.String (net.bytebuddy.renamed.java.lang.Object$ByteBuddy$rpycQEYo$ByteBuddy$bHEk1ADY is in unnamed module of loader net.bytebuddy.dynamic.loading.ByteArrayClassLoader @19569ebd; java.lang.String is in module java.base of loader 'bootstrap')
-        val exceptionMessage = Regex("cannot be cast to (class )?(.+/)?(.+?)( \\((.+)\\))?$")
+        // HotSpot pre-JEP358 (JDK 8-13):
+        //   net.bytebuddy.renamed.java.lang.Object$ByteBuddy$As29nsJf$ByteBuddy$877l7O7D cannot be cast to io.mockk.impl.recording.states.CallRecordingState
+        // HotSpot JEP358 (JDK 14+):
+        //   class net.bytebuddy.renamed.java.lang.Object$ByteBuddy$rpycQEYo$ByteBuddy$bHEk1ADY cannot be cast to class java.lang.String (net.bytebuddy.renamed.java.lang.Object$ByteBuddy$rpycQEYo$ByteBuddy$bHEk1ADY is in unnamed module of loader net.bytebuddy.dynamic.loading.ByteArrayClassLoader @19569ebd; java.lang.String is in module java.base of loader 'bootstrap')
+        // OpenJ9 / IBM Semeru (all releases):
+        //   net.bytebuddy.renamed.java.lang.Object$ByteBuddy$As29nsJf$ByteBuddy$877l7O7D incompatible with java.lang.String
+        val exceptionMessage =
+            Regex("(?:cannot be cast to|incompatible with) (class )?(.+/)?(.+?)( \\((.+)\\))?$")
 
         val log = Logger<JvmAutoHinter>()
     }

--- a/modules/mockk/src/jvmTest/kotlin/io/mockk/impl/recording/JvmAutoHinterTest.kt
+++ b/modules/mockk/src/jvmTest/kotlin/io/mockk/impl/recording/JvmAutoHinterTest.kt
@@ -1,0 +1,67 @@
+package io.mockk.impl.recording
+
+import io.mockk.impl.recording.JvmAutoHinter.Companion.exceptionMessage
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+
+class JvmAutoHinterTest {
+    @Test
+    fun extractsTargetClassFromHotSpotPreJep358Message() {
+        val msg =
+            "net.bytebuddy.renamed.java.lang.Object\$ByteBuddy\$abc " +
+                "cannot be cast to java.lang.String"
+        assertEquals(
+            "java.lang.String",
+            exceptionMessage
+                .find(msg)
+                ?.groups
+                ?.get(3)
+                ?.value,
+        )
+    }
+
+    @Test
+    fun extractsTargetClassFromHotSpotJep358Message() {
+        val msg =
+            "class net.bytebuddy.renamed.java.lang.Object\$ByteBuddy\$abc " +
+                "cannot be cast to class java.lang.String " +
+                "(net.bytebuddy.renamed.java.lang.Object\$ByteBuddy\$abc is in unnamed module " +
+                "of loader net.bytebuddy.dynamic.loading.ByteArrayClassLoader @19569ebd; " +
+                "java.lang.String is in module java.base of loader 'bootstrap')"
+        assertEquals(
+            "java.lang.String",
+            exceptionMessage
+                .find(msg)
+                ?.groups
+                ?.get(3)
+                ?.value,
+        )
+    }
+
+    @Test
+    fun extractsTargetClassFromOpenJ9Message() {
+        val msg =
+            "net.bytebuddy.renamed.java.lang.Object\$ByteBuddy\$abc " +
+                "incompatible with java.lang.String"
+        assertEquals(
+            "java.lang.String",
+            exceptionMessage
+                .find(msg)
+                ?.groups
+                ?.get(3)
+                ?.value,
+        )
+    }
+
+    @Test
+    fun returnsNullOnUnrecognisedMessage() {
+        assertNull(
+            exceptionMessage
+                .find("some other failure")
+                ?.groups
+                ?.get(3)
+                ?.value,
+        )
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #726.

## Root cause

### 1. JvmAutoHinter parses HotSpot-specific text

`JvmAutoHinter` recovers the expected return type of an erased generic call by catching the synthetic `ClassCastException` thrown during stub recording and parsing the exception message with a regex anchored on HotSpot's `"cannot be cast to"` phrasing:

```kotlin
val exceptionMessage =
    Regex("cannot be cast to (class )?(.+/)?(.+?)( \\((.+)\\))?$")
```

`extractClassName` reads capture group 3 (the target class), feeds it to `Class.forName`, stores the `KClass<*>` as a hint, and replays the recording round with the type pre-seeded.

### 2. OpenJ9 emits a different message format

OpenJ9 / IBM Semeru hardcodes its own `ClassCastException` message phrasing in the native VM helpers and never uses the JEP 358 wording. On OpenJ9 the same failure surfaces as:

```
java.lang.ClassCastException:
    java.lang.Object incompatible with java.lang.String
```

The HotSpot-shaped regex never matches -> `extractClassName` returns null -> the original `CCE` is re-thrown -> `prettifyRecordingException` wraps it as `MockKException: Class cast exception happened`. Auto-hinting silently fails.

### 3. User-visible failure mode

Minimal failing test on OpenJ9 (passes on HotSpot):

```kotlin
interface Provider<T> { fun get(): T }

class GenericHinterTest {
    @Test
    fun `auto hint does not work on OpenJ9`() {
        val mocked = mockk<Provider<String>>()
        every { mocked.get() } returns "Hello, World!"   // throws on OpenJ9
        assertEquals("Hello, World!", mocked.get())
    }
}
```

Workaround users currently apply on OpenJ9 - manual `hint` inside every block:

```kotlin
every {
    hint(String::class)
    mocked.get()
} returns "Hello, World!"
```

## Fix

`JvmAutoHinter.exceptionMessage` regex now matches both phrasings via an alternation. Capture group indices are preserved, so `extractClassName` reads group 3 unchanged.

| JVM / JDK | Message format |
|---|---|
| HotSpot pre-JEP358 (JDK 8-13) | `X cannot be cast to Y` |
| HotSpot JEP358 (JDK 14+) | `class X cannot be cast to class Y (... in module ...)` |
| OpenJ9 / IBM Semeru (all releases) | `X incompatible with Y` |

The format-variant comment block above the regex is updated to document all three cases.

## Test plan

- [x] `JvmAutoHinterTest` covers the three known message variants + an unrecognised-format negative case
- [x] `:modules:mockk:check` green locally on JDK 17 + Kotlin 2.2.21
- [x] `spotlessCheck` + mockk `apiCheck` clean — no public-API change
- [x] Per-module `check` green for every non-Android module
- [ ] CI matrix (Java 17/21/25 × Kotlin 1.5.32 → 2.3.0) pending