### PR TITLE
fix: prevent null packRef for value class with nullable inner value in sealed interface (#1326)

### DIFF
--- a/modules/dokka/build.gradle.kts
+++ b/modules/dokka/build.gradle.kts
@@ -6,12 +6,14 @@ plugins {
 dependencies {
     dokka(projects.modules.mockk)
     dokka(projects.modules.mockkAgent)
-    dokka(projects.modules.mockkAgentAndroid)
-    dokka(projects.modules.mockkAgentAndroidDispatcher)
+    listOf(
+        ":modules:mockk-agent-android",
+        ":modules:mockk-agent-android-dispatcher",
+        ":modules:mockk-android",
+        ":modules:mockk-bdd-android",
+    ).forEach { path -> findProject(path)?.let { dokka(it) } }
     dokka(projects.modules.mockkAgentApi)
-    dokka(projects.modules.mockkAndroid)
     dokka(projects.modules.mockkBdd)
-    dokka(projects.modules.mockkBddAndroid)
     dokka(projects.modules.mockkCore)
     dokka(projects.modules.mockkDsl)
 }

--- a/modules/dokka/build.gradle.kts
+++ b/modules/dokka/build.gradle.kts
@@ -6,14 +6,12 @@ plugins {
 dependencies {
     dokka(projects.modules.mockk)
     dokka(projects.modules.mockkAgent)
-    listOf(
-        ":modules:mockk-agent-android",
-        ":modules:mockk-agent-android-dispatcher",
-        ":modules:mockk-android",
-        ":modules:mockk-bdd-android",
-    ).forEach { path -> findProject(path)?.let { dokka(it) } }
+    dokka(projects.modules.mockkAgentAndroid)
+    dokka(projects.modules.mockkAgentAndroidDispatcher)
     dokka(projects.modules.mockkAgentApi)
+    dokka(projects.modules.mockkAndroid)
     dokka(projects.modules.mockkBdd)
+    dokka(projects.modules.mockkBddAndroid)
     dokka(projects.modules.mockkCore)
     dokka(projects.modules.mockkDsl)
 }

--- a/modules/mockk/src/jvmMain/kotlin/io/mockk/impl/InternalPlatform.kt
+++ b/modules/mockk/src/jvmMain/kotlin/io/mockk/impl/InternalPlatform.kt
@@ -73,7 +73,7 @@ actual object InternalPlatform {
     actual fun packRef(arg: Any?): Any? =
         when {
             arg == null -> null
-            isValueClass(arg::class) -> packRef(arg.boxedValue)
+            isValueClass(arg::class) -> packRef(arg.boxedValue) ?: ref(arg)
             isPassedByValue(arg::class.boxedClass) -> arg.boxedValue
             else -> ref(arg)
         }

--- a/modules/mockk/src/jvmTest/kotlin/io/mockk/impl/recording/JvmSignatureValueGeneratorTest.kt
+++ b/modules/mockk/src/jvmTest/kotlin/io/mockk/impl/recording/JvmSignatureValueGeneratorTest.kt
@@ -1,5 +1,6 @@
 package io.mockk.impl.recording
 
+import io.mockk.impl.InternalPlatform
 import io.mockk.impl.instantiation.AbstractInstantiator
 import io.mockk.impl.instantiation.AnyValueGenerator
 import io.mockk.impl.instantiation.CommonInstanceFactoryRegistry
@@ -13,6 +14,11 @@ import kotlin.test.fail
 import kotlin.time.Duration
 import kotlin.time.DurationUnit
 import kotlin.time.toDuration
+
+@JvmInline
+value class NullableInnerValueClass(
+    val value: String?,
+)
 
 class JvmSignatureValueGeneratorTest {
     private val generator = JvmSignatureValueGenerator(Random(42))
@@ -78,6 +84,16 @@ class JvmSignatureValueGeneratorTest {
 
             assertNotNull(duration, "Duration should be created successfully")
         }
+    }
+
+    // https://github.com/mockk/mockk/issues/1326
+    @Test
+    fun `packRef for value class with null inner value returns non-null`() {
+        val instance = NullableInnerValueClass(null)
+        assertNotNull(
+            InternalPlatform.packRef(instance),
+            "packRef for value class with null inner value must not return null",
+        )
     }
 
     companion object {

--- a/test-modules/client-tests/src/jvmTest/kotlin/io/mockk/core/SealedInterfaceWithValueClassTest.kt
+++ b/test-modules/client-tests/src/jvmTest/kotlin/io/mockk/core/SealedInterfaceWithValueClassTest.kt
@@ -1,0 +1,67 @@
+package io.mockk.core
+
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+// https://github.com/mockk/mockk/issues/1326
+sealed interface SealedInput
+
+@JvmInline
+value class WrappedString(
+    val value: String?,
+) : SealedInput
+
+@JvmInline
+value class WrappedNonNull(
+    val value: String,
+) : SealedInput
+
+interface Processor {
+    fun process(input: SealedInput): String
+}
+
+class SealedInterfaceWithValueClassTest {
+    @Test
+    fun `capturing argument of sealed interface with nullable-inner value class does not throw`() {
+        val mock = mockk<Processor>()
+        val slot = slot<SealedInput>()
+
+        every { mock.process(capture(slot)) } returns "ok"
+
+        val result = mock.process(WrappedString(null))
+        assertEquals("ok", result)
+        assertEquals(WrappedString(null), slot.captured)
+    }
+
+    @Test
+    fun `capturing argument of sealed interface with non-null-inner value class does not throw`() {
+        val mock = mockk<Processor>()
+        val slot = slot<SealedInput>()
+
+        every { mock.process(capture(slot)) } returns "ok"
+
+        val result = mock.process(WrappedNonNull("hello"))
+        assertEquals("ok", result)
+        assertEquals(WrappedNonNull("hello"), slot.captured)
+    }
+
+    @Test
+    fun `matching sealed interface argument returns correct stub`() {
+        val mock = mockk<Processor>()
+
+        every { mock.process(any()) } returns "matched"
+
+        assertEquals("matched", mock.process(WrappedString(null)))
+        assertEquals("matched", mock.process(WrappedNonNull("hi")))
+    }
+
+    @Test
+    fun `relaxed mock with sealed interface and value class subclass returns default`() {
+        val mock = mockk<Processor>(relaxed = true)
+        val result = mock.process(WrappedString(null))
+        assertEquals("", result)
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #1326

When a `sealed interface` has a `@JvmInline value class` subclass whose inner field is **nullable**, MockK crashes with:

```
java.lang.IllegalStateException: null packRef for class S signature A(value=null)
    at io.mockk.impl.recording.states.RecordingState.matcher(RecordingState.kt:53)
```

### Root Cause

`packRef()` in `InternalPlatform` unwraps a value class by calling `arg.boxedValue`. When the inner value is `null`, `boxedValue` returns `null`, so `packRef` itself returns `null` — even though `arg` (the boxed value class instance) is non-null. `RecordingState.matcher()` then hits the `?: error(...)` guard.

```kotlin
sealed interface S
@JvmInline value class A(val value: String?) : S

mockk<Service>().let {
    every { it.process(capture(slot)) } returns "ok"  // 💥 IllegalStateException
}
```

### Fix

Add a fallback to `ref(arg)` (identity ref of the boxed instance) when `boxedValue` is `null`:

```kotlin
// Before
isValueClass(arg::class) -> packRef(arg.boxedValue)

// After
isValueClass(arg::class) -> packRef(arg.boxedValue) ?: ref(arg)
```

This ensures `packRef` always returns a non-null key for a non-null argument, regardless of the inner value's nullability.

## Test plan

- [x] `JvmSignatureValueGeneratorTest`: new unit test directly validates `InternalPlatform.packRef` returns non-null for a value class with null inner value
- [x] `SealedInterfaceWithValueClassTest`: four integration tests covering
  - Capturing `SealedInput` arg backed by nullable-inner value class
  - Capturing `SealedInput` arg backed by non-null-inner value class
  - `any()` matcher across both subclass variants
  - Relaxed mock returning default value
- [x] `./gradlew check` passes (all existing tests green, Spotless/ktlint clean)