### PR TITLE
fix: make clearAllMocks flags correctly isolate mock types (#1520)

### DIFF
--- a/modules/mockk/src/commonMain/kotlin/io/mockk/impl/stub/CommonClearer.kt
+++ b/modules/mockk/src/commonMain/kotlin/io/mockk/impl/stub/CommonClearer.kt
@@ -26,11 +26,19 @@ class CommonClearer(
         currentThreadOnly: Boolean,
     ) {
         val currentThreadId = Thread.currentThread().id
-        stubRepository.allStubs.forEach {
-            if (currentThreadOnly && currentThreadId != it.threadId) {
+        stubRepository.allStubs.forEach { stub ->
+            if (currentThreadOnly && currentThreadId != stub.threadId) {
                 return@forEach
             }
-            it.clear(options)
+            val isRegularOrSpy =
+                when {
+                    stub is SpyKStub<*> -> stub.mockType == MockType.SPY
+                    stub is MockKStub -> stub.mockType == MockType.REGULAR
+                    else -> false
+                }
+            if (isRegularOrSpy) {
+                stub.clear(options)
+            }
         }
     }
 

--- a/modules/mockk/src/jvmMain/kotlin/io/mockk/impl/instantiation/JvmConstructorMockFactory.kt
+++ b/modules/mockk/src/jvmMain/kotlin/io/mockk/impl/instantiation/JvmConstructorMockFactory.kt
@@ -300,7 +300,18 @@ class JvmConstructorMockFactory(
         options: MockKGateway.ClearOptions,
         currentThreadOnly: Boolean,
     ) {
-        clearer.clearAll(options, currentThreadOnly)
+        val currentThreadId = Thread.currentThread().id
+        clearer.stubRepository.allStubs.forEach { stub ->
+            if (currentThreadOnly && currentThreadId != stub.threadId) {
+                return@forEach
+            }
+            val isConstructorMock =
+                stub is ConstructorStub ||
+                    (stub is SpyKStub<*> && stub.mockType == MockType.CONSTRUCTOR)
+            if (isConstructorMock) {
+                stub.clear(options)
+            }
+        }
     }
 
     fun isMock(cls: KClass<*>) =

--- a/modules/mockk/src/jvmMain/kotlin/io/mockk/impl/instantiation/JvmObjectMockFactory.kt
+++ b/modules/mockk/src/jvmMain/kotlin/io/mockk/impl/instantiation/JvmObjectMockFactory.kt
@@ -90,11 +90,13 @@ class JvmObjectMockFactory(
         currentThreadOnly: Boolean,
     ) {
         val currentThreadId = Thread.currentThread().id
-        stubRepository.allStubs.forEach {
-            if (currentThreadOnly && currentThreadId != it.threadId) {
+        stubRepository.allStubs.forEach { stub ->
+            if (currentThreadOnly && currentThreadId != stub.threadId) {
                 return@forEach
             }
-            it.clear(options)
+            if (stub is SpyKStub<*> && stub.mockType == MockType.OBJECT) {
+                stub.clear(options)
+            }
         }
     }
 

--- a/modules/mockk/src/jvmMain/kotlin/io/mockk/impl/instantiation/JvmStaticMockFactory.kt
+++ b/modules/mockk/src/jvmMain/kotlin/io/mockk/impl/instantiation/JvmStaticMockFactory.kt
@@ -71,11 +71,13 @@ class JvmStaticMockFactory(
         currentThreadOnly: Boolean,
     ) {
         val currentThreadId = Thread.currentThread().id
-        stubRepository.allStubs.forEach {
-            if (currentThreadOnly && currentThreadId != it.threadId) {
+        stubRepository.allStubs.forEach { stub ->
+            if (currentThreadOnly && currentThreadId != stub.threadId) {
                 return@forEach
             }
-            it.clear(options)
+            if (stub is SpyKStub<*> && stub.mockType == MockType.STATIC) {
+                stub.clear(options)
+            }
         }
     }
 

--- a/modules/mockk/src/jvmTest/kotlin/io/mockk/it/ClearAllMocksFlagIsolationTest.kt
+++ b/modules/mockk/src/jvmTest/kotlin/io/mockk/it/ClearAllMocksFlagIsolationTest.kt
@@ -1,0 +1,104 @@
+package io.mockk.it
+
+import io.mockk.clearAllMocks
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkConstructor
+import io.mockk.mockkObject
+import io.mockk.mockkStatic
+import io.mockk.spyk
+import io.mockk.unmockkAll
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+
+fun flagTestTopLevel() = 0
+
+class ClearAllMocksFlagIsolationTest {
+    class Target {
+        fun value() = 0
+    }
+
+    object ObjectTarget {
+        fun value() = 0
+    }
+
+    @AfterEach
+    fun tearDown() = unmockkAll()
+
+    @Test
+    fun `regularMocks flag only clears regular and spy mocks`() {
+        val mock = mockk<Target>(relaxed = true)
+        val spy = spyk(Target())
+        val obj = ObjectTarget
+        mockkObject(obj)
+
+        every { mock.value() } returns 10
+        every { spy.value() } returns 20
+        every { obj.value() } returns 30
+
+        clearAllMocks(regularMocks = true, objectMocks = false, staticMocks = false, constructorMocks = false)
+
+        assertEquals(0, mock.value())
+        assertEquals(0, spy.value())
+        assertEquals(30, obj.value())
+    }
+
+    @Test
+    fun `objectMocks flag only clears object mocks`() {
+        val mock = mockk<Target>(relaxed = true)
+        val obj = ObjectTarget
+        mockkObject(obj)
+
+        every { mock.value() } returns 10
+        every { obj.value() } returns 30
+
+        clearAllMocks(regularMocks = false, objectMocks = true, staticMocks = false, constructorMocks = false)
+
+        assertEquals(10, mock.value())
+        assertEquals(0, obj.value())
+    }
+
+    @Test
+    fun `staticMocks flag only clears static mocks`() {
+        val mock = mockk<Target>(relaxed = true)
+        mockkStatic("io.mockk.it.ClearAllMocksFlagIsolationTestKt")
+
+        every { mock.value() } returns 10
+        every { flagTestTopLevel() } returns 99
+
+        clearAllMocks(regularMocks = false, objectMocks = false, staticMocks = true, constructorMocks = false)
+
+        assertEquals(10, mock.value())
+        assertEquals(0, flagTestTopLevel())
+    }
+
+    @Test
+    fun `constructorMocks flag only clears constructor mocks`() {
+        val mock = mockk<Target>(relaxed = true)
+        mockkConstructor(Target::class)
+
+        every { mock.value() } returns 10
+        every { anyConstructed<Target>().value() } returns 77
+
+        clearAllMocks(regularMocks = false, objectMocks = false, staticMocks = false, constructorMocks = true)
+
+        assertEquals(10, mock.value())
+        assertEquals(0, Target().value())
+    }
+
+    @Test
+    fun `no flags set clears nothing`() {
+        val mock = mockk<Target>(relaxed = true)
+        val obj = ObjectTarget
+        mockkObject(obj)
+
+        every { mock.value() } returns 10
+        every { obj.value() } returns 30
+
+        clearAllMocks(regularMocks = false, objectMocks = false, staticMocks = false, constructorMocks = false)
+
+        assertEquals(10, mock.value())
+        assertEquals(30, obj.value())
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #1520

- Each `clearAll` implementation was iterating the entire shared `StubRepository` regardless of which flag was set, so `clearAllMocks(regularMocks=true, objectMocks=false, ...)` cleared every mock type instead of only regular/spy mocks.
- `CommonClearer.clearAll` now filters to `REGULAR` and `SPY` stubs only.
- `JvmObjectMockFactory.clearAll` now filters to `OBJECT` stubs only.
- `JvmStaticMockFactory.clearAll` now filters to `STATIC` stubs only.
- `JvmConstructorMockFactory.clearAll` now filters to `CONSTRUCTOR` stubs (both the representative `SpyKStub` and `ConstructorStub` wrapper instances).

The filtering uses the existing `MockType` field on `MockKStub`/`SpyKStub`, following the same pattern already used in `CommonMockTypeChecker`.

## Test plan

- [ ] New `ClearAllMocksFlagIsolationTest` (5 tests) — each flag clears only its intended mock type and leaves others untouched
- [ ] Existing `ClearMocksTest.clearAll` — `clearAllMocks()` with all flags defaulting to `true` still clears everything (no regression)
- [ ] Full JVM test suite passes with no regressions