### PR TITLE
fix: nullable value class issue in anyValue()

### DIFF
--- a/modules/mockk/src/jvmMain/kotlin/io/mockk/impl/instantiation/JvmAnyValueGenerator.kt
+++ b/modules/mockk/src/jvmMain/kotlin/io/mockk/impl/instantiation/JvmAnyValueGenerator.kt
@@ -9,8 +9,15 @@ open class JvmAnyValueGenerator(
         cls: KClass<*>,
         isNullable: Boolean,
         orInstantiateVia: () -> Any?,
-    ): Any? =
-        when (cls) {
+    ): Any? {
+        // For nullable value classes return null directly instead of creating an Objenesis instance.
+        // Objenesis zero-initializes the underlying field (e.g. 0L for Long-backed value classes),
+        // and maybeUnboxValueForMethodReturn then returns the instance rather than null because
+        // unbox-impl() is non-null. This causes the recording state to treat it as a live mock,
+        // triggering unnecessary child-mock creation that fails for value classes.
+        if (isNullable && runCatching { cls.isValue }.getOrDefault(false)) return null
+
+        return when (cls) {
             Void.TYPE.kotlin -> voidInstance
             Void::class -> voidInstance
 
@@ -41,4 +48,5 @@ open class JvmAnyValueGenerator(
                     }
                 }
         }
+    }
 }

--- a/test-modules/client-tests/src/jvmTest/kotlin/io/mockk/core/ValueClassSupportTest.kt
+++ b/test-modules/client-tests/src/jvmTest/kotlin/io/mockk/core/ValueClassSupportTest.kt
@@ -7,6 +7,7 @@ import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertNull
 import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 class ValueClassSupportTest {
     /** https://github.com/mockk/mockk/issues/868 */
@@ -31,6 +32,30 @@ class ValueClassSupportTest {
                 every { v } returns testValue
             }
         assertEquals(testValue, mock.v)
+    }
+
+    @Test
+    fun `verify mocked generic return value`() {
+        val value = InlineValueWrapper(1)
+        val mock =
+            mockk<ParameterizedValueClassService<InlineValueWrapper>> {
+                every { value() } returns value
+            }
+        assertEquals(value, mock.value())
+    }
+
+    @Test
+    fun `verify null mocked generic return value`() {
+        val mock =
+            mockk<ParameterizedValueClassService<InlineValueWrapper>> {
+                every { nullableValue() } returns null
+            }
+
+        // https://github.com/mockk/mockk/issues/1341
+        val isResNull = mock.nullableValue() == null
+        assertTrue(isResNull)
+
+        assertEquals(null, mock.nullableValue())
     }
 
     @Test
@@ -561,6 +586,21 @@ internal interface ValueClassService {
     suspend fun getSuspendPrimitiveValueClass(): PrimitiveValueClass
 
     suspend fun getSuspendNestedPrimitiveValueClass(): NestedPrimitiveValueClass
+}
+
+internal interface ValueWrapper {
+    val value: Long
+}
+
+@JvmInline
+internal value class InlineValueWrapper(
+    override val value: Long,
+) : ValueWrapper
+
+internal interface ParameterizedValueClassService<T : ValueWrapper> {
+    fun value(): T
+
+    fun nullableValue(): T?
 }
 
 private data class TestDataClass(


### PR DESCRIPTION
The test was written by me, the fix was done by a popular coding agent - after more than 1h of processing. I didn't even try to understand what's going on, but it seems reasonable.

I'm not sure if or how much of the added comment should be kept.

The LLM generated commit message:

Return null for nullable value class in anyValue() to prevent spurious child mock creation

When recording stubs for generic nullable value class returns (T? where T : ValueWrapper), Objenesis zero-initializes the backing field, causing maybeUnboxValueForMethodReturn to return a non-null instance. This made the recording state set isRetValueMock=true, triggering PermanentMocker to create an unwanted child mock that fails for value classes.

Fixes #1341