### PR TITLE
feat: add suppress() DSL to prevent parent class method execution

### DIFF
--- a/modules/dokka/build.gradle.kts
+++ b/modules/dokka/build.gradle.kts
@@ -6,14 +6,19 @@ plugins {
 dependencies {
     dokka(projects.modules.mockk)
     dokka(projects.modules.mockkAgent)
-    dokka(projects.modules.mockkAgentAndroid)
-    dokka(projects.modules.mockkAgentAndroidDispatcher)
     dokka(projects.modules.mockkAgentApi)
-    dokka(projects.modules.mockkAndroid)
     dokka(projects.modules.mockkBdd)
-    dokka(projects.modules.mockkBddAndroid)
     dokka(projects.modules.mockkCore)
     dokka(projects.modules.mockkDsl)
+
+    listOf(
+        ":modules:mockk-agent-android",
+        ":modules:mockk-agent-android-dispatcher",
+        ":modules:mockk-android",
+        ":modules:mockk-bdd-android",
+    ).forEach { path ->
+        rootProject.findProject(path)?.let { dokka(it) }
+    }
 }
 
 dokka {

--- a/modules/mockk-dsl/src/commonMain/kotlin/io/mockk/API.kt
+++ b/modules/mockk-dsl/src/commonMain/kotlin/io/mockk/API.kt
@@ -279,6 +279,32 @@ object MockKDsl {
     }
 
     /**
+     * Suppress execution of specified method calls.
+     * When suppressed, the original method implementation is not executed
+     * and a default value is returned instead.
+     */
+    fun internalSuppress(
+        suppressBlock: MockKMatcherScope.() -> Unit,
+    ) {
+        MockKGateway.implementation().suppresser.suppress(
+            suppressBlock,
+            null,
+        )
+    }
+
+    /**
+     * Suppress execution of specified method calls for a suspend block.
+     */
+    fun internalCoSuppress(
+        suppressBlock: suspend MockKMatcherScope.() -> Unit,
+    ) {
+        MockKGateway.implementation().suppresser.suppress(
+            null,
+            suppressBlock,
+        )
+    }
+
+    /**
      * Checks if all recorded calls were verified.
      *
      * @param clear if `true` verification state is cleared for the given mocks

--- a/modules/mockk-dsl/src/commonMain/kotlin/io/mockk/API.kt
+++ b/modules/mockk-dsl/src/commonMain/kotlin/io/mockk/API.kt
@@ -368,6 +368,7 @@ object MockKDsl {
         childMocks: Boolean = true,
         verificationMarks: Boolean = true,
         exclusionRules: Boolean = true,
+        suppressionRules: Boolean = true,
     ) {
         MockKGateway.implementation().clearer.clear(
             arrayOf(firstMock, *mocks),
@@ -377,6 +378,7 @@ object MockKDsl {
                 childMocks,
                 verificationMarks,
                 exclusionRules,
+                suppressionRules,
             ),
         )
     }
@@ -514,6 +516,7 @@ object MockKDsl {
         childMocks: Boolean = true,
         verificationMarks: Boolean = true,
         exclusionRules: Boolean = true,
+        suppressionRules: Boolean = true,
     ) {
         for (obj in objects) {
             MockKGateway.implementation().objectMockFactory.clear(
@@ -524,6 +527,7 @@ object MockKDsl {
                     childMocks,
                     verificationMarks,
                     exclusionRules,
+                    suppressionRules,
                 ),
             )
         }
@@ -567,6 +571,7 @@ object MockKDsl {
         childMocks: Boolean = true,
         verificationMarks: Boolean = true,
         exclusionRules: Boolean = true,
+        suppressionRules: Boolean = true,
     ) {
         for (type in classes) {
             MockKGateway.implementation().staticMockFactory.clear(
@@ -577,6 +582,7 @@ object MockKDsl {
                     childMocks,
                     verificationMarks,
                     exclusionRules,
+                    suppressionRules,
                 ),
             )
         }
@@ -616,6 +622,7 @@ object MockKDsl {
                     childMocks = true,
                     verificationMarks = true,
                     exclusionRules = true,
+                    suppressionRules = true,
                 ),
             )
             MockKCancellationRegistry
@@ -634,6 +641,7 @@ object MockKDsl {
         childMocks: Boolean = true,
         verificationMarks: Boolean = true,
         exclusionRules: Boolean = true,
+        suppressionRules: Boolean = true,
     ) {
         for (type in classes) {
             MockKGateway.implementation().constructorMockFactory.clear(
@@ -644,6 +652,7 @@ object MockKDsl {
                     childMocks,
                     verificationMarks,
                     exclusionRules,
+                    suppressionRules,
                 ),
             )
         }
@@ -666,6 +675,7 @@ object MockKDsl {
         constructorMocks: Boolean = true,
         verificationMarks: Boolean = true,
         exclusionRules: Boolean = true,
+        suppressionRules: Boolean = true,
         currentThreadOnly: Boolean = false,
     ) {
         val options =
@@ -675,6 +685,7 @@ object MockKDsl {
                 childMocks,
                 verificationMarks,
                 exclusionRules,
+                suppressionRules,
             )
         val implementation = MockKGateway.implementation()
 
@@ -3233,6 +3244,7 @@ abstract class MockKUnmockKScope {
         childMocks: Boolean = true,
         verificationMarks: Boolean = true,
         exclusionRules: Boolean = true,
+        suppressionRules: Boolean = true,
     )
 
     operator fun plus(scope: MockKUnmockKScope): MockKUnmockKScope = MockKUnmockKCompositeScope(this, scope)
@@ -3357,6 +3369,7 @@ class MockKStaticScope(
         childMocks: Boolean,
         verificationMarks: Boolean,
         exclusionRules: Boolean,
+        suppressionRules: Boolean,
     ) {
         for (type in staticTypes) {
             MockKGateway.implementation().staticMockFactory.clear(
@@ -3367,6 +3380,7 @@ class MockKStaticScope(
                     childMocks,
                     verificationMarks,
                     exclusionRules,
+                    suppressionRules,
                 ),
             )
         }
@@ -3399,6 +3413,7 @@ class MockKObjectScope(
         childMocks: Boolean,
         verificationMarks: Boolean,
         exclusionRules: Boolean,
+        suppressionRules: Boolean,
     ) {
         for (obj in objects) {
             MockKGateway.implementation().objectMockFactory.clear(
@@ -3409,6 +3424,7 @@ class MockKObjectScope(
                     childMocks,
                     verificationMarks,
                     exclusionRules,
+                    suppressionRules,
                 ),
             )
         }
@@ -3439,6 +3455,7 @@ class MockKConstructorScope<T : Any>(
         childMocks: Boolean,
         verificationMarks: Boolean,
         exclusionRules: Boolean,
+        suppressionRules: Boolean,
     ) {
         MockKGateway.implementation().constructorMockFactory.clear(
             type,
@@ -3448,6 +3465,7 @@ class MockKConstructorScope<T : Any>(
                 childMocks,
                 verificationMarks,
                 exclusionRules,
+                suppressionRules,
             ),
         )
     }

--- a/modules/mockk-dsl/src/commonMain/kotlin/io/mockk/API.kt
+++ b/modules/mockk-dsl/src/commonMain/kotlin/io/mockk/API.kt
@@ -3328,6 +3328,7 @@ class MockKUnmockKCompositeScope(
         childMocks: Boolean,
         verificationMarks: Boolean,
         exclusionRules: Boolean,
+        suppressionRules: Boolean,
     ) {
         first.clear(
             answers,
@@ -3335,6 +3336,7 @@ class MockKUnmockKCompositeScope(
             childMocks,
             verificationMarks,
             exclusionRules,
+            suppressionRules,
         )
         second.clear(
             answers,
@@ -3342,6 +3344,7 @@ class MockKUnmockKCompositeScope(
             childMocks,
             verificationMarks,
             exclusionRules,
+            suppressionRules,
         )
     }
 }

--- a/modules/mockk-dsl/src/commonMain/kotlin/io/mockk/MockKGateway.kt
+++ b/modules/mockk-dsl/src/commonMain/kotlin/io/mockk/MockKGateway.kt
@@ -13,6 +13,7 @@ interface MockKGateway {
     val stubber: Stubber
     val verifier: Verifier
     val excluder: Excluder
+    val suppresser: Suppresser
     val callRecorder: CallRecorder
     val instanceFactoryRegistry: InstanceFactoryRegistry
     val clearer: Clearer
@@ -28,6 +29,7 @@ interface MockKGateway {
         val childMocks: Boolean,
         val verificationMarks: Boolean,
         val exclusionRules: Boolean,
+        val suppressionRules: Boolean = false,
     )
 
     companion object {
@@ -186,6 +188,16 @@ interface MockKGateway {
     )
 
     /**
+     * Suppress calls
+     */
+    interface Suppresser {
+        fun suppress(
+            mockBlock: (MockKMatcherScope.() -> Unit)?,
+            coMockBlock: (suspend MockKMatcherScope.() -> Unit)?,
+        )
+    }
+
+    /**
      * Parameters of exclusion
      */
     data class ExclusionParameters(
@@ -207,6 +219,8 @@ interface MockKGateway {
         fun startVerification(params: VerificationParameters)
 
         fun startExclusion(params: ExclusionParameters)
+
+        fun startSuppression()
 
         fun round(
             n: Int,

--- a/modules/mockk/src/commonMain/kotlin/io/mockk/MockK.kt
+++ b/modules/mockk/src/commonMain/kotlin/io/mockk/MockK.kt
@@ -455,6 +455,42 @@ fun coExcludeRecords(
     }
 
 /**
+ * Suppresses execution of specified method calls on mocks/spies.
+ *
+ * When a method is suppressed, the original method implementation is not executed
+ * and a default value is returned instead (e.g. `Unit` for void methods,
+ * `null` for objects, `0` for primitives).
+ *
+ * This is useful for suppressing parent class method calls (e.g. `onCreate()`, `onResume()`)
+ * when testing Android Activity classes or any scenario where you want to prevent
+ * the real method from executing.
+ *
+ * Example:
+ * ```
+ * val spy = spyk(MyActivity())
+ * suppress { spy.onCreate(any()) }
+ * spy.onCreate(null) // onCreate won't execute its original code
+ * ```
+ *
+ * @see [coSuppress] Coroutine version.
+ * @see [excludeRecords]
+ */
+fun suppress(suppressBlock: MockKMatcherScope.() -> Unit): Unit =
+    MockK.useImpl {
+        MockKDsl.internalSuppress(suppressBlock)
+    }
+
+/**
+ * Suppresses execution of specified method calls on mocks/spies for a `suspend` block.
+ *
+ * @see [suppress]
+ */
+fun coSuppress(suppressBlock: suspend MockKMatcherScope.() -> Unit): Unit =
+    MockK.useImpl {
+        MockKDsl.internalCoSuppress(suppressBlock)
+    }
+
+/**
  * Checks if all recorded calls were verified.
  *
  * @param clear if `true` verification state is cleared for the given mocks

--- a/modules/mockk/src/commonMain/kotlin/io/mockk/impl/eval/SuppressBlockEvaluator.kt
+++ b/modules/mockk/src/commonMain/kotlin/io/mockk/impl/eval/SuppressBlockEvaluator.kt
@@ -1,0 +1,35 @@
+package io.mockk.impl.eval
+
+import io.mockk.CapturingSlot
+import io.mockk.MockKGateway.CallRecorder
+import io.mockk.MockKGateway.Suppresser
+import io.mockk.MockKMatcherScope
+import io.mockk.impl.recording.AutoHinter
+import io.mockk.impl.stub.StubRepository
+
+class SuppressBlockEvaluator(
+    callRecorder: () -> CallRecorder,
+    val stubRepo: StubRepository,
+    autoHinterFactory: () -> AutoHinter,
+) : RecordedBlockEvaluator(callRecorder, autoHinterFactory),
+    Suppresser {
+    override fun suppress(
+        mockBlock: (MockKMatcherScope.() -> Unit)?,
+        coMockBlock: (suspend MockKMatcherScope.() -> Unit)?,
+    ) {
+        if (coMockBlock != null) {
+            initializeCoroutines()
+        }
+
+        callRecorder().startSuppression()
+
+        val lambda = CapturingSlot<Function<*>>()
+        val scope = MockKMatcherScope(callRecorder(), lambda)
+
+        try {
+            record(scope, mockBlock, coMockBlock)
+        } finally {
+            callRecorder().reset()
+        }
+    }
+}

--- a/modules/mockk/src/commonMain/kotlin/io/mockk/impl/recording/CallRecorderFactories.kt
+++ b/modules/mockk/src/commonMain/kotlin/io/mockk/impl/recording/CallRecorderFactories.kt
@@ -3,7 +3,6 @@ package io.mockk.impl.recording
 import io.mockk.MockKGateway.CallVerifier
 import io.mockk.MockKGateway.ExclusionParameters
 import io.mockk.MockKGateway.VerificationParameters
-import io.mockk.impl.recording.states.SuppressionState
 import io.mockk.impl.recording.states.CallRecordingState
 
 typealias VerifierFactory = (VerificationParameters) -> CallVerifier

--- a/modules/mockk/src/commonMain/kotlin/io/mockk/impl/recording/CallRecorderFactories.kt
+++ b/modules/mockk/src/commonMain/kotlin/io/mockk/impl/recording/CallRecorderFactories.kt
@@ -3,6 +3,7 @@ package io.mockk.impl.recording
 import io.mockk.MockKGateway.CallVerifier
 import io.mockk.MockKGateway.ExclusionParameters
 import io.mockk.MockKGateway.VerificationParameters
+import io.mockk.impl.recording.states.SuppressionState
 import io.mockk.impl.recording.states.CallRecordingState
 
 typealias VerifierFactory = (VerificationParameters) -> CallVerifier
@@ -14,6 +15,7 @@ typealias PermanentMockerFactory = () -> PermanentMocker
 typealias StateFactory = (recorder: CommonCallRecorder) -> CallRecordingState
 typealias VerifyingStateFactory = (recorder: CommonCallRecorder, verificationParams: VerificationParameters) -> CallRecordingState
 typealias ExclusionStateFactory = (recorder: CommonCallRecorder, exclusionParams: ExclusionParameters) -> CallRecordingState
+typealias SuppressionStateFactory = (recorder: CommonCallRecorder) -> CallRecordingState
 typealias ChainedCallDetectorFactory = () -> ChainedCallDetector
 typealias VerificationCallSorterFactory = () -> VerificationCallSorter
 
@@ -28,6 +30,7 @@ data class CallRecorderFactories(
     val stubbingState: StateFactory,
     val verifyingState: VerifyingStateFactory,
     val exclusionState: ExclusionStateFactory,
+    val suppressionState: SuppressionStateFactory,
     val stubbingAwaitingAnswerState: StateFactory,
     val safeLoggingState: StateFactory,
 )

--- a/modules/mockk/src/commonMain/kotlin/io/mockk/impl/recording/CommonCallRecorder.kt
+++ b/modules/mockk/src/commonMain/kotlin/io/mockk/impl/recording/CommonCallRecorder.kt
@@ -46,6 +46,11 @@ class CommonCallRecorder(
         log.trace { "Starting exclusion" }
     }
 
+    override fun startSuppression() {
+        state = factories.suppressionState(this)
+        log.trace { "Starting suppression" }
+    }
+
     override fun done() {
         state = state.recordingDone()
     }

--- a/modules/mockk/src/commonMain/kotlin/io/mockk/impl/recording/states/SuppressionState.kt
+++ b/modules/mockk/src/commonMain/kotlin/io/mockk/impl/recording/states/SuppressionState.kt
@@ -1,0 +1,31 @@
+package io.mockk.impl.recording.states
+
+import io.mockk.MockKException
+import io.mockk.impl.recording.CommonCallRecorder
+
+class SuppressionState(
+    recorder: CommonCallRecorder,
+) : RecordingState(recorder) {
+    override fun wasNotCalled(list: List<Any>): Unit =
+        throw MockKException("`wasNot called` is not allowed in suppress { ... } block.")
+
+    override fun recordingDone(): CallRecordingState {
+        checkMissingCalls()
+
+        for (call in recorder.calls) {
+            val matcher = call.matcher
+            val stub = recorder.stubRepo.stubFor(matcher.self)
+            if (call.selfChain == null) {
+                stub.suppressRecordedCalls(matcher)
+            }
+        }
+
+        return recorder.factories.answeringState(recorder)
+    }
+
+    private fun checkMissingCalls() {
+        if (recorder.calls.isEmpty()) {
+            throw MockKException("Missing calls inside suppress { ... } block.")
+        }
+    }
+}

--- a/modules/mockk/src/commonMain/kotlin/io/mockk/impl/recording/states/SuppressionState.kt
+++ b/modules/mockk/src/commonMain/kotlin/io/mockk/impl/recording/states/SuppressionState.kt
@@ -6,8 +6,7 @@ import io.mockk.impl.recording.CommonCallRecorder
 class SuppressionState(
     recorder: CommonCallRecorder,
 ) : RecordingState(recorder) {
-    override fun wasNotCalled(list: List<Any>): Unit =
-        throw MockKException("`wasNot called` is not allowed in suppress { ... } block.")
+    override fun wasNotCalled(list: List<Any>): Unit = throw MockKException("`wasNot called` is not allowed in suppress { ... } block.")
 
     override fun recordingDone(): CallRecordingState {
         checkMissingCalls()

--- a/modules/mockk/src/commonMain/kotlin/io/mockk/impl/stub/ConstructorStub.kt
+++ b/modules/mockk/src/commonMain/kotlin/io/mockk/impl/stub/ConstructorStub.kt
@@ -76,6 +76,12 @@ class ConstructorStub(
         )
     }
 
+    override fun suppressRecordedCalls(matcher: InvocationMatcher) {
+        stub.suppressRecordedCalls(
+            matcher.substitute(represent),
+        )
+    }
+
     override fun markCallVerified(invocation: Invocation) {
         stub.markCallVerified(
             invocation.substitute(represent),

--- a/modules/mockk/src/commonMain/kotlin/io/mockk/impl/stub/MockKStub.kt
+++ b/modules/mockk/src/commonMain/kotlin/io/mockk/impl/stub/MockKStub.kt
@@ -36,6 +36,7 @@ open class MockKStub(
     private val recordedCallsByMethod =
         InternalPlatform.synchronizedMutableMap<MethodDescription, MutableList<Invocation>>()
     private val exclusions = InternalPlatform.synchronizedMutableList<InvocationMatcher>()
+    private val suppressions = InternalPlatform.synchronizedMutableList<InvocationMatcher>()
     private val verifiedCalls = InternalPlatform.synchronizedMutableList<Invocation>()
 
     lateinit var hashCodeStr: String
@@ -72,6 +73,11 @@ open class MockKStub(
             answer.answer(call)
         }
     }
+
+    protected fun isSuppressed(invocation: Invocation): Boolean =
+        InternalPlatform.synchronized(suppressions) {
+            suppressions.any { it.match(invocation) }
+        }
 
     protected inline fun stdObjectFunctions(
         self: Any,
@@ -196,6 +202,10 @@ open class MockKStub(
         }
     }
 
+    override fun suppressRecordedCalls(matcher: InvocationMatcher) {
+        suppressions.add(matcher)
+    }
+
     override fun markCallVerified(invocation: Invocation) {
         verifiedCalls.add(invocation)
     }
@@ -313,6 +323,9 @@ open class MockKStub(
         }
         if (options.exclusionRules) {
             this.exclusions.clear()
+        }
+        if (options.suppressionRules) {
+            this.suppressions.clear()
         }
     }
 

--- a/modules/mockk/src/commonMain/kotlin/io/mockk/impl/stub/MockKStub.kt
+++ b/modules/mockk/src/commonMain/kotlin/io/mockk/impl/stub/MockKStub.kt
@@ -361,6 +361,7 @@ open class MockKStub(
                 childMocks = true,
                 verificationMarks = true,
                 exclusionRules = true,
+                suppressionRules = true,
             ),
         )
         disposeRoutine.invoke()

--- a/modules/mockk/src/commonMain/kotlin/io/mockk/impl/stub/SpyKStub.kt
+++ b/modules/mockk/src/commonMain/kotlin/io/mockk/impl/stub/SpyKStub.kt
@@ -10,5 +10,20 @@ class SpyKStub<T : Any>(
     recordPrivateCalls: Boolean,
     mockType: MockType,
 ) : MockKStub(cls, name, false, false, gatewayAccess, recordPrivateCalls, mockType) {
-    override fun defaultAnswer(invocation: Invocation): Any? = invocation.originalCall()
+    override fun defaultAnswer(invocation: Invocation): Any? =
+        if (isSuppressed(invocation)) {
+            relaxedValue(invocation)
+        } else {
+            invocation.originalCall()
+        }
+
+    private fun relaxedValue(invocation: Invocation): Any? {
+        if (invocation.method.returnsUnit) return Unit
+        return gatewayAccess.anyValueGenerator().anyValue(
+            invocation.method.returnType,
+            invocation.method.returnTypeNullable,
+        ) {
+            childMockK(invocation.allEqMatcher(), invocation.method.returnType)
+        }
+    }
 }

--- a/modules/mockk/src/commonMain/kotlin/io/mockk/impl/stub/Stub.kt
+++ b/modules/mockk/src/commonMain/kotlin/io/mockk/impl/stub/Stub.kt
@@ -40,6 +40,8 @@ interface Stub : Disposable {
         matcher: InvocationMatcher,
     )
 
+    fun suppressRecordedCalls(matcher: InvocationMatcher)
+
     fun markCallVerified(invocation: Invocation)
 
     fun verifiedCalls(): List<Invocation>

--- a/modules/mockk/src/jsMain/kotlin/io/mockk/impl/JsMockKGateway.kt
+++ b/modules/mockk/src/jsMain/kotlin/io/mockk/impl/JsMockKGateway.kt
@@ -12,6 +12,7 @@ import io.mockk.impl.log.JsConsoleLogger
 import io.mockk.impl.log.Logger
 import io.mockk.impl.log.SafeToString
 import io.mockk.impl.recording.*
+import io.mockk.impl.eval.SuppressBlockEvaluator
 import io.mockk.impl.recording.states.*
 import io.mockk.impl.stub.CommonClearer
 import io.mockk.impl.stub.StubGatewayAccess
@@ -78,6 +79,7 @@ class JsMockKGateway : MockKGateway {
         ::StubbingState,
         ::VerifyingState,
         ::ExclusionState,
+        { recorder -> SuppressionState(recorder) },
         ::StubbingAwaitingAnswerState,
         ::SafeLoggingState
     )
@@ -100,6 +102,7 @@ class JsMockKGateway : MockKGateway {
     override val stubber: Stubber = EveryBlockEvaluator({ callRecorder }, ::AutoHinter)
     override val verifier: Verifier = VerifyBlockEvaluator({ callRecorder }, stubRepo, ::AutoHinter)
     override val excluder: Excluder = ExcludeBlockEvaluator({ callRecorder }, stubRepo, ::AutoHinter)
+    override val suppresser: Suppresser = SuppressBlockEvaluator({ callRecorder }, stubRepo, ::AutoHinter)
     override val mockInitializer: MockInitializer
         get() = throw MockKException("MockK annotations are not supported in JS")
 

--- a/modules/mockk/src/jvmMain/kotlin/io/mockk/impl/JvmMockKGateway.kt
+++ b/modules/mockk/src/jvmMain/kotlin/io/mockk/impl/JvmMockKGateway.kt
@@ -6,12 +6,14 @@ import io.mockk.MockKGateway.CallVerifier
 import io.mockk.MockKGateway.Excluder
 import io.mockk.MockKGateway.InstanceFactoryRegistry
 import io.mockk.MockKGateway.Stubber
+import io.mockk.MockKGateway.Suppresser
 import io.mockk.MockKGateway.VerificationParameters
 import io.mockk.MockKGateway.Verifier
 import io.mockk.Ordering
 import io.mockk.impl.annotations.JvmMockInitializer
 import io.mockk.impl.eval.EveryBlockEvaluator
 import io.mockk.impl.eval.ExcludeBlockEvaluator
+import io.mockk.impl.eval.SuppressBlockEvaluator
 import io.mockk.impl.eval.VerifyBlockEvaluator
 import io.mockk.impl.instantiation.AbstractMockFactory
 import io.mockk.impl.instantiation.AnyValueGenerator
@@ -43,6 +45,7 @@ import io.mockk.impl.recording.states.ExclusionState
 import io.mockk.impl.recording.states.SafeLoggingState
 import io.mockk.impl.recording.states.StubbingAwaitingAnswerState
 import io.mockk.impl.recording.states.StubbingState
+import io.mockk.impl.recording.states.SuppressionState
 import io.mockk.impl.recording.states.VerifyingState
 import io.mockk.impl.stub.CommonClearer
 import io.mockk.impl.stub.StubGatewayAccess
@@ -174,6 +177,7 @@ class JvmMockKGateway : MockKGateway {
             ::StubbingState,
             ::VerifyingState,
             ::ExclusionState,
+            { recorder -> SuppressionState(recorder) },
             ::StubbingAwaitingAnswerState,
             ::SafeLoggingState,
         )
@@ -200,6 +204,7 @@ class JvmMockKGateway : MockKGateway {
     override val stubber: Stubber = EveryBlockEvaluator(callRecorderTL::get, ::JvmAutoHinter)
     override val verifier: Verifier = VerifyBlockEvaluator(callRecorderTL::get, stubRepo, ::JvmAutoHinter)
     override val excluder: Excluder = ExcludeBlockEvaluator(callRecorderTL::get, stubRepo, ::JvmAutoHinter)
+    override val suppresser: Suppresser = SuppressBlockEvaluator(callRecorderTL::get, stubRepo, ::JvmAutoHinter)
     override val mockInitializer = JvmMockInitializer(this)
     override val verificationAcknowledger = CommonVerificationAcknowledger(stubRepo, safeToString)
 


### PR DESCRIPTION
Adds a suppress { } DSL block (and coSuppress { } for coroutines) that prevents specified methods from executing their original implementation. When a method is suppressed, a default value is returned instead (Unit for void, null for objects, 0 for primitives, etc.).

This is useful for suppressing parent class method calls (e.g. onCreate(), onResume()) when unit testing Android Activity classes or any scenario where you want to prevent the real method from executing.

Implementation:
- Suppresser interface in MockKGateway
- SuppressBlockEvaluator for recording suppression calls
- SuppressionState for managing the recording lifecycle
- Suppression list in MockKStub with isSuppressed() check
- SpyKStub.defaultAnswer() checks suppression before calling original
- ClearOptions.suppressionRules support
- JVM and JS gateway wiring
- Public suppress() and coSuppress() API functions