### PR TITLE
Fix nested value class matching and capture on JVM

### DIFF
--- a/modules/mockk-dsl/src/commonMain/kotlin/io/mockk/API.kt
+++ b/modules/mockk-dsl/src/commonMain/kotlin/io/mockk/API.kt
@@ -5194,19 +5194,25 @@ interface Matcher<in T> {
 interface TypedMatcher {
     val argumentType: KClass<*>
 
-    fun checkType(arg: Any?): Boolean = checkType(arg, null)
-
-    fun checkType(
-        arg: Any?,
-        parameterType: KClass<*>?,
-    ): Boolean =
+    fun checkType(arg: Any?): Boolean =
         when {
             argumentType.simpleName === null -> true
             else -> {
-                argumentType.valueClassAwareIsInstance(arg, parameterType)
+                argumentType.valueClassAwareIsInstance(arg, null)
             }
         }
 }
+
+private fun TypedMatcher.checkType(
+    arg: Any?,
+    parameterType: KClass<*>?,
+): Boolean =
+    when {
+        argumentType.simpleName === null -> true
+        else -> {
+            argumentType.valueClassAwareIsInstance(arg, parameterType)
+        }
+    }
 
 /**
  * Allows to substitute matcher to find correct chained call

--- a/modules/mockk-dsl/src/commonMain/kotlin/io/mockk/API.kt
+++ b/modules/mockk-dsl/src/commonMain/kotlin/io/mockk/API.kt
@@ -5199,14 +5199,13 @@ interface TypedMatcher {
     fun checkType(
         arg: Any?,
         parameterType: KClass<*>?,
-    ): Boolean {
-        return when {
+    ): Boolean =
+        when {
             argumentType.simpleName === null -> true
             else -> {
                 argumentType.valueClassAwareIsInstance(arg, parameterType)
             }
         }
-    }
 }
 
 /**

--- a/modules/mockk-dsl/src/commonMain/kotlin/io/mockk/API.kt
+++ b/modules/mockk-dsl/src/commonMain/kotlin/io/mockk/API.kt
@@ -8,7 +8,6 @@ import io.mockk.MockKGateway.CallRecorder
 import io.mockk.MockKGateway.ClearOptions
 import io.mockk.MockKGateway.ExclusionParameters
 import io.mockk.MockKGateway.VerificationParameters
-import io.mockk.core.ValueClassSupport.boxedClass
 import kotlinx.coroutines.awaitCancellation
 import kotlin.coroutines.Continuation
 import kotlin.reflect.KClass
@@ -5195,12 +5194,16 @@ interface Matcher<in T> {
 interface TypedMatcher {
     val argumentType: KClass<*>
 
-    fun checkType(arg: Any?): Boolean {
+    fun checkType(arg: Any?): Boolean = checkType(arg, null)
+
+    fun checkType(
+        arg: Any?,
+        parameterType: KClass<*>?,
+    ): Boolean {
         return when {
             argumentType.simpleName === null -> true
             else -> {
-                val unboxedClass = argumentType.boxedClass
-                return unboxedClass.isInstance(arg)
+                argumentType.valueClassAwareIsInstance(arg, parameterType)
             }
         }
     }
@@ -5407,7 +5410,7 @@ data class InvocationMatcher(
             val matcher = args[i]
             val arg = invocation.args[i]
 
-            if (arg != null && matcher is TypedMatcher && !matcher.checkType(arg)) return false
+            if (arg != null && matcher is TypedMatcher && !matcher.checkType(arg, method.paramTypes.getOrNull(i))) return false
 
             if (!matcher.match(arg)) {
                 return false

--- a/modules/mockk-dsl/src/commonMain/kotlin/io/mockk/Matchers.kt
+++ b/modules/mockk-dsl/src/commonMain/kotlin/io/mockk/Matchers.kt
@@ -120,15 +120,12 @@ data class FunctionWithNullableArgMatcher<in T : Any>(
             false
         }
 
-    override fun checkType(
-        arg: Any?,
-        parameterType: KClass<*>?,
-    ): Boolean {
+    override fun checkType(arg: Any?): Boolean {
         if (arg == null) {
             return true
         }
 
-        return super.checkType(arg, parameterType)
+        return super.checkType(arg)
     }
 
     override fun toString(): String = "matcher<${argumentType.simpleName}>()"
@@ -180,15 +177,12 @@ data class CaptureNullableMatcher<T : Any>(
 
     override fun match(arg: T?): Boolean = true
 
-    override fun checkType(
-        arg: Any?,
-        parameterType: KClass<*>?,
-    ): Boolean {
+    override fun checkType(arg: Any?): Boolean {
         if (arg == null) {
             return true
         }
 
-        return super.checkType(arg, parameterType)
+        return super.checkType(arg)
     }
 
     override fun toString(): String = "capture<${argumentType.simpleName}?>()"
@@ -240,15 +234,12 @@ data class CapturingNullableSlotMatcher<T : Any>(
 
     override fun match(arg: T?): Boolean = true
 
-    override fun checkType(
-        arg: Any?,
-        parameterType: KClass<*>?,
-    ): Boolean {
+    override fun checkType(arg: Any?): Boolean {
         if (arg == null) {
             return true
         }
 
-        return super.checkType(arg, parameterType)
+        return super.checkType(arg)
     }
 
     override fun toString(): String = "slotCapture<${argumentType.simpleName}>()"
@@ -595,14 +586,11 @@ data class AnyTypedMatcher(
 
     override fun equivalent(): Matcher<Any> = this
 
-    override fun checkType(
-        arg: Any?,
-        parameterType: KClass<*>?,
-    ): Boolean {
+    override fun checkType(arg: Any?): Boolean {
         if (arg == null) return true
         if (argumentType.simpleName == null) return true
 
-        return argumentType.valueClassAwareIsInstance(arg, parameterType)
+        return argumentType.valueClassAwareIsInstance(arg, null)
     }
 
     override fun toString(): String = "any<${argumentType.simpleName}>()"

--- a/modules/mockk-dsl/src/commonMain/kotlin/io/mockk/Matchers.kt
+++ b/modules/mockk-dsl/src/commonMain/kotlin/io/mockk/Matchers.kt
@@ -2,7 +2,6 @@ package io.mockk
 
 import io.mockk.InternalPlatformDsl.toArray
 import io.mockk.InternalPlatformDsl.toStr
-import io.mockk.core.ValueClassSupport.boxedClass
 import io.mockk.core.ValueClassSupport.boxedValue
 import kotlin.math.min
 import kotlin.reflect.KClass

--- a/modules/mockk-dsl/src/commonMain/kotlin/io/mockk/Matchers.kt
+++ b/modules/mockk-dsl/src/commonMain/kotlin/io/mockk/Matchers.kt
@@ -121,12 +121,15 @@ data class FunctionWithNullableArgMatcher<in T : Any>(
             false
         }
 
-    override fun checkType(arg: Any?): Boolean {
+    override fun checkType(
+        arg: Any?,
+        parameterType: KClass<*>?,
+    ): Boolean {
         if (arg == null) {
             return true
         }
 
-        return super.checkType(arg)
+        return super.checkType(arg, parameterType)
     }
 
     override fun toString(): String = "matcher<${argumentType.simpleName}>()"
@@ -169,17 +172,24 @@ data class CaptureNullableMatcher<T : Any>(
 
     @Suppress("UNCHECKED_CAST")
     override fun capture(arg: Any?) {
-        captureList.add(arg as T?)
+        if (arg == null) {
+            captureList.add(null)
+        } else {
+            captureList.add(InternalPlatformDsl.boxCast(argumentType, arg))
+        }
     }
 
     override fun match(arg: T?): Boolean = true
 
-    override fun checkType(arg: Any?): Boolean {
+    override fun checkType(
+        arg: Any?,
+        parameterType: KClass<*>?,
+    ): Boolean {
         if (arg == null) {
             return true
         }
 
-        return super.checkType(arg)
+        return super.checkType(arg, parameterType)
     }
 
     override fun toString(): String = "capture<${argumentType.simpleName}?>()"
@@ -231,12 +241,15 @@ data class CapturingNullableSlotMatcher<T : Any>(
 
     override fun match(arg: T?): Boolean = true
 
-    override fun checkType(arg: Any?): Boolean {
+    override fun checkType(
+        arg: Any?,
+        parameterType: KClass<*>?,
+    ): Boolean {
         if (arg == null) {
             return true
         }
 
-        return super.checkType(arg)
+        return super.checkType(arg, parameterType)
     }
 
     override fun toString(): String = "slotCapture<${argumentType.simpleName}>()"
@@ -579,41 +592,18 @@ data class AnyTypedMatcher(
 ) : Matcher<Any>,
     TypedMatcher,
     EquivalentMatcher {
-    private val underlyingBoxed: KClass<*>? by lazy(LazyThreadSafetyMode.PUBLICATION) {
-        if (!argumentType.isValue) return@lazy null
-        argumentType.constructors
-            .firstOrNull()
-            ?.parameters
-            ?.singleOrNull()
-            ?.type
-            ?.classifier as? KClass<*>
-    }
-
     override fun match(arg: Any?): Boolean = true
 
     override fun equivalent(): Matcher<Any> = this
 
-    override fun checkType(arg: Any?): Boolean {
+    override fun checkType(
+        arg: Any?,
+        parameterType: KClass<*>?,
+    ): Boolean {
         if (arg == null) return true
         if (argumentType.simpleName == null) return true
 
-        if (argumentType.isInstance(arg)) return true
-
-        val expectedBoxed = argumentType.boxedClass
-        if (expectedBoxed.isInstance(arg)) return true
-
-        val normalizedArg = arg.boxedValue
-        if (argumentType.isInstance(normalizedArg)) return true
-        if (expectedBoxed.isInstance(normalizedArg)) return true
-
-        val ub = underlyingBoxed
-        if (ub != null) {
-            val ubBoxed = ub.boxedClass
-            if (ubBoxed.isInstance(arg)) return true
-            if (ubBoxed.isInstance(normalizedArg)) return true
-        }
-
-        return false
+        return argumentType.valueClassAwareIsInstance(arg, parameterType)
     }
 
     override fun toString(): String = "any<${argumentType.simpleName}>()"

--- a/modules/mockk-dsl/src/commonMain/kotlin/io/mockk/ValueClassSupportExtensions.kt
+++ b/modules/mockk-dsl/src/commonMain/kotlin/io/mockk/ValueClassSupportExtensions.kt
@@ -1,0 +1,36 @@
+package io.mockk
+
+import io.mockk.core.ValueClassSupport.boxedClass
+import kotlin.reflect.KClass
+
+internal fun KClass<*>.innermostBoxedClass(): KClass<*> {
+    return boxedClassChain().last()
+}
+
+internal fun KClass<*>.boxedClassChain(): List<KClass<*>> {
+    val result = mutableListOf<KClass<*>>()
+    val visited = mutableSetOf<KClass<*>>()
+    var current = this
+
+    while (visited.add(current)) {
+        result += current
+        val boxed = runCatching { current.boxedClass }.getOrElse { return result }
+        if (boxed == current) return result
+        current = boxed
+    }
+
+    return result
+}
+
+internal fun KClass<*>.valueClassAwareIsInstance(
+    arg: Any?,
+    parameterType: KClass<*>?,
+): Boolean {
+    if (arg == null) return false
+    if (isInstance(arg)) return true
+
+    return parameterType != null &&
+        boxedClassChain()
+            .drop(1)
+            .any { boxedType -> boxedType == parameterType && boxedType.isInstance(arg) }
+}

--- a/modules/mockk-dsl/src/commonMain/kotlin/io/mockk/ValueClassSupportExtensions.kt
+++ b/modules/mockk-dsl/src/commonMain/kotlin/io/mockk/ValueClassSupportExtensions.kt
@@ -3,9 +3,7 @@ package io.mockk
 import io.mockk.core.ValueClassSupport.boxedClass
 import kotlin.reflect.KClass
 
-internal fun KClass<*>.innermostBoxedClass(): KClass<*> {
-    return boxedClassChain().last()
-}
+internal fun KClass<*>.innermostBoxedClass(): KClass<*> = boxedClassChain().last()
 
 internal fun KClass<*>.boxedClassChain(): List<KClass<*>> {
     val result = mutableListOf<KClass<*>>()

--- a/modules/mockk-dsl/src/jvmMain/kotlin/io/mockk/InternalPlatformDsl.kt
+++ b/modules/mockk-dsl/src/jvmMain/kotlin/io/mockk/InternalPlatformDsl.kt
@@ -246,16 +246,18 @@ actual object InternalPlatformDsl {
             if (cls.isInstance(arg)) return arg as T
 
             val constructor = cls.primaryConstructor!!.apply { isAccessible = true }
-            val value = constructor.parameters.singleOrNull()
-                ?.type
-                ?.classifier
-                .let { boxedClass ->
-                    if (boxedClass is KClass<*> && boxedClass.isValue && !boxedClass.isInstance(arg)) {
-                        boxCast<Any>(boxedClass, arg)
-                    } else {
-                        arg
+            val value =
+                constructor.parameters
+                    .singleOrNull()
+                    ?.type
+                    ?.classifier
+                    .let { boxedClass ->
+                        if (boxedClass is KClass<*> && boxedClass.isValue && !boxedClass.isInstance(arg)) {
+                            boxCast<Any>(boxedClass, arg)
+                        } else {
+                            arg
+                        }
                     }
-                }
 
             constructor.call(value) as T
         } else {

--- a/modules/mockk-dsl/src/jvmMain/kotlin/io/mockk/InternalPlatformDsl.kt
+++ b/modules/mockk-dsl/src/jvmMain/kotlin/io/mockk/InternalPlatformDsl.kt
@@ -241,13 +241,27 @@ actual object InternalPlatformDsl {
     internal actual fun <T : Any> boxCast(
         cls: KClass<*>,
         arg: Any,
-    ): T =
-        if (cls.isValue) {
+    ): T {
+        return if (cls.isValue) {
+            if (cls.isInstance(arg)) return arg as T
+
             val constructor = cls.primaryConstructor!!.apply { isAccessible = true }
-            constructor.call(arg) as T
+            val value = constructor.parameters.singleOrNull()
+                ?.type
+                ?.classifier
+                .let { boxedClass ->
+                    if (boxedClass is KClass<*> && boxedClass.isValue && !boxedClass.isInstance(arg)) {
+                        boxCast<Any>(boxedClass, arg)
+                    } else {
+                        arg
+                    }
+                }
+
+            constructor.call(value) as T
         } else {
             arg as T
         }
+    }
 }
 
 class JvmCoroutineCall<T>(

--- a/modules/mockk/src/commonTest/kotlin/io/mockk/it/ValueClassTest.kt
+++ b/modules/mockk/src/commonTest/kotlin/io/mockk/it/ValueClassTest.kt
@@ -1,8 +1,8 @@
 package io.mockk.it
 
+import io.mockk.MockKException
 import io.mockk.coEvery
 import io.mockk.every
-import io.mockk.MockKException
 import io.mockk.mockk
 import io.mockk.registerInstanceFactory
 import io.mockk.slot

--- a/modules/mockk/src/commonTest/kotlin/io/mockk/it/ValueClassTest.kt
+++ b/modules/mockk/src/commonTest/kotlin/io/mockk/it/ValueClassTest.kt
@@ -2,6 +2,7 @@ package io.mockk.it
 
 import io.mockk.coEvery
 import io.mockk.every
+import io.mockk.MockKException
 import io.mockk.mockk
 import io.mockk.registerInstanceFactory
 import io.mockk.slot
@@ -16,6 +17,7 @@ import java.util.UUID
 import kotlin.test.Ignore
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertTrue
 
 class ValueClassTest {
@@ -267,14 +269,13 @@ class ValueClassTest {
     }
 
     @Test
-    @Ignore // TODO support nested value classes https://github.com/mockk/mockk/issues/859
     fun `arg is any(ValueClass), returns Wrapper`() {
         val mock =
             mockk<DummyService> {
                 every { argValueClassReturnWrapper(any()) } returns dummyValueWrapperReturn
             }
 
-        assertEquals(dummyValueWrapperArg, mock.argValueClassReturnWrapper(dummyValueClassArg))
+        assertEquals(dummyValueWrapperReturn, mock.argValueClassReturnWrapper(dummyValueClassArg))
 
         verify { mock.argValueClassReturnWrapper(dummyValueClassArg) }
     }
@@ -366,7 +367,6 @@ class ValueClassTest {
     }
 
     @Test
-    @Ignore // TODO support nested value classes https://github.com/mockk/mockk/issues/859
     fun `arg is slot(Wrapper), returns ValueClass`() {
         val slot = slot<DummyValueWrapper>()
         val mock =
@@ -408,7 +408,6 @@ class ValueClassTest {
     }
 
     @Test
-    @Ignore // TODO support nested value classes https://github.com/mockk/mockk/issues/859
     fun `arg is slot(Wrapper), answers ValueClass`() {
         val slot = slot<DummyValueWrapper>()
 
@@ -453,7 +452,6 @@ class ValueClassTest {
     }
 
     @Test
-    @Ignore // TODO support nested value classes https://github.com/mockk/mockk/issues/859
     fun `arg is slot(Wrapper), returns Wrapper`() {
         val slot = slot<DummyValueWrapper>()
         val mock =
@@ -495,7 +493,6 @@ class ValueClassTest {
     }
 
     @Test
-    @Ignore // TODO support nested value classes https://github.com/mockk/mockk/issues/859
     fun `arg is slot(Wrapper), answers Wrapper`() {
         val slot = slot<DummyValueWrapper>()
 
@@ -511,6 +508,36 @@ class ValueClassTest {
         assertEquals(dummyValueWrapperArg, slot.captured)
 
         verify { mock.argWrapperReturnWrapper(dummyValueWrapperArg) }
+    }
+
+    @Test
+    fun `any Wrapper does not match unrelated value class with same underlying type`() {
+        val mock =
+            mockk<DummyService> {
+                every { argAnyReturnString(any<DummyValueWrapper>()) } returns "wrapper"
+            }
+
+        assertEquals("wrapper", mock.argAnyReturnString(dummyValueWrapperArg))
+
+        assertFailsWith<MockKException> {
+            mock.argAnyReturnString(dummyValueClassArg)
+        }
+        assertFailsWith<MockKException> {
+            mock.argAnyReturnString(dummyValueClassArg.value)
+        }
+    }
+
+    @Test
+    fun `arg is captureNullable list Wrapper, returns String`() {
+        val captured = mutableListOf<DummyValueWrapper?>()
+        val mock =
+            mockk<DummyService> {
+                every { argNullableWrapperReturnString(captureNullable(captured)) } returns "wrapper"
+            }
+
+        assertEquals("wrapper", mock.argNullableWrapperReturnString(dummyValueWrapperArg))
+        assertEquals("wrapper", mock.argNullableWrapperReturnString(null))
+        assertEquals(listOf(dummyValueWrapperArg, null), captured)
     }
     // </editor-fold>
 
@@ -1005,6 +1032,10 @@ class ValueClassTest {
             fun argGenericValueClassReturnResultWrapped(valueClass: ComplexValue): Result<ComplexValue> = Result.success(valueClass)
 
             fun argValueClassReturnValueClass(valueClass: DummyValue): DummyValue = DummyValue(0)
+
+            fun argAnyReturnString(value: Any): String = value.toString()
+
+            fun argNullableWrapperReturnString(wrapper: DummyValueWrapper?): String = wrapper.toString()
 
             fun argComplexValueClassReturnComplexValueClass(complexValue: ComplexValue): ComplexValue =
                 ComplexValue(UUID.fromString("7dea337b-ce0b-4e25-9788-79e708aadc33"))


### PR DESCRIPTION
## Summary

Fixes #859.

The original issue describes nested Kotlin value classes on JVM, for example `DummyValueWrapper(DummyValue(Int))`, failing across wrapped stubbing, `any()`, and `slot()` matcher paths. In current MockK, return-value unboxing already has recursive value-class handling in `ValueClassSupport`, but matcher type checks and captured argument reconstruction still needed to understand the JVM raw representation of nested value classes.

This PR fixes those remaining matcher and capture paths on JVM.

## Changes

- Add value-class-aware matcher type checks using the actual JVM method parameter type as context.
- Reconstruct nested value classes recursively in JVM `boxCast()`, so captured raw values can be boxed back into the requested value class chain.
- Make nullable list capture use the same `boxCast()` path as non-null list and slot captures.
- Re-enable the ignored #859 nested value class tests.
- Add regression coverage to ensure `any<DummyValueWrapper>()` does not match unrelated value classes or raw underlying values in erased `Any` parameter positions.

## Validation

```bash
ANDROID_HOME="$HOME/Library/Android/sdk" ./gradlew :modules:mockk:jvmTest --tests io.mockk.it.ValueClassTest
```

```bash
ANDROID_HOME="$HOME/Library/Android/sdk" ./gradlew :test-modules:client-tests:jvmTest --tests io.mockk.core.ValueClassSupportTest
```

```bash
ANDROID_HOME="$HOME/Library/Android/sdk" ./gradlew :modules:mockk-dsl:compileKotlinMetadata
```

Note: `:modules:mockk-dsl:compileKotlinMetadata` completed successfully but the task was skipped by Gradle. `:modules:mockk-dsl:compileKotlinJs` is not available in this project; `mockk-dsl` currently exposes JVM and metadata compile tasks only.