### PR TITLE
Preserve typed matcher checks for value class context

### DIFF
--- a/modules/mockk-dsl/src/commonMain/kotlin/io/mockk/API.kt
+++ b/modules/mockk-dsl/src/commonMain/kotlin/io/mockk/API.kt
@@ -5203,16 +5203,21 @@ interface TypedMatcher {
         }
 }
 
-private fun TypedMatcher.checkType(
+private fun TypedMatcher.checkTypeWithParameterType(
     arg: Any?,
     parameterType: KClass<*>?,
-): Boolean =
-    when {
+): Boolean {
+    if (checkType(arg)) {
+        return true
+    }
+
+    return when {
         argumentType.simpleName === null -> true
         else -> {
             argumentType.valueClassAwareIsInstance(arg, parameterType)
         }
     }
+}
 
 /**
  * Allows to substitute matcher to find correct chained call
@@ -5415,7 +5420,11 @@ data class InvocationMatcher(
             val matcher = args[i]
             val arg = invocation.args[i]
 
-            if (arg != null && matcher is TypedMatcher && !matcher.checkType(arg, method.paramTypes.getOrNull(i))) return false
+            if (arg != null && matcher is TypedMatcher &&
+                !matcher.checkTypeWithParameterType(arg, method.paramTypes.getOrNull(i))
+            ) {
+                return false
+            }
 
             if (!matcher.match(arg)) {
                 return false


### PR DESCRIPTION
## Summary
- preserve existing `TypedMatcher.checkType(arg)` behavior before applying value-class parameter fallback
- keep the parameter-aware matcher check private so `mockk-dsl` public API remains unchanged
- make the value-class context helper name explicit for `InvocationMatcher`

## Context
Follow-up to #1539. The nested value class matcher fix needs method parameter context internally, but that fallback should not bypass custom or nullable matcher `checkType(arg)` behavior.

## Verification
```
ANDROID_HOME="$HOME/Library/Android/sdk" ./gradlew :modules:mockk-dsl:jvmApiCheck :modules:mockk:jvmTest --tests io.mockk.it.ValueClassTest :modules:mockk-dsl:spotlessKotlinCheck :modules:mockk:spotlessKotlinCheck -Pio_mockk_kotlin_version=1.5.32 -Pio_mockk_java_toolchain_test_version=17
```