### PR TITLE
Fix generic value class boxed type handling

### DIFF
--- a/modules/mockk-core/src/jvmMain/kotlin/io/mockk/core/ValueClassSupport.kt
+++ b/modules/mockk-core/src/jvmMain/kotlin/io/mockk/core/ValueClassSupport.kt
@@ -5,6 +5,7 @@ import java.lang.reflect.Method
 import kotlin.reflect.KClass
 import kotlin.reflect.KProperty
 import kotlin.reflect.KProperty1
+import kotlin.reflect.KTypeParameter
 import kotlin.reflect.full.declaredMemberProperties
 import kotlin.reflect.full.isSuperclassOf
 import kotlin.reflect.jvm.internal.KotlinReflectionInternalError
@@ -122,7 +123,13 @@ actual object ValueClassSupport {
             if (!this.isValue_safe) {
                 this
             } else {
-                this.boxedProperty.returnType.classifier as KClass<*>
+                this.boxedProperty.returnType.classifier.let { classifier ->
+                    when (classifier) {
+                        is KClass<*> -> classifier
+                        is KTypeParameter -> classifier.upperBounds.firstNotNullOfOrNull { it.classifier as? KClass<*> } ?: Any::class
+                        else -> Any::class
+                    }
+                }
             }
 
     /**

--- a/test-modules/client-tests/src/jvmTest/kotlin/io/mockk/core/ValueClassSupportTest.kt
+++ b/test-modules/client-tests/src/jvmTest/kotlin/io/mockk/core/ValueClassSupportTest.kt
@@ -421,6 +421,56 @@ class ValueClassSupportTest {
         assertEquals(testValue, mock.getResult())
     }
 
+    /** https://github.com/mockk/mockk/issues/1528 */
+    @Test
+    fun `verify generic underlying value class`() {
+        val testValue = GenericUnderlyingValueClass("generic underlying")
+
+        val mock =
+            mockk<ValueClassService> {
+                every { getGenericUnderlyingValueClass() } returns testValue
+            }
+
+        assertEquals(testValue, mock.getGenericUnderlyingValueClass())
+    }
+
+    /** https://github.com/mockk/mockk/issues/1528 */
+    @Test
+    fun `verify generic underlying value class property`() {
+        val testValue = GenericUnderlyingValueClass("generic underlying property")
+
+        val mock =
+            mockk<ValueClassService> {
+                every { genericUnderlyingValueClassProperty } returns testValue
+            }
+
+        assertEquals(testValue, mock.genericUnderlyingValueClassProperty)
+    }
+
+    /** https://github.com/mockk/mockk/issues/1528 */
+    @Test
+    fun `verify any matcher with generic underlying value class`() {
+        val mock =
+            mockk<ValueClassService> {
+                every { argGenericUnderlyingValueClass(any()) } returns "matched"
+            }
+
+        assertEquals("matched", mock.argGenericUnderlyingValueClass(GenericUnderlyingValueClass("generic underlying arg")))
+    }
+
+    /** https://github.com/mockk/mockk/issues/1528 */
+    @Test
+    fun `verify generic underlying value class returned as interface type`() {
+        val testValue = GenericUnderlyingValueClass("generic underlying interface")
+
+        val mock =
+            mockk<ValueClassService> {
+                every { getGenericUnderlyingValueClassAsInterfaceType() } returns testValue
+            }
+
+        assertEquals(testValue, mock.getGenericUnderlyingValueClassAsInterfaceType())
+    }
+
     @Test
     fun `verify suspend function returning a value class`() {
         val testValue = ValueClass("suspend")
@@ -500,6 +550,14 @@ class ValueClassSupportTest {
         assertEquals(PrimitiveValueClass::class, ValueClassSupport.run { klass.innermostBoxedClass(2) })
         assertEquals(Int::class, ValueClassSupport.run { klass.innermostBoxedClass(3) })
     }
+
+    /** https://github.com/mockk/mockk/issues/1528 */
+    @Test
+    fun `verify innermostBoxedClass resolves generic underlying value class to upper bound`() {
+        val klass = GenericUnderlyingValueClass::class
+
+        assertEquals(Any::class, ValueClassSupport.run { klass.innermostBoxedClass() })
+    }
 }
 
 private class MockTarget {
@@ -569,6 +627,14 @@ internal interface ValueClassService {
 
     fun getResult(): Result<String>
 
+    fun getGenericUnderlyingValueClass(): GenericUnderlyingValueClass<String>
+
+    val genericUnderlyingValueClassProperty: GenericUnderlyingValueClass<String>
+
+    fun argGenericUnderlyingValueClass(value: GenericUnderlyingValueClass<String>): String
+
+    fun getGenericUnderlyingValueClassAsInterfaceType(): GenericUnderlyingValueClassSuperType
+
     fun getValueClassAsAny(): Any
 
     fun getValueClassAsInterfaceType(): ValueClassSuperType
@@ -596,6 +662,13 @@ internal interface ValueWrapper {
 internal value class InlineValueWrapper(
     override val value: Long,
 ) : ValueWrapper
+
+@JvmInline
+internal value class GenericUnderlyingValueClass<T>(
+    val value: T,
+) : GenericUnderlyingValueClassSuperType
+
+internal interface GenericUnderlyingValueClassSuperType
 
 internal interface ParameterizedValueClassService<T : ValueWrapper> {
     fun value(): T


### PR DESCRIPTION
Fixes #1528.

## Summary
- Resolve generic value class backing type parameters to their upper bound instead of casting them as `KClass` directly.
- Add regression coverage for generic-underlying value class returns, properties, matcher signature generation, and interface return shape.

## Verification
- `./gradlew :test-modules:client-tests:jvmTest --tests 'io.mockk.core.ValueClassSupportTest' :modules:mockk:jvmTest --tests 'io.mockk.it.ValueClassTest'`
- `./gradlew spotlessCheck`
