### PR TITLE
fix: instrument all overloads that erase to the same JVM signature

### DIFF
--- a/modules/mockk-agent/src/jvmMain/kotlin/io/mockk/proxy/jvm/JvmMockKAgentFactory.kt
+++ b/modules/mockk-agent/src/jvmMain/kotlin/io/mockk/proxy/jvm/JvmMockKAgentFactory.kt
@@ -16,6 +16,7 @@ import net.bytebuddy.ByteBuddy
 import net.bytebuddy.NamingStrategy
 import net.bytebuddy.agent.ByteBuddyAgent
 import net.bytebuddy.description.type.TypeDescription
+import net.bytebuddy.dynamic.scaffold.MethodGraph
 import net.bytebuddy.dynamic.scaffold.TypeValidation
 import java.lang.instrument.Instrumentation
 import java.util.concurrent.atomic.AtomicLong
@@ -63,6 +64,12 @@ class JvmMockKAgentFactory : MockKAgentFactory {
                     ByteBuddy()
                         .with(TypeValidation.DISABLED)
                         .with(MockKSubclassNamingStrategy())
+                        // Distinguish methods by their return type as well as name and parameters.
+                        // Overloads whose generic parameters erase to the same JVM signature (e.g.
+                        // hello(List<String>): String and hello(List<Int>): List<String>) are separate
+                        // methods; the default (Java hierarchy) view merges them, so only one gets
+                        // instrumented and calls to the other hit the real implementation. See #1300.
+                        .with(MethodGraph.Compiler.Default.forJVMHierarchy())
 
                 jvmInstantiator =
                     ObjenesisInstantiator(

--- a/test-modules/client-tests/src/jvmTest/kotlin/io/mockk/core/OverloadedMethodWithErasedParamsTest.kt
+++ b/test-modules/client-tests/src/jvmTest/kotlin/io/mockk/core/OverloadedMethodWithErasedParamsTest.kt
@@ -1,0 +1,31 @@
+package io.mockk.core
+
+import io.mockk.every
+import io.mockk.mockk
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+// https://github.com/mockk/mockk/issues/1300
+class OverloadedMethodWithErasedParamsTest {
+
+    class MyService {
+        fun hello(names: List<String>): String {
+            throw RuntimeException("real hello(List<String>) must not be called (names=$names)")
+        }
+
+        fun hello(ages: List<Int>): List<String> {
+            throw RuntimeException("real hello(List<Int>) must not be called (ages=$ages)")
+        }
+    }
+
+    @Test
+    fun `every stubs the correct overload without calling the real method`() {
+        val service = mockk<MyService>()
+
+        every { service.hello(any<List<String>>()) } returns "Hello"
+        assertEquals("Hello", service.hello(listOf("bob")))
+
+        every { service.hello(any<List<Int>>()) } returns listOf("World")
+        assertEquals(listOf("World"), service.hello(listOf(1)))
+    }
+}


### PR DESCRIPTION
Fixes #1300.

When a mocked class has two overloads whose generic parameters erase to the same JVM signature — `hello(names: List<String>): String` and `hello(ages: List<Int>): List<String>` — only one of them actually got instrumented. Calls to the other ran the real method during `every { }` recording, which is why the real body executes (and non-deterministically, since it depends on method order).

The ByteBuddy instance in `JvmMockKAgentFactory` used the default method-graph compiler, which models methods the way the Java language does (name + parameter types, ignoring return type), so the two overloads collapse to one method and only one gets the proxy advice. Building ByteBuddy with `MethodGraph.Compiler.Default.forJVMHierarchy()` distinguishes them by return type too, so both are instrumented.

Added `OverloadedMethodWithErasedParamsTest` with the case from the issue — it fails on `main` and passes with the fix. The `:modules:mockk-agent`, `:modules:mockk` and `:test-modules:client-tests` JVM suites are green (817 tests).

Written with AI assistance (Claude); I reviewed the change and the ByteBuddy behavior it relies on.