### PR TITLE
docs: update JVM installation dependency to mockk-jvm

### DIFF
--- a/ANDROID.md
+++ b/ANDROID.md
@@ -127,7 +127,7 @@ All you need to get started is by adding a dependency to `MockK` library.
 #### Unit tests
 
 ```
-testImplementation "io.mockk:mockk-jvm:{version}"
+testImplementation "io.mockk:mockk-android:{version}"
 ```
 
 #### Android instrumented tests

--- a/ANDROID.md
+++ b/ANDROID.md
@@ -127,7 +127,7 @@ All you need to get started is by adding a dependency to `MockK` library.
 #### Unit tests
 
 ```
-testImplementation "io.mockk:mockk:{version}"
+testImplementation "io.mockk:mockk-jvm:{version}"
 ```
 
 #### Android instrumented tests

--- a/README.md
+++ b/README.md
@@ -22,14 +22,14 @@ All you need to get started is just to add a dependency to `MockK` library.
 <td><img src="doc/gradle.png" alt="Gradle"/></td>
 <td>
 <pre>
-testImplementation "io.mockk:mockk:${mockkVersion}"
+testImplementation "io.mockk:mockk-jvm:${mockkVersion}"
 </pre>
 </td>
 </tr>
 <tr>
 <td><img src="doc/gradle.png" alt="Gradle"/> (Kotlin DSL)</td>
  <td>
-  <pre>testImplementation("io.mockk:mockk:${mockkVersion}")</pre>
+  <pre>testImplementation("io.mockk:mockk-jvm:${mockkVersion}")</pre>
  </td>
 </tr>
 <tr>


### PR DESCRIPTION
## Summary

This PR updates the JVM installation instructions to use the correct artifact for MockK 1.13.1+.

### Changes
- Updated the Gradle (Groovy DSL) example in `README.md` to use `io.mockk:mockk-jvm`.
- Updated the Gradle (Kotlin DSL) example in `README.md` to use `io.mockk:mockk-jvm`.
- Updated the JVM unit test dependency example in `ANDROID.md` to use `io.mockk:mockk-jvm`.

### Reason

The README and Android documentation currently recommend `io.mockk:mockk`, but since MockK 1.13.1 the correct JVM artifact is `io.mockk:mockk-jvm`. Updating the installation instructions prevents confusion caused by the legacy `mockk` artifact.

Closes #1065 