### PR TITLE
fix: clear every mock kind in a single stub repository pass (#1546)

### DIFF
--- a/modules/mockk-dsl/api/mockk-dsl.api
+++ b/modules/mockk-dsl/api/mockk-dsl.api
@@ -730,6 +730,7 @@ public final class io/mockk/MockKGateway$ClearOptions {
 public abstract interface class io/mockk/MockKGateway$Clearer {
 	public abstract fun clear ([Ljava/lang/Object;Lio/mockk/MockKGateway$ClearOptions;)V
 	public abstract fun clearAll (Lio/mockk/MockKGateway$ClearOptions;Z)V
+	public abstract fun clearAll (Lio/mockk/MockKGateway$ClearOptions;ZZZZZ)V
 	public abstract fun clearAllStubsFromMemory (ZLjava/util/List;)V
 }
 

--- a/modules/mockk-dsl/src/commonMain/kotlin/io/mockk/API.kt
+++ b/modules/mockk-dsl/src/commonMain/kotlin/io/mockk/API.kt
@@ -651,18 +651,14 @@ object MockKDsl {
             )
         val implementation = MockKGateway.implementation()
 
-        if (regularMocks) {
-            implementation.clearer.clearAll(options, currentThreadOnly)
-        }
-        if (objectMocks) {
-            implementation.objectMockFactory.clearAll(options, currentThreadOnly)
-        }
-        if (staticMocks) {
-            implementation.staticMockFactory.clearAll(options, currentThreadOnly)
-        }
-        if (constructorMocks) {
-            implementation.constructorMockFactory.clearAll(options, currentThreadOnly)
-        }
+        implementation.clearer.clearAll(
+            options,
+            currentThreadOnly,
+            regularMocks,
+            objectMocks,
+            staticMocks,
+            constructorMocks,
+        )
     }
 
     inline fun internalClearMemory(

--- a/modules/mockk-dsl/src/commonMain/kotlin/io/mockk/MockKGateway.kt
+++ b/modules/mockk-dsl/src/commonMain/kotlin/io/mockk/MockKGateway.kt
@@ -136,6 +136,22 @@ interface MockKGateway {
             currentThreadOnly: Boolean,
         )
 
+        /**
+         * Clears every requested kind of mock in a single pass over the stub repository.
+         *
+         * [clearAll] and the `clearAll` of [ObjectMockFactory], [StaticMockFactory] and
+         * [ConstructorMockFactory] each walk every live stub, so clearing all four kinds through
+         * them costs four passes to clear each mock once.
+         */
+        fun clearAll(
+            options: ClearOptions,
+            currentThreadOnly: Boolean,
+            regularMocks: Boolean,
+            objectMocks: Boolean,
+            staticMocks: Boolean,
+            constructorMocks: Boolean,
+        )
+
         fun clearAllStubsFromMemory(
             currentThreadOnly: Boolean = false,
             excludeMocks: List<Any> = emptyList(),

--- a/modules/mockk/api/mockk.api
+++ b/modules/mockk/api/mockk.api
@@ -961,6 +961,7 @@ public final class io/mockk/impl/stub/CommonClearer : io/mockk/MockKGateway$Clea
 	public fun <init> (Lio/mockk/impl/stub/StubRepository;Lio/mockk/impl/log/SafeToString;)V
 	public fun clear ([Ljava/lang/Object;Lio/mockk/MockKGateway$ClearOptions;)V
 	public fun clearAll (Lio/mockk/MockKGateway$ClearOptions;Z)V
+	public fun clearAll (Lio/mockk/MockKGateway$ClearOptions;ZZZZZ)V
 	public fun clearAllStubsFromMemory (ZLjava/util/List;)V
 	public final fun getLog ()Lio/mockk/impl/log/Logger;
 	public final fun getSafeToString ()Lio/mockk/impl/log/SafeToString;

--- a/modules/mockk/src/commonMain/kotlin/io/mockk/impl/stub/ClearKind.kt
+++ b/modules/mockk/src/commonMain/kotlin/io/mockk/impl/stub/ClearKind.kt
@@ -1,0 +1,30 @@
+package io.mockk.impl.stub
+
+/**
+ * The kind of mock a [Stub] represents, as `clearAllMocks` groups them.
+ */
+internal enum class ClearKind {
+    REGULAR,
+    OBJECT,
+    STATIC,
+    CONSTRUCTOR,
+}
+
+/**
+ * The [ClearKind] this stub belongs to, or `null` when `clearAllMocks` never clears it.
+ */
+internal val Stub.clearKind: ClearKind?
+    get() =
+        when {
+            this is ConstructorStub -> ClearKind.CONSTRUCTOR
+            this is SpyKStub<*> ->
+                when (mockType) {
+                    MockType.SPY -> ClearKind.REGULAR
+                    MockType.OBJECT -> ClearKind.OBJECT
+                    MockType.STATIC -> ClearKind.STATIC
+                    MockType.CONSTRUCTOR -> ClearKind.CONSTRUCTOR
+                    else -> null
+                }
+            this is MockKStub -> ClearKind.REGULAR.takeIf { mockType == MockType.REGULAR }
+            else -> null
+        }

--- a/modules/mockk/src/commonMain/kotlin/io/mockk/impl/stub/CommonClearer.kt
+++ b/modules/mockk/src/commonMain/kotlin/io/mockk/impl/stub/CommonClearer.kt
@@ -24,19 +24,40 @@ class CommonClearer(
     override fun clearAll(
         options: MockKGateway.ClearOptions,
         currentThreadOnly: Boolean,
+    ) = clearAll(
+        options = options,
+        currentThreadOnly = currentThreadOnly,
+        regularMocks = true,
+        objectMocks = false,
+        staticMocks = false,
+        constructorMocks = false,
+    )
+
+    override fun clearAll(
+        options: MockKGateway.ClearOptions,
+        currentThreadOnly: Boolean,
+        regularMocks: Boolean,
+        objectMocks: Boolean,
+        staticMocks: Boolean,
+        constructorMocks: Boolean,
     ) {
+        if (!regularMocks && !objectMocks && !staticMocks && !constructorMocks) {
+            return
+        }
         val currentThreadId = Thread.currentThread().id
         stubRepository.allStubs.forEach { stub ->
             if (currentThreadOnly && currentThreadId != stub.threadId) {
                 return@forEach
             }
-            val isRegularOrSpy =
-                when {
-                    stub is SpyKStub<*> -> stub.mockType == MockType.SPY
-                    stub is MockKStub -> stub.mockType == MockType.REGULAR
-                    else -> false
+            val isRequested =
+                when (stub.clearKind) {
+                    ClearKind.REGULAR -> regularMocks
+                    ClearKind.OBJECT -> objectMocks
+                    ClearKind.STATIC -> staticMocks
+                    ClearKind.CONSTRUCTOR -> constructorMocks
+                    null -> false
                 }
-            if (isRegularOrSpy) {
+            if (isRequested) {
                 stub.clear(options)
             }
         }

--- a/modules/mockk/src/commonTest/kotlin/io/mockk/impl/stub/CommonClearerTest.kt
+++ b/modules/mockk/src/commonTest/kotlin/io/mockk/impl/stub/CommonClearerTest.kt
@@ -1,0 +1,51 @@
+package io.mockk.impl.stub
+
+import io.mockk.MockKGateway
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import kotlin.test.Test
+
+class CommonClearerTest {
+    class Target
+
+    private val options = MockKGateway.ClearOptions(true, true, true, true, true)
+
+    private fun oneStubOfEachKind(): List<Stub> =
+        MockType.values().map { mockType ->
+            SpyKStub(Target::class, mockType.name, mockk(relaxed = true), false, mockType)
+        }
+
+    @Test
+    fun `clearing every kind of mock reads the stub repository once`() {
+        val stubRepository = mockk<StubRepository>(relaxed = true)
+        every { stubRepository.allStubs } returns oneStubOfEachKind()
+
+        CommonClearer(stubRepository, mockk(relaxed = true)).clearAll(
+            options = options,
+            currentThreadOnly = false,
+            regularMocks = true,
+            objectMocks = true,
+            staticMocks = true,
+            constructorMocks = true,
+        )
+
+        verify(exactly = 1) { stubRepository.allStubs }
+    }
+
+    @Test
+    fun `clearing no kind of mock does not read the stub repository`() {
+        val stubRepository = mockk<StubRepository>(relaxed = true)
+
+        CommonClearer(stubRepository, mockk(relaxed = true)).clearAll(
+            options = options,
+            currentThreadOnly = false,
+            regularMocks = false,
+            objectMocks = false,
+            staticMocks = false,
+            constructorMocks = false,
+        )
+
+        verify(exactly = 0) { stubRepository.allStubs }
+    }
+}

--- a/modules/mockk/src/jvmMain/kotlin/io/mockk/impl/instantiation/JvmConstructorMockFactory.kt
+++ b/modules/mockk/src/jvmMain/kotlin/io/mockk/impl/instantiation/JvmConstructorMockFactory.kt
@@ -10,11 +10,13 @@ import io.mockk.MockKGateway.ConstructorMockFactory
 import io.mockk.NullCheckMatcher
 import io.mockk.impl.InternalPlatform
 import io.mockk.impl.log.Logger
+import io.mockk.impl.stub.ClearKind
 import io.mockk.impl.stub.CommonClearer
 import io.mockk.impl.stub.ConstructorStub
 import io.mockk.impl.stub.MockType
 import io.mockk.impl.stub.SpyKStub
 import io.mockk.impl.stub.StubGatewayAccess
+import io.mockk.impl.stub.clearKind
 import io.mockk.proxy.Cancelable
 import io.mockk.proxy.MockKConstructorProxyMaker
 import io.mockk.proxy.MockKInvocationHandler
@@ -305,10 +307,7 @@ class JvmConstructorMockFactory(
             if (currentThreadOnly && currentThreadId != stub.threadId) {
                 return@forEach
             }
-            val isConstructorMock =
-                stub is ConstructorStub ||
-                    (stub is SpyKStub<*> && stub.mockType == MockType.CONSTRUCTOR)
-            if (isConstructorMock) {
+            if (stub.clearKind == ClearKind.CONSTRUCTOR) {
                 stub.clear(options)
             }
         }

--- a/modules/mockk/src/jvmMain/kotlin/io/mockk/impl/instantiation/JvmObjectMockFactory.kt
+++ b/modules/mockk/src/jvmMain/kotlin/io/mockk/impl/instantiation/JvmObjectMockFactory.kt
@@ -6,10 +6,12 @@ import io.mockk.MockKGateway
 import io.mockk.MockKGateway.ObjectMockFactory
 import io.mockk.impl.InternalPlatform
 import io.mockk.impl.log.Logger
+import io.mockk.impl.stub.ClearKind
 import io.mockk.impl.stub.MockType
 import io.mockk.impl.stub.SpyKStub
 import io.mockk.impl.stub.StubGatewayAccess
 import io.mockk.impl.stub.StubRepository
+import io.mockk.impl.stub.clearKind
 import io.mockk.proxy.MockKAgentException
 import io.mockk.proxy.MockKProxyMaker
 
@@ -94,7 +96,7 @@ class JvmObjectMockFactory(
             if (currentThreadOnly && currentThreadId != stub.threadId) {
                 return@forEach
             }
-            if (stub is SpyKStub<*> && stub.mockType == MockType.OBJECT) {
+            if (stub.clearKind == ClearKind.OBJECT) {
                 stub.clear(options)
             }
         }

--- a/modules/mockk/src/jvmMain/kotlin/io/mockk/impl/instantiation/JvmStaticMockFactory.kt
+++ b/modules/mockk/src/jvmMain/kotlin/io/mockk/impl/instantiation/JvmStaticMockFactory.kt
@@ -6,10 +6,12 @@ import io.mockk.MockKGateway
 import io.mockk.MockKGateway.StaticMockFactory
 import io.mockk.impl.InternalPlatform.hkd
 import io.mockk.impl.log.Logger
+import io.mockk.impl.stub.ClearKind
 import io.mockk.impl.stub.MockType
 import io.mockk.impl.stub.SpyKStub
 import io.mockk.impl.stub.StubGatewayAccess
 import io.mockk.impl.stub.StubRepository
+import io.mockk.impl.stub.clearKind
 import io.mockk.proxy.MockKAgentException
 import io.mockk.proxy.MockKStaticProxyMaker
 import kotlin.reflect.KClass
@@ -75,7 +77,7 @@ class JvmStaticMockFactory(
             if (currentThreadOnly && currentThreadId != stub.threadId) {
                 return@forEach
             }
-            if (stub is SpyKStub<*> && stub.mockType == MockType.STATIC) {
+            if (stub.clearKind == ClearKind.STATIC) {
                 stub.clear(options)
             }
         }


### PR DESCRIPTION
Fixes #1546.

## Summary
- `MockKDsl.internalClearAllMocks` dispatched to `Clearer.clearAll`, `ObjectMockFactory.clearAll`, `StaticMockFactory.clearAll` and `ConstructorMockFactory.clearAll` in turn. All four read `StubRepository.allStubs`, and that property rebuilds a list of every live stub on each access, so a single `clearAllMocks()` walked all live mocks four times to clear each mock once.
- Added a `Clearer.clearAll` overload that takes the four kind flags. `CommonClearer` implements it as one pass that routes each stub to the requested kind, and `internalClearAllMocks` now makes a single call.
- The kind classification moved into an internal `Stub.clearKind`. `CommonClearer` and the three JVM factories each carried their own copy of the same `mockType` checks; now they share one.
- Behaviour is unchanged. The two-argument `Clearer.clearAll` delegates to the new overload with only `regularMocks` set, so it still clears regular and spy mocks only, and the per-kind `clearAll` of the three factories keeps working for callers that drive the factories directly. The flag isolation from #1533 is still covered by `ClearAllMocksFlagIsolationTest`, which passes unmodified.
- `apiDump` adds one line per module for the new overload.

## Measurement
Counting reads of `StubRepository.allStubs` during one `clearAllMocks()` with a regular mock, a spy, an object mock, a static mock and a constructor mock live. Measured with a temporary counter on the property, which is not part of this PR:

| | reads of `allStubs` |
| --- | --- |
| master | 4 |
| this branch | 1 |

Wall clock for one `clearAllMocks()` with 5000 live stubbed mocks, JDK 21 on an M-series Mac, 30 warmup calls then 25 samples. Single machine, single run, so treat the ratio rather than the absolute numbers as the result:

| | min | median |
| --- | --- | --- |
| master | 2409 us | 4167 us |
| this branch | 1330 us | 1589 us |

It is not a 4x win because `Stub.clear` runs once per mock either way. Only the repeated traversal and list rebuild go away.

`CommonClearerTest` pins the single read so the extra passes cannot come back unnoticed. Reintroducing one extra `stubRepository.allStubs` read fails `clearing every kind of mock reads the stub repository once` while the second test stays green.

## Verification
- `./gradlew check` on JDK 21: 842 tests, 0 failures, 19 skipped. All skips are pre-existing `@Ignore`, for example `ConstructorMockTest.clear` for #1224.
- `./gradlew spotlessCheck` and `./gradlew apiDump` are clean.
