### PR TITLE
fix: don't let inline function detection break mocking 

### DIFF
--- a/modules/mockk/src/jvmMain/kotlin/io/mockk/impl/instantiation/JvmMockFactoryHelper.kt
+++ b/modules/mockk/src/jvmMain/kotlin/io/mockk/impl/instantiation/JvmMockFactoryHelper.kt
@@ -20,7 +20,6 @@ import kotlin.reflect.KParameter
 import kotlin.reflect.KProperty1
 import kotlin.reflect.KType
 import kotlin.reflect.full.memberProperties
-import kotlin.reflect.jvm.internal.KotlinReflectionInternalError
 import kotlin.reflect.jvm.javaField
 import kotlin.reflect.jvm.javaMethod
 import kotlin.reflect.jvm.kotlinFunction
@@ -125,21 +124,17 @@ object JvmMockFactoryHelper {
         }
     }
 
-    private fun Method.isKotlinInline(): Boolean {
+    private fun Method.isKotlinInline(): Boolean =
         try {
-            val kotlinFunction = this.kotlinFunction
-            if (kotlinFunction != null && kotlinFunction.isInline) return true
-        } catch (_: KotlinReflectionInternalError) {
-            null // fall back to annotation check
-        } catch (_: UnsupportedOperationException) {
-            null // fall back to annotation check
+            kotlinFunction?.isInline == true
+        } catch (_: Throwable) {
+            // Reading kotlinFunction makes kotlin-reflect resolve the whole declaring class
+            // hierarchy, which fails in unforeseeable ways on classes it cannot analyze (#1432,
+            // #1439, #1512), so the same broad catch as toDescription() below is needed.
+            // Detection is best-effort: an unanalyzable method counts as not inline and mocking
+            // proceeds.
+            false
         }
-
-        return this.declaredAnnotations.any { ann ->
-            val n = ann.annotationClass.qualifiedName ?: ann.annotationClass.java.name
-            n == "kotlin.internal.InlineOnly"
-        }
-    }
 
     internal fun Method.toDescription(): MethodDescription {
         val cached = cache[this]

--- a/modules/mockk/src/jvmTest/java/io/mockk/it/CloneDeclaredOnSubInterface.java
+++ b/modules/mockk/src/jvmTest/java/io/mockk/it/CloneDeclaredOnSubInterface.java
@@ -1,0 +1,43 @@
+package io.mockk.it;
+
+/**
+ * Minimal replica of the Quartz scheduler Trigger hierarchy (issue #1432): the base
+ * interface extends Cloneable while clone() is only declared on a subinterface, and the
+ * implementation also inherits Cloneable through a second interface that does not declare
+ * clone(). kotlin-reflect cannot analyze such classes and fails with
+ * "Cannot infer visibility for inherited open fun clone".
+ */
+public class CloneDeclaredOnSubInterface {
+    public interface Trigger extends Cloneable {
+        void trigger();
+    }
+
+    public interface MutableTrigger extends Trigger {
+        Object clone();
+    }
+
+    public interface SimpleTrigger extends Trigger {
+        int getTimesTriggered();
+    }
+
+    public abstract static class AbstractTrigger implements MutableTrigger {
+        @Override
+        public Object clone() {
+            return null;
+        }
+    }
+
+    public static class SimpleTriggerImpl extends AbstractTrigger implements SimpleTrigger {
+        private int timesTriggered = 0;
+
+        @Override
+        public int getTimesTriggered() {
+            return timesTriggered;
+        }
+
+        @Override
+        public void trigger() {
+            timesTriggered++;
+        }
+    }
+}

--- a/modules/mockk/src/jvmTest/kotlin/io/mockk/it/InlineMemberFunctionFailFastTest.kt
+++ b/modules/mockk/src/jvmTest/kotlin/io/mockk/it/InlineMemberFunctionFailFastTest.kt
@@ -3,6 +3,8 @@ package io.mockk.it
 import io.mockk.MockKException
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.unmockkObject
 import java.lang.reflect.InvocationTargetException
 import kotlin.test.Test
 import kotlin.test.assertContains
@@ -17,6 +19,18 @@ private class HasWrapper {
     private val impl = HasInline()
 
     fun addOne(x: Int) = impl.addOne(x) // non-inline wrapper
+}
+
+// replica of issue #1439: kotlin-reflect fails with ClassNotFoundException: kotlin.Array
+// when analyzing a companion containing a @JvmStatic external function returning Array
+private class HasExternalJniMethod private constructor() {
+    companion object {
+        val instance: HasExternalJniMethod = HasExternalJniMethod()
+
+        @Suppress("unused")
+        @JvmStatic
+        external fun jniMethod(): Array<String>
+    }
 }
 
 class InlineMemberFunctionFailFastTest {
@@ -53,5 +67,33 @@ class InlineMemberFunctionFailFastTest {
 
         val msg = cause.message ?: ""
         assertContains(msg, "Mocking Kotlin inline functions is not supported")
+    }
+
+    /**
+     * Inline detection must stay best-effort: when kotlin-reflect cannot analyze the declaring
+     * class it throws (here: ClassNotFoundException for kotlin.Array, see #1439), and mocking
+     * has to proceed as if the method were not inline instead of failing.
+     */
+    @Test
+    fun stubOfCompanionWithExternalArrayReturningFunctionStillWorks() {
+        mockkObject(HasExternalJniMethod.Companion)
+        try {
+            val replacement = mockk<HasExternalJniMethod>()
+            every { HasExternalJniMethod.instance } returns replacement
+            assertEquals(replacement, HasExternalJniMethod.instance)
+        } finally {
+            unmockkObject(HasExternalJniMethod.Companion)
+        }
+    }
+
+    /**
+     * Same best-effort requirement for a Java hierarchy kotlin-reflect rejects with
+     * "Cannot infer visibility for inherited open fun clone" (see #1432).
+     */
+    @Test
+    fun stubOfJavaClassWithCloneDeclaredOnSubInterfaceStillWorks() {
+        val trigger = mockk<CloneDeclaredOnSubInterface.SimpleTriggerImpl>()
+        every { trigger.timesTriggered } returns 1
+        assertEquals(1, trigger.timesTriggered)
     }
 }


### PR DESCRIPTION
Fixes #1432, fixes #1439, fixes #1512. This also supersedes #1459, which only addresses #1432.

added the inline fail-fast guard in #1421, then narrowed its `catch (_: Throwable)` to two exception types in `9e2bb073`. The narrow version is what broke mocking in 1.14.6. This puts the broad catch back.

### What went wrong

`isKotlinInline()` reads `Method.kotlinFunction` on every mock invocation. It looks like a cheap property read, but it makes kotlin-reflect resolve the whole declaring class — the full hierarchy and every member signature. kotlin-reflect can't do that for every class, and it throws when it can't. It also fails per class, not per method, so a member you never touched can take down the method you did mock.

Three reports, none of them about an inline function:

- #1439 — `ClassNotFoundException: kotlin.Array`. The mocked member was a plain `instance` property. The same companion also declared `@JvmStatic external fun jniMethod(): Array<String>`, and resolving that signature is what failed.
- #1432 — `IllegalStateException: Cannot infer visibility for inherited open fun clone()`. Quartz extends `Cloneable` on one interface and declares `clone()` on a subinterface, and kotlin-reflect has no way to model that.
- #1512 — `ArrayIndexOutOfBoundsException` from an Android 12/12L bug: `getParameterAnnotations()` returns an empty array for 29 methods on `Context` and `ContextWrapper`.

These all worked in 1.14.5, and the reason matters. kotlin-reflect failed on the same classes back then too — it just never surfaced, because the other two kotlin-reflect calls on the invocation path already guard against it. `toDescription()` catches bare `Throwable` (that's from #18 and #22) and `findBackingField()` wraps its call in `runCatching`. #1421 added a third call with a weaker guard, in front of both.

The #1432 fixture in this PR shows it directly: `Method.kotlinFunction` on `getTimesTriggered` throws, and `toDescription()` only survives because its catch is broad. That leaves two policies for the same call in the same file, which is what this PR settles.

### Why not just add the missing types

#1421 whether we could catch only what we expect, and I agreed and narrowed it. I got that wrong, for two reasons.

The set of exceptions isn't closed. "kotlin-reflect can't analyze this class" can come out as almost anything, and even with three known failures in hand, enumerating them still doesn't hold. `catch (Exception)` plus `KotlinReflectionInternalError` covers all three, but `NoClassDefFoundError` — the `Error` twin of #1439's failure, and an easy variant of the same classpath problem — walks straight through. That's my worry about #1459 too: adding `IllegalStateException` fixes #1432 and leaves the other two broken.

The other reason is that the fallback I promised in exchange never ran. I said the annotation check would cover the narrowed cases, but `@kotlin.internal.InlineOnly` is compiled with `CLASS` retention, so `Method.declaredAnnotations` can never see it, and it's `internal` to the stdlib so nobody can apply it by hand either. That branch always returned `false`. Narrowing dropped the guard and replaced it with nothing, which is how all three regressions shipped.

### What this does

`isKotlinInline()` catches `Throwable` again and returns `false`, the same way `toDescription()` does a few lines down. The dead annotation check is deleted.

The guard itself keeps working. I checked both ways of reaching it on a mock: reflection, which `stubOfInlineFunctionViaReflectionThrowsFailFastError` covers, and a Java caller invoking an inline Kotlin member, which is how you get there without reflection. Both still produce `Mocking Kotlin inline functions is not supported`, and an ordinary method on the same mock behaves normally, so nothing is misfiring.

The DSL hint in `StubbingState` and `SignatureMatcherDetector` is untouched, and it's the half that covers plain Kotlin code. `every { }` on an inline member never reaches the proxy at all, so what you see there is the "no call is recorded" message.

The only behavioural change is who fails. Before, "you mocked an inline function" and "you mocked a class kotlin-reflect can't parse" both failed. Now only the first one does. This function decides whether to raise a diagnostic and nothing else, so falling back to "not inline" can cost you an error message but can't change a test result.

### Tests

Two regression tests, added to the existing `InlineMemberFunctionFailFastTest` instead of issue-numbered classes, per CONTRIBUTING:

- `stubOfCompanionWithExternalArrayReturningFunctionStillWorks` for #1439
- `stubOfJavaClassWithCloneDeclaredOnSubInterfaceStillWorks` for #1432, with `CloneDeclaredOnSubInterface.java` reduced from the files attached to that issue

Both fail before the change with the exceptions from the original reports, and neither exception was caught by the old two-type version, so they're testing the right thing.

`./gradlew check` passes for every non-Android module (836 tests). No Android SDK on my machine, so I couldn't run `connectedCheck` locally.

### #1512 needs someone with an emulator

I can't reproduce the Android case on the JVM. The empty array comes from ART, the JDK returns correctly sized ones, and `Method` is final so there's nothing to stub out. `ArrayIndexOutOfBoundsException` lands in the same bucket as #1432's `IllegalStateException`, so the fix covers it by construction, but no test drives it.

Worth flagging why CI missed this in the first place. The instrumented matrix is `[ 21, 26, 28, 34, 36 ]`, which skips both affected versions, and the only framework class any instrumented test mocks is `FrameLayout`. Adding 31/32 and a test that mocks something in the `Context` family would give this real coverage. I left both out because I can't verify Android code here, but say the word and I'll add them.

### Follow-ups

Two things I ran into that don't belong in this PR.

The guard sits on the invocation path but hardly ever fires. Inline members are inlined at the call site, so ordinary Kotlin code never reaches the proxy — that's the DSL hint's job. Only reflection and Java callers get there, yet every invocation of every mock pays for the kotlin-reflect resolution. Doing the check on the failure path instead would make the normal path free.

`JvmMockFactoryHelper.cache` never hits for classes instrumented in place. `JvmWeakConcurrentMap` keys by identity, and the advice path (`JvmMockKProxyAdvice`, using `net.bytebuddy.asm.Advice.Origin`) seems to hand out a fresh `Method` each time: 500 calls on a final class mock added 500 entries, so `toDescription()` recomputed all of them. An open class did the same. Interface mocks go through `JvmMockKProxyInterceptor` and `net.bytebuddy.implementation.bind.annotation.Origin`, and there 500 calls added nothing. Objects and statics use the advice path too so they're probably in the same boat, but I only measured classes.
