### PR TITLE
fix(mockk): single non-reified slot() factory

### DIFF
--- a/modules/mockk/api/mockk.api
+++ b/modules/mockk/api/mockk.api
@@ -73,6 +73,7 @@ public final class io/mockk/MockKKt {
 	public static final fun mockkStatic ([Ljava/lang/String;Lkotlin/jvm/functions/Function0;)V
 	public static final fun mockkStatic ([Lkotlin/reflect/KClass;)V
 	public static final fun mockkStatic ([Lkotlin/reflect/KClass;Lkotlin/jvm/functions/Function0;)V
+	public static final fun slot ()Lio/mockk/CapturingSlot;
 	public static final fun unmockkAll ()V
 	public static final fun unmockkConstructor ([Lkotlin/reflect/KClass;)V
 	public static final fun unmockkObject ([Ljava/lang/Object;)V

--- a/modules/mockk/src/commonMain/kotlin/io/mockk/MockK.kt
+++ b/modules/mockk/src/commonMain/kotlin/io/mockk/MockK.kt
@@ -116,6 +116,12 @@ inline fun <reified T : Any> spyk(
  * Slots allow you to capture what arguments a mocked method is called with.
  * When mocking a method using [every], pass the slot wrapped with the `io.mockk.MockKMatcherScope.capture` function in place of a method argument or `io.mockk.MockKMatcherScope.any`.
  *
+ * [T] may be nullable (`slot<String?>()`) or non-null (`slot<String>()`).
+ *
+ * This factory is intentionally a single non-inline, non-reified function with upper bound
+ * `Any?` so multiplatform / IDE resolution sees exactly one candidate (see #1429).
+ * Creating a slot does not require the MockK gateway, so [MockK.useImpl] is not used.
+ *
  * Example:
  * ```
  * interface FileNetwork {
@@ -131,10 +137,7 @@ inline fun <reified T : Any> spyk(
  * // slot.captured is now "testfile"
  * ```
  */
-inline fun <reified T : Any?> slot(): CapturingSlot<T> =
-    MockK.useImpl {
-        MockKDsl.internalSlot<T>()
-    }
+fun <T : Any?> slot(): CapturingSlot<T> = CapturingSlot()
 
 /**
  * Starts a block of stubbing. Part of DSL.

--- a/modules/mockk/src/commonTest/kotlin/io/mockk/it/CapturingTest.kt
+++ b/modules/mockk/src/commonTest/kotlin/io/mockk/it/CapturingTest.kt
@@ -17,6 +17,7 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertNull
+import kotlin.test.assertTrue
 
 class CapturingTest {
     private val mock = mockk<MockedSubject>()
@@ -64,6 +65,25 @@ class CapturingTest {
         assertNull(slot.captured?.value)
 
         verify { mock.nullableOp(1, 2, null) }
+    }
+
+    /**
+     * Regression for #1429: a single `slot` factory must resolve for both non-null and
+     * nullable type arguments without overload ambiguity.
+     */
+    @Test
+    fun `slot factory resolves for non-null and nullable type arguments`() {
+        val nonNullSlot = slot<String>()
+        nonNullSlot.captured = "value"
+        assertEquals("value", nonNullSlot.captured)
+
+        val nullableSlot = slot<String?>()
+        nullableSlot.captured = null
+        assertNull(nullableSlot.captured)
+        assertTrue(nullableSlot.isNull)
+
+        nullableSlot.captured = "also"
+        assertEquals("also", nullableSlot.captured)
     }
 
     @Test


### PR DESCRIPTION
## Summary

Fixes #1429 — IDE overload-resolution ambiguity for `slot()` in multiplatform projects.

### Problem

In KMP projects the IDE reported:

```
Overload resolution ambiguity between candidates:
  fun <reified T : Any> slot(): CapturingSlot<T>
  fun <reified T> slot(): CapturingSlot<T>
```

Tests still compiled. The dual candidates come from treating a reified inline factory as both a JVM-erased `T : Any` view and an unconstrained/`Any?` view.

### Fix

Make `slot()` a single non-inline, non-reified factory:

```kotlin
fun <T : Any?> slot(): CapturingSlot<T> = CapturingSlot()
```

- Creating a slot does not need the MockK gateway or reification (`CapturingSlot` construction is pure).
- One signature with upper bound `Any?` supports both `slot<String>()` and `slot<String?>()`.
- Binary ABI now exposes `MockKKt.slot()` (was previously an inline-only reified helper).

### Tests

- Added `slot factory resolves for non-null and nullable type arguments` in `CapturingTest`.
- `:modules:mockk:jvmTest` — all green (including existing capturing tests).
- `:modules:mockk:apiCheck` — green after `apiDump`.