### PR TITLE
fix(mockk): report the verified call in unordered verification failures

### DIFF
--- a/modules/mockk/src/commonMain/kotlin/io/mockk/impl/verify/UnorderedCallVerifier.kt
+++ b/modules/mockk/src/commonMain/kotlin/io/mockk/impl/verify/UnorderedCallVerifier.kt
@@ -120,9 +120,9 @@ open class UnorderedCallVerifier(
                             } else {
                                 VerificationResult.Failure(
                                     "$callIdxMsg. One matching call found, but needs ${callsBoundsMsg(min, max)}" +
-                                        "\nCall: " + allCallsForMock.first() +
+                                        "\nCall: " + onlyCall +
                                         if (MockKSettings.stackTracesOnVerify) {
-                                            "\nStack trace:\n" + stackTrace(0, allCallsForMock.first().callStack())
+                                            "\nStack trace:\n" + stackTrace(0, onlyCall.callStack())
                                         } else {
                                             ""
                                         },
@@ -138,7 +138,7 @@ open class UnorderedCallVerifier(
                                             "but arguments are not matching:\n" +
                                             describeArgumentDifference(matcher, onlyCall) +
                                             if (MockKSettings.stackTracesOnVerify) {
-                                                "\nStack trace:\n" + stackTrace(0, allCallsForMock.first().callStack())
+                                                "\nStack trace:\n" + stackTrace(0, onlyCall.callStack())
                                             } else {
                                                 ""
                                             }

--- a/modules/mockk/src/commonTest/kotlin/io/mockk/it/VerificationErrorsTest.kt
+++ b/modules/mockk/src/commonTest/kotlin/io/mockk/it/VerificationErrorsTest.kt
@@ -146,6 +146,63 @@ class VerificationErrorsTest {
     }
 
     @Test
+    fun argumentsNotMatchingTraceIsTakenFromTheCallThatIsDescribed() {
+        clearMocks(mock)
+
+        every { mock.otherOp(1, any()) } answers { 2 + firstArg<Int>() }
+        every { mock.manyArgsOp() } returns 0.0
+
+        mock.manyArgsOp()
+        mock.otherOp(1, 2)
+
+        try {
+            verify { mock.otherOp(1, 3) }
+            fail("Block should throw verification failure")
+        } catch (ex: AssertionError) {
+            val message = ex.message!!
+            val trace = message.substringAfter("Stack trace:", "")
+
+            if (!message.contains("but arguments are not matching")) {
+                fail("Bad message: " + message)
+            }
+            if (trace.isNotEmpty() && trace.contains("manyArgsOp")) {
+                fail("Stack trace should belong to the call being described: " + message)
+            }
+        }
+    }
+
+    @Test
+    fun oneMatchingCallFoundReportsThatCallAndNotAnotherCallOnTheSameMock() {
+        clearMocks(mock)
+
+        every { mock.otherOp(1, any()) } answers { 2 + firstArg<Int>() }
+        every { mock.manyArgsOp() } returns 0.0
+
+        mock.manyArgsOp()
+        mock.otherOp(1, 2)
+
+        try {
+            verify(exactly = 2) { mock.otherOp(1, 2) }
+            fail("Block should throw verification failure")
+        } catch (ex: AssertionError) {
+            val message = ex.message!!
+            val reportedCall =
+                message.lineSequence().firstOrNull { it.startsWith("Call: ") }
+                    ?: fail("Message has no reported call: " + message)
+
+            if (!message.contains("One matching call found, but needs exactly 2 calls")) {
+                fail("Bad message: " + message)
+            }
+            if (!reportedCall.contains("otherOp")) {
+                fail("Reported call should be the verified one: " + message)
+            }
+            if (reportedCall.contains("manyArgsOp")) {
+                fail("Reported call should not be an unrelated call to the same mock: " + message)
+            }
+        }
+    }
+
+    @Test
     fun callsAreNotInVerificationOrder() {
         expectVerificationError("calls are not in verification order", "MockCls.otherOp") {
             every { mock.otherOp(1, any()) } answers { 2 + firstArg<Int>() }


### PR DESCRIPTION
## Summary

`UnorderedCallVerifier` reports the wrong invocation when exactly one call to the
verified method was recorded. `allCallsForMock` holds every call recorded on the
mock across all of its methods, so once another method of the same mock ran
earlier, the `Call:` line and the stack trace point at an unrelated invocation.
The argument-mismatch branch also describes `onlyCall` while printing a different
call's stack trace.

Both branches already bind the right value as `onlyCall`.

## Verification

`./gradlew :modules:mockk:jvmTest --tests "io.mockk.it.VerificationErrorsTest"`

Both added tests fail on master (reported call is `manyArgsOp`, and its stack
trace is printed) and pass with the change; the 15 existing tests are unaffected.
`./gradlew check` passes.
